### PR TITLE
ci: give pre-commit.ci conventional commit messages

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,3 +1,10 @@
+# pre-commit.ci writes these messages as both the commit subject and the PR
+# title. Keep them Conventional Commits so the "Validate PR title" check passes
+# without manual renaming.
+ci:
+  autoupdate_commit_msg: "ci: pre-commit autoupdate"
+  autofix_commit_msg: "style: auto fixes from pre-commit.com hooks"
+
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v6.0.0


### PR DESCRIPTION
## Problem

The pre-commit.ci bot opens PRs (e.g. #3) with auto-generated titles like
`[pre-commit.ci] pre-commit autoupdate`. These are not Conventional Commits, so the
`PR: Lint` → **Validate PR title** check fails on every autoupdate/autofix PR and
requires a manual rename.

## Fix

Add a `ci:` block to `.pre-commit-config.yaml`. pre-commit.ci uses these messages as
both the commit subject and the generated PR title:

- `autoupdate_commit_msg: "ci: pre-commit autoupdate"`
- `autofix_commit_msg: "style: auto fixes from pre-commit.com hooks"`

Future bot PRs will be born Conventional-Commit-compliant and pass the title check
without intervention.

🤖 Generated with [Claude Code](https://claude.com/claude-code)