### PR TITLE
fix(mcp): return tool result content as array of blocks

### DIFF
--- a/.github/workflows/_build.yaml
+++ b/.github/workflows/_build.yaml
@@ -55,6 +55,14 @@ jobs:
       - name: Build
         run: xmake build --yes devbench
 
+      # Host-independent unit tests (ToolRegistry dispatch + MCP content-shape
+      # contract). Builds without CommonLibSSE-NG, so it's cheap and gates both CI
+      # and release packaging on the pure-logic seams.
+      - name: Build & run unit tests
+        run: |
+          xmake build --yes devbench-tests
+          xmake run devbench-tests
+
       - name: Stage binaries
         shell: pwsh
         run: |

--- a/src/McpAdapter.cpp
+++ b/src/McpAdapter.cpp
@@ -1,6 +1,7 @@
 #include "McpAdapter.h"
 
 #include "EventBus.h"
+#include "McpContent.h"
 #include "ToolRegistry.h"
 
 #include <mcp_server.h>
@@ -32,13 +33,12 @@ namespace dvb
 			m_server.register_tool(t, [this, name = a_desc.name](const json& a_args, const std::string& a_session) -> json {
 				const ToolResult r = m_registry.Invoke(name, a_args, ToolContext{ a_session });
 				if (r.ok)
-					return r.value;
-				// Surface a failure as an MCP tool error result (isError + text).
-				return json{
-					{ "isError", true },
-					{ "code", r.errorCode },
-					{ "content", json::array({ json{ { "type", "text" }, { "text", r.errorMessage } } }) },
-				};
+					return ToContentBlocks(r.value);  // must be a content ARRAY — see McpContent.h
+				// Throwing lets cpp-mcp build the canonical error result (isError:true +
+				// text content array); returning an {isError,...} object here would land
+				// inside "content" as a non-array and break the same validation. cpp-mcp
+				// only surfaces what(), so fold the status code into the message.
+				throw std::runtime_error("[" + std::to_string(r.errorCode) + "] " + r.errorMessage);
 			});
 		};
 

--- a/src/McpContent.h
+++ b/src/McpContent.h
@@ -1,0 +1,26 @@
+#pragma once
+
+#include "Json.h"
+
+#include <string>
+
+namespace dvb
+{
+	/// Wrap a tool's structured result into the MCP `content` array.
+	///
+	/// cpp-mcp assigns a tool handler's return value *verbatim* to the JSON-RPC
+	/// result's `content` field (see mcp_server.cpp), and the MCP spec requires
+	/// `content` to be an ARRAY of content blocks. Returning a bare object made
+	/// every readable devbench call fail client-side validation with
+	/// "expected array, received object". We surface any payload as a single text
+	/// block holding its JSON (strings pass through unquoted). The REST facade,
+	/// which has no such envelope, keeps returning the value unwrapped.
+	///
+	/// Header-only and game-independent so it can be unit-tested without a running
+	/// Skyrim — this is the exact seam that regressed (see tests/McpContent_test.cpp).
+	inline json ToContentBlocks(const json& a_value)
+	{
+		const std::string text = a_value.is_string() ? a_value.get<std::string>() : a_value.dump(2);
+		return json::array({ json{ { "type", "text" }, { "text", text } } });
+	}
+}

--- a/tests/McpContent_test.cpp
+++ b/tests/McpContent_test.cpp
@@ -1,0 +1,58 @@
+// Regression coverage for the MCP `content` envelope. cpp-mcp assigns a tool
+// handler's return value verbatim to result["content"], which the MCP spec
+// requires to be an ARRAY of content blocks. A bare object here is what made
+// every readable devbench call fail client-side with "expected array, received
+// object" — these cases pin the array shape so it can't silently regress.
+
+#include "test_framework.h"
+
+#include "McpContent.h"
+
+using dvb::json;
+using dvb::ToContentBlocks;
+
+namespace
+{
+	// A valid content block is an object with a string "type" and matching payload.
+	bool IsTextBlock(const json& a_block)
+	{
+		return a_block.is_object() &&
+		       a_block.contains("type") && a_block["type"] == "text" &&
+		       a_block.contains("text") && a_block["text"].is_string();
+	}
+}
+
+TEST_CASE("content is always a non-empty array of blocks")
+{
+	for (const json& v : { json::object(), json("hi"), json(42), json(nullptr),
+			 json::array({ 1, 2 }), json{ { "ok", true } } }) {
+		const json content = ToContentBlocks(v);
+		CHECK_MESSAGE(content.is_array(), "content must be an array for value: " + v.dump());
+		CHECK(!content.empty());
+		CHECK(IsTextBlock(content[0]));
+	}
+}
+
+TEST_CASE("structured object payload is embedded as JSON text")
+{
+	const json value = { { "feature", "TAA" }, { "enabled", true }, { "weight", 0.5 } };
+	const json content = ToContentBlocks(value);
+
+	CHECK(content.is_array());
+	CHECK(content.size() == 1);
+	CHECK(IsTextBlock(content[0]));
+
+	// The text block round-trips back to the original structured value.
+	const json parsed = json::parse(content[0]["text"].get<std::string>());
+	CHECK(parsed == value);
+}
+
+TEST_CASE("string payload passes through unquoted")
+{
+	const json content = ToContentBlocks(json("pong"));
+
+	CHECK(content.is_array());
+	CHECK(IsTextBlock(content[0]));
+	// A string is surfaced as-is, not JSON-re-encoded to "\"pong\"".
+	CHECK(content[0]["text"] == "pong");
+}

--- a/tests/ToolRegistry_test.cpp
+++ b/tests/ToolRegistry_test.cpp
@@ -1,0 +1,111 @@
+// Host-independent coverage for ToolRegistry: registration, dispatch, and the
+// exception->ToolResult folding that the adapters rely on (no exception is ever
+// allowed to cross the adapter boundary).
+
+#include "test_framework.h"
+
+#include "ToolRegistry.h"
+
+using dvb::json;
+using dvb::ToolContext;
+using dvb::ToolDescriptor;
+using dvb::ToolError;
+using dvb::ToolRegistry;
+using dvb::ToolResult;
+
+namespace
+{
+	ToolDescriptor Desc(std::string a_name)
+	{
+		ToolDescriptor d;
+		d.name = std::move(a_name);
+		d.description = "test tool";
+		return d;
+	}
+}
+
+TEST_CASE("register then invoke returns the handler payload")
+{
+	ToolRegistry reg;
+	const bool   fresh = reg.Register(Desc("echo"), [](const json& a_args, const ToolContext&) {
+		return a_args;
+	});
+
+	CHECK(fresh);  // first registration of this name
+	CHECK(reg.Has("echo"));
+
+	const ToolResult r = reg.Invoke("echo", json{ { "v", 7 } }, ToolContext{});
+	CHECK(r.ok);
+	CHECK(r.value == (json{ { "v", 7 } }));
+	CHECK(r.errorCode == 0);
+}
+
+TEST_CASE("unknown tool yields a 404 result, never throws")
+{
+	ToolRegistry reg;
+	ToolResult   r;
+	CHECK_NOTHROW(r = reg.Invoke("nope", json::object(), ToolContext{}));
+	CHECK(!r.ok);
+	CHECK(r.errorCode == 404);
+}
+
+TEST_CASE("ToolError is folded into a failure result with its code")
+{
+	ToolRegistry reg;
+	reg.Register(Desc("bad"), [](const json&, const ToolContext&) -> json {
+		throw ToolError{ 422, "unprocessable" };
+	});
+
+	const ToolResult r = reg.Invoke("bad", json::object(), ToolContext{});
+	CHECK(!r.ok);
+	CHECK(r.errorCode == 422);
+	CHECK(r.errorMessage == "unprocessable");
+}
+
+TEST_CASE("a non-ToolError exception folds to a 500 result")
+{
+	ToolRegistry reg;
+	reg.Register(Desc("boom"), [](const json&, const ToolContext&) -> json {
+		throw std::runtime_error("kaboom");
+	});
+
+	const ToolResult r = reg.Invoke("boom", json::object(), ToolContext{});
+	CHECK(!r.ok);
+	CHECK(r.errorCode == 500);
+}
+
+TEST_CASE("re-registering the same name reports replacement")
+{
+	ToolRegistry reg;
+	CHECK(reg.Register(Desc("dup"), [](const json&, const ToolContext&) { return json::object(); }));
+	// Second Register of an existing name returns false (replaced).
+	CHECK(!reg.Register(Desc("dup"), [](const json&, const ToolContext&) { return json::object(); }));
+}
+
+TEST_CASE("Describe and List reflect registered tools")
+{
+	ToolRegistry reg;
+	reg.Register(Desc("a"), [](const json&, const ToolContext&) { return json::object(); });
+	reg.Register(Desc("b"), [](const json&, const ToolContext&) { return json::object(); });
+
+	const auto a = reg.Describe("a");
+	CHECK(a.has_value());
+	CHECK(a->description == "test tool");
+	CHECK(!reg.Describe("missing").has_value());
+	CHECK(reg.List().size() == 2);
+}
+
+TEST_CASE("registration listener fires for tools added after wiring")
+{
+	ToolRegistry reg;
+	int          seen = 0;
+	std::string  lastName;
+	reg.SetRegistrationListener([&](const ToolDescriptor& d) {
+		++seen;
+		lastName = d.name;
+	});
+
+	reg.Register(Desc("late"), [](const json&, const ToolContext&) { return json::object(); });
+	CHECK(seen == 1);
+	CHECK(lastName == "late");
+}

--- a/tests/pch.h
+++ b/tests/pch.h
@@ -1,0 +1,47 @@
+#pragma once
+
+// Test-only precompiled header. The production PCH (src/pch.h) pulls in
+// RE/Skyrim.h + SKSE and aliases `namespace logs = SKSE::log`. The unit tests
+// link NONE of CommonLibSSE-NG/SKSE — they compile only the host-independent
+// production TUs (e.g. ToolRegistry.cpp) — so we supply a no-op `logs` stub with
+// the same call surface. Messages are discarded; tests assert on return values.
+
+#define WIN32_LEAN_AND_MEAN
+#define NOMINMAX
+#define _WINSOCKAPI_
+
+#include <nlohmann/json.hpp>
+
+#include <format>
+#include <functional>
+#include <memory>
+#include <mutex>
+#include <optional>
+#include <string>
+#include <string_view>
+#include <unordered_map>
+#include <vector>
+
+namespace logs
+{
+	template <class... Args>
+	void trace(Args&&...) noexcept
+	{}
+	template <class... Args>
+	void debug(Args&&...) noexcept
+	{}
+	template <class... Args>
+	void info(Args&&...) noexcept
+	{}
+	template <class... Args>
+	void warn(Args&&...) noexcept
+	{}
+	template <class... Args>
+	void error(Args&&...) noexcept
+	{}
+	template <class... Args>
+	void critical(Args&&...) noexcept
+	{}
+}
+
+using namespace std::literals;

--- a/tests/test_framework.h
+++ b/tests/test_framework.h
@@ -1,0 +1,111 @@
+#pragma once
+
+// Minimal self-contained test harness. Deliberately dependency-free: the rest of
+// devbench's deps are pinned in xmake-requires.lock, and adding a unit-test
+// framework (doctest/Catch/gtest) would mean lock churn + a network fetch for a
+// handful of host-independent cases. If the suite outgrows this, swapping in
+// doctest is a drop-in replacement (same TEST_CASE / CHECK surface).
+
+#include <cstdio>
+#include <exception>
+#include <functional>
+#include <string>
+#include <vector>
+
+namespace tf
+{
+	struct Case
+	{
+		const char*           name;
+		std::function<void()> fn;
+	};
+
+	inline std::vector<Case>& cases()
+	{
+		static std::vector<Case> c;
+		return c;
+	}
+
+	inline int& failures()
+	{
+		static int f = 0;
+		return f;
+	}
+
+	inline void fail(const char* a_file, int a_line, const std::string& a_msg)
+	{
+		++failures();
+		std::printf("    FAIL %s:%d: %s\n", a_file, a_line, a_msg.c_str());
+	}
+
+	struct Registrar
+	{
+		Registrar(const char* a_name, std::function<void()> a_fn) { cases().push_back({ a_name, std::move(a_fn) }); }
+	};
+
+	/// Run every registered case; print a per-case PASS/FAIL line and a summary.
+	/// Returns a process exit code: 0 = all passed, 1 = at least one failure.
+	inline int run()
+	{
+		int failed = 0;
+		for (auto& c : cases()) {
+			const int before = failures();
+			try {
+				c.fn();
+			} catch (const std::exception& e) {
+				fail(__FILE__, __LINE__, std::string("unexpected exception: ") + e.what());
+			} catch (...) {
+				fail(__FILE__, __LINE__, "unexpected non-std exception");
+			}
+			const bool ok = failures() == before;
+			std::printf("[%s] %s\n", ok ? "PASS" : "FAIL", c.name);
+			if (!ok)
+				++failed;
+		}
+		std::printf("\n%zu case(s), %d failed\n", cases().size(), failed);
+		return failed == 0 ? 0 : 1;
+	}
+}
+
+#define TF_CONCAT_INNER(a, b) a##b
+#define TF_CONCAT(a, b) TF_CONCAT_INNER(a, b)
+
+/// Define and auto-register a test case: `TEST_CASE("name") { ... }`.
+#define TEST_CASE(name)                                     \
+	static void            TF_CONCAT(tf_case_, __LINE__)(); \
+	static ::tf::Registrar TF_CONCAT(tf_reg_, __LINE__)(    \
+		name, &TF_CONCAT(tf_case_, __LINE__));              \
+	static void TF_CONCAT(tf_case_, __LINE__)()
+
+#define CHECK(cond)                                                 \
+	do {                                                            \
+		if (!(cond))                                                \
+			::tf::fail(__FILE__, __LINE__, "CHECK failed: " #cond); \
+	} while (0)
+
+#define CHECK_MESSAGE(cond, msg)                   \
+	do {                                           \
+		if (!(cond))                               \
+			::tf::fail(__FILE__, __LINE__, (msg)); \
+	} while (0)
+
+#define CHECK_THROWS(expr)                                                     \
+	do {                                                                       \
+		bool tf_threw = false;                                                 \
+		try {                                                                  \
+			(void)(expr);                                                      \
+		} catch (...) {                                                        \
+			tf_threw = true;                                                   \
+		}                                                                      \
+		if (!tf_threw)                                                         \
+			::tf::fail(__FILE__, __LINE__, "expected exception from: " #expr); \
+	} while (0)
+
+#define CHECK_NOTHROW(expr)                                                      \
+	do {                                                                         \
+		try {                                                                    \
+			(void)(expr);                                                        \
+		} catch (...) {                                                          \
+			::tf::fail(__FILE__, __LINE__, "unexpected exception from: " #expr); \
+		}                                                                        \
+	} while (0)

--- a/tests/test_main.cpp
+++ b/tests/test_main.cpp
@@ -1,0 +1,7 @@
+#include "test_framework.h"
+
+// Cases self-register via TEST_CASE across the other TUs; just run them all.
+int main()
+{
+	return ::tf::run();
+}

--- a/xmake.lua
+++ b/xmake.lua
@@ -97,3 +97,24 @@ after_build(function(target)
         end
     end
 end)
+
+-- Host-independent unit tests. Compiles only the pure-logic production TUs
+-- (ToolRegistry) and header-only seams (McpContent) against a no-op `logs` stub
+-- (tests/pch.h), so it builds and runs on CI WITHOUT CommonLibSSE-NG/SKSE or a
+-- running game. Not built by default (`xmake` / `xmake build devbench` skip it);
+-- build with `xmake build devbench-tests`, run with `xmake run devbench-tests`.
+target("devbench-tests")
+set_kind("binary")
+set_default(false)
+set_languages("c++23")
+add_packages("nlohmann_json")
+add_includedirs("src")
+add_files("tests/*.cpp")
+add_files("src/ToolRegistry.cpp") -- exercised directly; pure logic, no game deps
+add_headerfiles("tests/*.h")
+set_pcxxheader("tests/pch.h")
+add_defines("_WINSOCKAPI_")
+-- /EHsc: the suite asserts on thrown exceptions (CHECK_THROWS). /utf-8 matches
+-- the main target so the shared nlohmann_json headers parse identically.
+add_cxflags("/utf-8", "/EHsc", { force = true })
+target_end()


### PR DESCRIPTION
## What

cpp-mcp assigns a tool handler's return value **verbatim** to the JSON-RPC result's `content` field, which the MCP spec requires to be an **array** of content blocks. The adapter returned a bare object (the payload on success, an `{isError,...}` object on failure), so every readable devbench call failed client-side validation with `expected array, received object`. Fire-and-forget calls "worked" only because nothing read the malformed reply.

- **`McpContent.h`** — header-only `ToContentBlocks()` wraps any payload as a single JSON text block; extracted so the regressed seam is unit-testable without a running Skyrim.
- **`McpAdapter.cpp`** — success returns `ToContentBlocks(value)`; failure throws so cpp-mcp builds the canonical `isError` result (status code folded into the message, which is all cpp-mcp surfaces).
- **`McpContent_test.cpp`** — pins the content-array shape across object / string / scalar / null payloads.

## Note

Replaces #6, which GitHub auto-closed when its stacked base branch (`test/unit-test-scaffold`, merged in #5) was deleted. Test scaffold from #5 is already in `main`, so this diff is just the 3 fix files.

## Verification

Full suite: `xmake run devbench-tests` → 10/10 pass locally and in CI.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Tests**
  * Added host-independent unit test suite covering content formatting and tool registry functionality.
  * Implemented lightweight test framework with automated execution in CI/CD pipeline.

* **Chores**
  * Updated build workflow to gate artifact upload on successful unit test completion.
  * Configured test target as opt-in to prevent impact on default builds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->