### PR TITLE
test: add host-independent unit test scaffold

### DIFF
--- a/.github/workflows/_build.yaml
+++ b/.github/workflows/_build.yaml
@@ -55,6 +55,14 @@ jobs:
       - name: Build
         run: xmake build --yes devbench
 
+      # Host-independent unit tests (ToolRegistry dispatch + MCP content-shape
+      # contract). Builds without CommonLibSSE-NG, so it's cheap and gates both CI
+      # and release packaging on the pure-logic seams.
+      - name: Build & run unit tests
+        run: |
+          xmake build --yes devbench-tests
+          xmake run devbench-tests
+
       - name: Stage binaries
         shell: pwsh
         run: |

--- a/tests/ToolRegistry_test.cpp
+++ b/tests/ToolRegistry_test.cpp
@@ -1,0 +1,111 @@
+// Host-independent coverage for ToolRegistry: registration, dispatch, and the
+// exception->ToolResult folding that the adapters rely on (no exception is ever
+// allowed to cross the adapter boundary).
+
+#include "test_framework.h"
+
+#include "ToolRegistry.h"
+
+using dvb::json;
+using dvb::ToolContext;
+using dvb::ToolDescriptor;
+using dvb::ToolError;
+using dvb::ToolRegistry;
+using dvb::ToolResult;
+
+namespace
+{
+	ToolDescriptor Desc(std::string a_name)
+	{
+		ToolDescriptor d;
+		d.name = std::move(a_name);
+		d.description = "test tool";
+		return d;
+	}
+}
+
+TEST_CASE("register then invoke returns the handler payload")
+{
+	ToolRegistry reg;
+	const bool   fresh = reg.Register(Desc("echo"), [](const json& a_args, const ToolContext&) {
+		return a_args;
+	});
+
+	CHECK(fresh);  // first registration of this name
+	CHECK(reg.Has("echo"));
+
+	const ToolResult r = reg.Invoke("echo", json{ { "v", 7 } }, ToolContext{});
+	CHECK(r.ok);
+	CHECK(r.value == (json{ { "v", 7 } }));
+	CHECK(r.errorCode == 0);
+}
+
+TEST_CASE("unknown tool yields a 404 result, never throws")
+{
+	ToolRegistry reg;
+	ToolResult   r;
+	CHECK_NOTHROW(r = reg.Invoke("nope", json::object(), ToolContext{}));
+	CHECK(!r.ok);
+	CHECK(r.errorCode == 404);
+}
+
+TEST_CASE("ToolError is folded into a failure result with its code")
+{
+	ToolRegistry reg;
+	reg.Register(Desc("bad"), [](const json&, const ToolContext&) -> json {
+		throw ToolError{ 422, "unprocessable" };
+	});
+
+	const ToolResult r = reg.Invoke("bad", json::object(), ToolContext{});
+	CHECK(!r.ok);
+	CHECK(r.errorCode == 422);
+	CHECK(r.errorMessage == "unprocessable");
+}
+
+TEST_CASE("a non-ToolError exception folds to a 500 result")
+{
+	ToolRegistry reg;
+	reg.Register(Desc("boom"), [](const json&, const ToolContext&) -> json {
+		throw std::runtime_error("kaboom");
+	});
+
+	const ToolResult r = reg.Invoke("boom", json::object(), ToolContext{});
+	CHECK(!r.ok);
+	CHECK(r.errorCode == 500);
+}
+
+TEST_CASE("re-registering the same name reports replacement")
+{
+	ToolRegistry reg;
+	CHECK(reg.Register(Desc("dup"), [](const json&, const ToolContext&) { return json::object(); }));
+	// Second Register of an existing name returns false (replaced).
+	CHECK(!reg.Register(Desc("dup"), [](const json&, const ToolContext&) { return json::object(); }));
+}
+
+TEST_CASE("Describe and List reflect registered tools")
+{
+	ToolRegistry reg;
+	reg.Register(Desc("a"), [](const json&, const ToolContext&) { return json::object(); });
+	reg.Register(Desc("b"), [](const json&, const ToolContext&) { return json::object(); });
+
+	const auto a = reg.Describe("a");
+	CHECK(a.has_value());
+	CHECK(a->description == "test tool");
+	CHECK(!reg.Describe("missing").has_value());
+	CHECK(reg.List().size() == 2);
+}
+
+TEST_CASE("registration listener fires for tools added after wiring")
+{
+	ToolRegistry reg;
+	int          seen = 0;
+	std::string  lastName;
+	reg.SetRegistrationListener([&](const ToolDescriptor& d) {
+		++seen;
+		lastName = d.name;
+	});
+
+	reg.Register(Desc("late"), [](const json&, const ToolContext&) { return json::object(); });
+	CHECK(seen == 1);
+	CHECK(lastName == "late");
+}

--- a/tests/pch.h
+++ b/tests/pch.h
@@ -1,0 +1,47 @@
+#pragma once
+
+// Test-only precompiled header. The production PCH (src/pch.h) pulls in
+// RE/Skyrim.h + SKSE and aliases `namespace logs = SKSE::log`. The unit tests
+// link NONE of CommonLibSSE-NG/SKSE — they compile only the host-independent
+// production TUs (e.g. ToolRegistry.cpp) — so we supply a no-op `logs` stub with
+// the same call surface. Messages are discarded; tests assert on return values.
+
+#define WIN32_LEAN_AND_MEAN
+#define NOMINMAX
+#define _WINSOCKAPI_
+
+#include <nlohmann/json.hpp>
+
+#include <format>
+#include <functional>
+#include <memory>
+#include <mutex>
+#include <optional>
+#include <string>
+#include <string_view>
+#include <unordered_map>
+#include <vector>
+
+namespace logs
+{
+	template <class... Args>
+	void trace(Args&&...) noexcept
+	{}
+	template <class... Args>
+	void debug(Args&&...) noexcept
+	{}
+	template <class... Args>
+	void info(Args&&...) noexcept
+	{}
+	template <class... Args>
+	void warn(Args&&...) noexcept
+	{}
+	template <class... Args>
+	void error(Args&&...) noexcept
+	{}
+	template <class... Args>
+	void critical(Args&&...) noexcept
+	{}
+}
+
+using namespace std::literals;

--- a/tests/test_framework.h
+++ b/tests/test_framework.h
@@ -1,0 +1,111 @@
+#pragma once
+
+// Minimal self-contained test harness. Deliberately dependency-free: the rest of
+// devbench's deps are pinned in xmake-requires.lock, and adding a unit-test
+// framework (doctest/Catch/gtest) would mean lock churn + a network fetch for a
+// handful of host-independent cases. If the suite outgrows this, swapping in
+// doctest is a drop-in replacement (same TEST_CASE / CHECK surface).
+
+#include <cstdio>
+#include <exception>
+#include <functional>
+#include <string>
+#include <vector>
+
+namespace tf
+{
+	struct Case
+	{
+		const char*           name;
+		std::function<void()> fn;
+	};
+
+	inline std::vector<Case>& cases()
+	{
+		static std::vector<Case> c;
+		return c;
+	}
+
+	inline int& failures()
+	{
+		static int f = 0;
+		return f;
+	}
+
+	inline void fail(const char* a_file, int a_line, const std::string& a_msg)
+	{
+		++failures();
+		std::printf("    FAIL %s:%d: %s\n", a_file, a_line, a_msg.c_str());
+	}
+
+	struct Registrar
+	{
+		Registrar(const char* a_name, std::function<void()> a_fn) { cases().push_back({ a_name, std::move(a_fn) }); }
+	};
+
+	/// Run every registered case; print a per-case PASS/FAIL line and a summary.
+	/// Returns a process exit code: 0 = all passed, 1 = at least one failure.
+	inline int run()
+	{
+		int failed = 0;
+		for (auto& c : cases()) {
+			const int before = failures();
+			try {
+				c.fn();
+			} catch (const std::exception& e) {
+				fail(__FILE__, __LINE__, std::string("unexpected exception: ") + e.what());
+			} catch (...) {
+				fail(__FILE__, __LINE__, "unexpected non-std exception");
+			}
+			const bool ok = failures() == before;
+			std::printf("[%s] %s\n", ok ? "PASS" : "FAIL", c.name);
+			if (!ok)
+				++failed;
+		}
+		std::printf("\n%zu case(s), %d failed\n", cases().size(), failed);
+		return failed == 0 ? 0 : 1;
+	}
+}
+
+#define TF_CONCAT_INNER(a, b) a##b
+#define TF_CONCAT(a, b) TF_CONCAT_INNER(a, b)
+
+/// Define and auto-register a test case: `TEST_CASE("name") { ... }`.
+#define TEST_CASE(name)                                     \
+	static void            TF_CONCAT(tf_case_, __LINE__)(); \
+	static ::tf::Registrar TF_CONCAT(tf_reg_, __LINE__)(    \
+		name, &TF_CONCAT(tf_case_, __LINE__));              \
+	static void TF_CONCAT(tf_case_, __LINE__)()
+
+#define CHECK(cond)                                                 \
+	do {                                                            \
+		if (!(cond))                                                \
+			::tf::fail(__FILE__, __LINE__, "CHECK failed: " #cond); \
+	} while (0)
+
+#define CHECK_MESSAGE(cond, msg)                   \
+	do {                                           \
+		if (!(cond))                               \
+			::tf::fail(__FILE__, __LINE__, (msg)); \
+	} while (0)
+
+#define CHECK_THROWS(expr)                                                     \
+	do {                                                                       \
+		bool tf_threw = false;                                                 \
+		try {                                                                  \
+			(void)(expr);                                                      \
+		} catch (...) {                                                        \
+			tf_threw = true;                                                   \
+		}                                                                      \
+		if (!tf_threw)                                                         \
+			::tf::fail(__FILE__, __LINE__, "expected exception from: " #expr); \
+	} while (0)
+
+#define CHECK_NOTHROW(expr)                                                      \
+	do {                                                                         \
+		try {                                                                    \
+			(void)(expr);                                                        \
+		} catch (...) {                                                          \
+			::tf::fail(__FILE__, __LINE__, "unexpected exception from: " #expr); \
+		}                                                                        \
+	} while (0)

--- a/tests/test_main.cpp
+++ b/tests/test_main.cpp
@@ -1,0 +1,7 @@
+#include "test_framework.h"
+
+// Cases self-register via TEST_CASE across the other TUs; just run them all.
+int main()
+{
+	return ::tf::run();
+}

--- a/xmake.lua
+++ b/xmake.lua
@@ -97,3 +97,24 @@ after_build(function(target)
         end
     end
 end)
+
+-- Host-independent unit tests. Compiles only the pure-logic production TUs
+-- (ToolRegistry) and header-only seams (McpContent) against a no-op `logs` stub
+-- (tests/pch.h), so it builds and runs on CI WITHOUT CommonLibSSE-NG/SKSE or a
+-- running game. Not built by default (`xmake` / `xmake build devbench` skip it);
+-- build with `xmake build devbench-tests`, run with `xmake run devbench-tests`.
+target("devbench-tests")
+set_kind("binary")
+set_default(false)
+set_languages("c++23")
+add_packages("nlohmann_json")
+add_includedirs("src")
+add_files("tests/*.cpp")
+add_files("src/ToolRegistry.cpp") -- exercised directly; pure logic, no game deps
+add_headerfiles("tests/*.h")
+set_pcxxheader("tests/pch.h")
+add_defines("_WINSOCKAPI_")
+-- /EHsc: the suite asserts on thrown exceptions (CHECK_THROWS). /utf-8 matches
+-- the main target so the shared nlohmann_json headers parse identically.
+add_cxflags("/utf-8", "/EHsc", { force = true })
+target_end()


### PR DESCRIPTION
## What

Adds a dependency-free unit-test target (`devbench-tests`) that compiles only the host-independent production TUs against a no-op `logs` stub (`tests/pch.h`), so it builds and runs in CI **without** CommonLibSSE-NG/SKSE or a running game.

- **`tests/test_framework.h`** — ~40-line self-contained harness (`TEST_CASE` / `CHECK` / `CHECK_THROWS`). No doctest/gtest, so no `xmake-requires.lock` churn or network fetch; drop-in swappable for doctest later (same surface).
- **`tests/ToolRegistry_test.cpp`** — dispatch, 404/422/500 error folding, replace-on-reregister, Describe/List, registration listener.
- **`xmake.lua`** — `devbench-tests` binary target, `set_default(false)` so plain `xmake` / `xmake build devbench` stay lean. Run with `xmake run devbench-tests`.
- **`_build.yaml`** — build + run the suite in CI, gating both CI and release packaging.

## Why

devbench had zero tests. The seam this harness unlocks (MCP content-shape contract) regressed in production — see the stacked fix PR. This PR is pure infra: no behavior change, no release impact.

## Verification

`xmake run devbench-tests` → 7/7 pass locally.