### PR TITLE
fix(mcp): return tool result content as array of blocks

### DIFF
--- a/src/McpAdapter.cpp
+++ b/src/McpAdapter.cpp
@@ -1,6 +1,7 @@
 #include "McpAdapter.h"
 
 #include "EventBus.h"
+#include "McpContent.h"
 #include "ToolRegistry.h"
 
 #include <mcp_server.h>
@@ -32,13 +33,12 @@ namespace dvb
 			m_server.register_tool(t, [this, name = a_desc.name](const json& a_args, const std::string& a_session) -> json {
 				const ToolResult r = m_registry.Invoke(name, a_args, ToolContext{ a_session });
 				if (r.ok)
-					return r.value;
-				// Surface a failure as an MCP tool error result (isError + text).
-				return json{
-					{ "isError", true },
-					{ "code", r.errorCode },
-					{ "content", json::array({ json{ { "type", "text" }, { "text", r.errorMessage } } }) },
-				};
+					return ToContentBlocks(r.value);  // must be a content ARRAY — see McpContent.h
+				// Throwing lets cpp-mcp build the canonical error result (isError:true +
+				// text content array); returning an {isError,...} object here would land
+				// inside "content" as a non-array and break the same validation. cpp-mcp
+				// only surfaces what(), so fold the status code into the message.
+				throw std::runtime_error("[" + std::to_string(r.errorCode) + "] " + r.errorMessage);
 			});
 		};
 

--- a/src/McpContent.h
+++ b/src/McpContent.h
@@ -1,0 +1,26 @@
+#pragma once
+
+#include "Json.h"
+
+#include <string>
+
+namespace dvb
+{
+	/// Wrap a tool's structured result into the MCP `content` array.
+	///
+	/// cpp-mcp assigns a tool handler's return value *verbatim* to the JSON-RPC
+	/// result's `content` field (see mcp_server.cpp), and the MCP spec requires
+	/// `content` to be an ARRAY of content blocks. Returning a bare object made
+	/// every readable devbench call fail client-side validation with
+	/// "expected array, received object". We surface any payload as a single text
+	/// block holding its JSON (strings pass through unquoted). The REST facade,
+	/// which has no such envelope, keeps returning the value unwrapped.
+	///
+	/// Header-only and game-independent so it can be unit-tested without a running
+	/// Skyrim — this is the exact seam that regressed (see tests/McpContent_test.cpp).
+	inline json ToContentBlocks(const json& a_value)
+	{
+		const std::string text = a_value.is_string() ? a_value.get<std::string>() : a_value.dump(2);
+		return json::array({ json{ { "type", "text" }, { "text", text } } });
+	}
+}

--- a/tests/McpContent_test.cpp
+++ b/tests/McpContent_test.cpp
@@ -1,0 +1,58 @@
+// Regression coverage for the MCP `content` envelope. cpp-mcp assigns a tool
+// handler's return value verbatim to result["content"], which the MCP spec
+// requires to be an ARRAY of content blocks. A bare object here is what made
+// every readable devbench call fail client-side with "expected array, received
+// object" — these cases pin the array shape so it can't silently regress.
+
+#include "test_framework.h"
+
+#include "McpContent.h"
+
+using dvb::json;
+using dvb::ToContentBlocks;
+
+namespace
+{
+	// A valid content block is an object with a string "type" and matching payload.
+	bool IsTextBlock(const json& a_block)
+	{
+		return a_block.is_object() &&
+		       a_block.contains("type") && a_block["type"] == "text" &&
+		       a_block.contains("text") && a_block["text"].is_string();
+	}
+}
+
+TEST_CASE("content is always a non-empty array of blocks")
+{
+	for (const json& v : { json::object(), json("hi"), json(42), json(nullptr),
+			 json::array({ 1, 2 }), json{ { "ok", true } } }) {
+		const json content = ToContentBlocks(v);
+		CHECK_MESSAGE(content.is_array(), "content must be an array for value: " + v.dump());
+		CHECK(!content.empty());
+		CHECK(IsTextBlock(content[0]));
+	}
+}
+
+TEST_CASE("structured object payload is embedded as JSON text")
+{
+	const json value = { { "feature", "TAA" }, { "enabled", true }, { "weight", 0.5 } };
+	const json content = ToContentBlocks(value);
+
+	CHECK(content.is_array());
+	CHECK(content.size() == 1);
+	CHECK(IsTextBlock(content[0]));
+
+	// The text block round-trips back to the original structured value.
+	const json parsed = json::parse(content[0]["text"].get<std::string>());
+	CHECK(parsed == value);
+}
+
+TEST_CASE("string payload passes through unquoted")
+{
+	const json content = ToContentBlocks(json("pong"));
+
+	CHECK(content.is_array());
+	CHECK(IsTextBlock(content[0]));
+	// A string is surfaced as-is, not JSON-re-encoded to "\"pong\"".
+	CHECK(content[0]["text"] == "pong");
+}


### PR DESCRIPTION
## What

cpp-mcp assigns a tool handler's return value **verbatim** to the JSON-RPC result's `content` field, which the MCP spec requires to be an **array** of content blocks. The adapter returned a bare object (the payload on success, an `{isError,...}` object on failure), so every readable devbench call failed client-side validation with `expected array, received object`. Fire-and-forget calls "worked" only because nothing read the malformed reply.

- **`McpContent.h`** — header-only `ToContentBlocks()` wraps any payload as a single JSON text block; extracted so the regressed seam is unit-testable without a running Skyrim.
- **`McpAdapter.cpp`** — success returns `ToContentBlocks(value)`; failure throws so cpp-mcp builds the canonical `isError` result (status code folded into the message, which is all cpp-mcp surfaces).
- **`McpContent_test.cpp`** — pins the content-array shape across object / string / scalar / null payloads.

## Stacking

Based on `test/unit-test-scaffold` (#5) so the diff is just the 3 fix files. GitHub auto-retargets this to `main` once that PR merges.

## Verification

Full stack: `xmake run devbench-tests` → 10/10 pass. Fixed DLL already deployed locally; MCP reads return valid arrays after game restart.