### PR TITLE
ci: add semantic-release to the release pipeline

### DIFF
--- a/.github/workflows/_build.yaml
+++ b/.github/workflows/_build.yaml
@@ -10,6 +10,10 @@ on:
         description: "Name for the uploaded binaries artifact."
         type: string
         default: devbench-binaries
+      ref:
+        description: "Git ref to build. Empty = the triggering commit (CI default)."
+        type: string
+        default: ""
     outputs:
       artifact-name:
         description: "Artifact name the binaries were uploaded under."
@@ -26,6 +30,7 @@ jobs:
       - name: Checkout (with submodules)
         uses: actions/checkout@v6
         with:
+          ref: ${{ inputs.ref }}
           submodules: recursive
 
       - name: Set up xmake

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -51,7 +51,7 @@ jobs:
       - name: Set up Node
         uses: actions/setup-node@v6
         with:
-          node-version: 20
+          node-version: 24
 
       - name: Semantic Release
         id: semantic

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -25,8 +25,10 @@ concurrency:
   group: release-${{ github.ref }}
   cancel-in-progress: false
 
+# Default to read-only; the two jobs that push commits/tags or publish assets
+# opt into contents: write individually.
 permissions:
-  contents: write # semantic-release pushes the bump commit + tag and creates the release
+  contents: read
 
 jobs:
   semantic-release:
@@ -34,6 +36,8 @@ jobs:
     runs-on: ubuntu-latest
     # Source repo only: forks have no release/Nexus credentials.
     if: github.repository_owner == 'alandtse'
+    permissions:
+      contents: write # push the bump commit + tag, create the GitHub Release
     outputs:
       new_release_published: ${{ steps.semantic.outputs.new_release_published }}
       new_release_version: ${{ steps.semantic.outputs.new_release_version }}
@@ -81,6 +85,8 @@ jobs:
     needs: [semantic-release, build]
     if: needs.semantic-release.outputs.new_release_published == 'true'
     runs-on: ubuntu-latest
+    permissions:
+      contents: write # attach the .7z asset and promote the draft release
     steps:
       - name: Checkout
         uses: actions/checkout@v6
@@ -112,15 +118,19 @@ jobs:
           echo "Built ${stage}.7z:"
           7z l "${stage}.7z"
 
-      # semantic-release already created the GitHub Release (with the changelog as its
-      # body); this only attaches the .7z asset, leaving the notes untouched.
-      - name: Attach archive to release
-        uses: svenstaro/upload-release-action@v2
-        with:
-          repo_token: ${{ secrets.GITHUB_TOKEN }}
-          file: ${{ steps.pkg.outputs.archive }}
-          tag: ${{ needs.semantic-release.outputs.new_release_git_tag }}
-          overwrite: true
+      # semantic-release created the GitHub Release as a draft (with the changelog as
+      # its body). Attach the .7z, then promote the draft to published — but only now
+      # that the asset exists. If build or packaging had failed, the release would stay
+      # a hidden draft instead of shipping a tagged release with no download. Using gh
+      # (not a third-party action) keeps draft handling reliable and trims a dependency.
+      - name: Attach archive and publish release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAG: ${{ needs.semantic-release.outputs.new_release_git_tag }}
+          ARCHIVE: ${{ steps.pkg.outputs.archive }}
+        run: |
+          gh release upload "$TAG" "$ARCHIVE" --clobber
+          gh release edit "$TAG" --draft=false
 
   # Upload to Nexus, reusing semantic-release's curated notes as the changelog.
   # Default is a dry-run (report only). Set repository variable NEXUS_AUTO_UPLOAD=true
@@ -134,4 +144,7 @@ jobs:
       tag: ${{ needs.semantic-release.outputs.new_release_git_tag }}
       dry_run: ${{ vars.NEXUS_AUTO_UPLOAD == 'true' && 'false' || 'true' }}
       changelog: ${{ needs.semantic-release.outputs.new_release_notes }}
-    secrets: inherit
+    # Pass only the secrets nexus-upload declares, rather than inheriting all of them.
+    secrets:
+      UNEX_NEXUSMODS_SESSION_COOKIE: ${{ secrets.UNEX_NEXUSMODS_SESSION_COOKIE }}
+      UNEX_APIKEY: ${{ secrets.UNEX_APIKEY }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,14 +1,24 @@
-# Release: build the plugin, assemble the mod-archive layout, and publish a GitHub
-# release. Triggered by pushing a vX.Y.Z tag (final release) or run manually
-# (workflow_dispatch → draft pre-release built from the current xmake version).
+# Release pipeline. Every push to main runs semantic-release: it reads the
+# Conventional Commit history (squash-merge makes each PR title the commit subject),
+# picks the next version, bumps `local version` in xmake.lua, commits it back to main
+# (with [skip ci] so it doesn't re-trigger), creates the vX.Y.Z tag, and publishes a
+# GitHub Release whose body is the curated changelog. Downstream jobs then build the
+# plugin, attach the .7z mod archive to that release, and — on the source repo —
+# upload to Nexus with the same changelog.
 #
-# devbench is intentionally light on release machinery: the version lives in
-# xmake.lua and the tag is the source of truth — there is no semantic-release here.
+# Single workflow on purpose (mirrors CrashLoggerSSE): because build/package/nexus
+# run in the same run as semantic-release, they read its outputs directly and nothing
+# depends on the tag push re-triggering another workflow. That's why the default
+# GITHUB_TOKEN suffices — no RELEASE_PAT needed (main is unprotected).
+#
+# workflow_dispatch runs the same path: if there are unreleased commits it cuts the
+# release; otherwise semantic-release no-ops and the build/package/nexus jobs skip.
+# (Manual re-upload of an already-published tag to Nexus lives in nexus-upload.yaml.)
 name: Release
 
 on:
   push:
-    tags: ["v*"]
+    branches: [main]
   workflow_dispatch:
 
 concurrency:
@@ -16,21 +26,66 @@ concurrency:
   cancel-in-progress: false
 
 permissions:
-  contents: read
+  contents: write # semantic-release pushes the bump commit + tag and creates the release
 
 jobs:
-  build:
-    uses: ./.github/workflows/_build.yaml
-
-  package:
-    name: Package & publish
-    needs: build
+  semantic-release:
+    name: Semantic Release
     runs-on: ubuntu-latest
-    permissions:
-      contents: write # create the release + tag
+    # Source repo only: forks have no release/Nexus credentials.
+    if: github.repository_owner == 'alandtse'
+    outputs:
+      new_release_published: ${{ steps.semantic.outputs.new_release_published }}
+      new_release_version: ${{ steps.semantic.outputs.new_release_version }}
+      new_release_git_tag: ${{ steps.semantic.outputs.new_release_git_tag }}
+      new_release_notes: ${{ steps.semantic.outputs.new_release_notes }}
     steps:
       - name: Checkout
         uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+          # CommonLibSSE-NG isn't needed to compute the version, but the working
+          # tree must be complete for the @semantic-release/git commit to be clean.
+          submodules: recursive
+
+      - name: Set up Node
+        uses: actions/setup-node@v6
+        with:
+          node-version: 20
+
+      - name: Semantic Release
+        id: semantic
+        uses: cycjimmy/semantic-release-action@v6
+        with:
+          # Pin for reproducible releases (matches the sibling repos).
+          semantic_version: 24.2.6
+          # commit-analyzer, release-notes-generator, and github ship with the
+          # action; these two do not, so they're installed on the fly.
+          extra_plugins: |
+            @semantic-release/git
+            @google/semantic-release-replace-plugin
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  build:
+    name: Build release binaries
+    needs: semantic-release
+    if: needs.semantic-release.outputs.new_release_published == 'true'
+    uses: ./.github/workflows/_build.yaml
+    with:
+      # Build the exact tagged commit so the compiled-in version matches the tag.
+      ref: ${{ needs.semantic-release.outputs.new_release_git_tag }}
+
+  package:
+    name: Package & publish
+    needs: [semantic-release, build]
+    if: needs.semantic-release.outputs.new_release_published == 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          ref: ${{ needs.semantic-release.outputs.new_release_git_tag }}
 
       - name: Download binaries
         uses: actions/download-artifact@v7
@@ -38,29 +93,12 @@ jobs:
           name: ${{ needs.build.outputs.artifact-name }}
           path: bin
 
-      - name: Resolve version
-        id: ver
-        run: |
-          if [[ "${GITHUB_REF}" == refs/tags/* ]]; then
-            version="${GITHUB_REF#refs/tags/}"
-            prerelease=$([[ "$version" == *-* ]] && echo true || echo false)
-            draft=false
-          else
-            # Manual run → draft pre-release stamped from xmake.lua + run number.
-            base="$(grep -oP 'local version = "\K[0-9.]+' xmake.lua)"
-            version="v${base}-dev.${GITHUB_RUN_NUMBER}"
-            prerelease=true
-            draft=true
-          fi
-          echo "version=$version" >> "$GITHUB_OUTPUT"
-          echo "prerelease=$prerelease" >> "$GITHUB_OUTPUT"
-          echo "draft=$draft" >> "$GITHUB_OUTPUT"
-          echo "Resolved version=$version prerelease=$prerelease draft=$draft"
-
       - name: Assemble mod archive
+        id: pkg
         run: |
           set -euo pipefail
-          stage="devbench-${{ steps.ver.outputs.version }}"
+          tag="${{ needs.semantic-release.outputs.new_release_git_tag }}"
+          stage="devbench-${tag}"
           mkdir -p "$stage/SKSE/Plugins" "$stage/Developer"
           cp bin/devbench.dll bin/devbench.pdb "$stage/SKSE/Plugins/"
           # No config.json: the plugin auto-creates a self-documenting one on first run,
@@ -70,30 +108,30 @@ jobs:
           # MIT C-ABI glue for developers who want to register their own tools.
           cp include/DevBenchAPI.h include/DevBenchAPI.cpp include/DevBenchAPI.LICENSE.txt "$stage/Developer/"
           7z a -t7z -mx=9 "${stage}.7z" "$stage"
+          echo "archive=${stage}.7z" >> "$GITHUB_OUTPUT"
           echo "Built ${stage}.7z:"
           7z l "${stage}.7z"
 
-      - name: Publish release
-        uses: softprops/action-gh-release@v2
+      # semantic-release already created the GitHub Release (with the changelog as its
+      # body); this only attaches the .7z asset, leaving the notes untouched.
+      - name: Attach archive to release
+        uses: svenstaro/upload-release-action@v2
         with:
-          tag_name: ${{ steps.ver.outputs.version }}
-          name: devbench ${{ steps.ver.outputs.version }}
-          draft: ${{ steps.ver.outputs.draft }}
-          prerelease: ${{ steps.ver.outputs.prerelease }}
-          generate_release_notes: true
-          files: devbench-${{ steps.ver.outputs.version }}.7z
+          repo_token: ${{ secrets.GITHUB_TOKEN }}
+          file: ${{ steps.pkg.outputs.archive }}
+          tag: ${{ needs.semantic-release.outputs.new_release_git_tag }}
+          overwrite: true
 
-  # After a stable tag publishes, run the Nexus step. Default is a dry-run (report
-  # only). Set repository variable NEXUS_AUTO_UPLOAD=true (plus the UNEX_* secrets)
-  # to make a stable tag push upload for real — i.e. the full build → release →
-  # Nexus pipeline from a single `git push` of the tag. Pre-release tags (vX.Y.Z-…)
-  # are skipped either way.
+  # Upload to Nexus, reusing semantic-release's curated notes as the changelog.
+  # Default is a dry-run (report only). Set repository variable NEXUS_AUTO_UPLOAD=true
+  # (plus the UNEX_* secrets) to make a push-driven release upload for real.
   nexus:
     name: Nexus upload
-    needs: package
-    if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v') && !contains(github.ref_name, '-')
+    needs: [semantic-release, build, package]
+    if: needs.semantic-release.outputs.new_release_published == 'true'
     uses: ./.github/workflows/nexus-upload.yaml
     with:
-      tag: ${{ github.ref_name }}
+      tag: ${{ needs.semantic-release.outputs.new_release_git_tag }}
       dry_run: ${{ vars.NEXUS_AUTO_UPLOAD == 'true' && 'false' || 'true' }}
+      changelog: ${{ needs.semantic-release.outputs.new_release_notes }}
     secrets: inherit

--- a/.releaserc
+++ b/.releaserc
@@ -24,7 +24,12 @@
       }
     ],
     "@semantic-release/release-notes-generator",
-    ["@semantic-release/github"],
+    [
+      "@semantic-release/github",
+      {
+        "draft": true
+      }
+    ],
     [
       "@semantic-release/git",
       {

--- a/.releaserc
+++ b/.releaserc
@@ -1,0 +1,36 @@
+{
+  "branches": ["main"],
+  "plugins": [
+    "@semantic-release/commit-analyzer",
+    [
+      "@google/semantic-release-replace-plugin",
+      {
+        "replacements": [
+          {
+            "files": ["xmake.lua"],
+            "from": "local version = \".*\"",
+            "to": "local version = \"${nextRelease.version}\"",
+            "results": [
+              {
+                "file": "xmake.lua",
+                "hasChanged": true,
+                "numMatches": 1,
+                "numReplacements": 1
+              }
+            ],
+            "countMatches": true
+          }
+        ]
+      }
+    ],
+    "@semantic-release/release-notes-generator",
+    ["@semantic-release/github"],
+    [
+      "@semantic-release/git",
+      {
+        "assets": ["xmake.lua"],
+        "message": "chore(release): ${nextRelease.version} [skip ci]\n\n${nextRelease.notes}"
+      }
+    ]
+  ]
+}


### PR DESCRIPTION
## Why

Releases were tag-only — pushing a fix to `main` did nothing until someone hand-pushed a `vX.Y.Z` tag (which is what just happened: a squashed `fix:` produced no release). This wires [semantic-release](https://semantic-release.gitbook.io/) into the release workflow so every push to `main` with a releasable Conventional Commit cuts a release automatically.

## Approach

Follows the **single-workflow model** from the sibling `CrashLoggerSSE` repo (its structural twin: single `main`, Nexus upload, same owner):

- `semantic-release` runs as job 0 — bumps `local version` in `xmake.lua` via `@google/semantic-release-replace-plugin`, commits it back with `[skip ci]`, tags `vX.Y.Z`, and publishes a GitHub Release whose body is the curated changelog (`@semantic-release/github`).
- `build` → `package` → `nexus` run in the **same** workflow, gated on `new_release_published`. Because they read semantic-release's outputs directly, the default `GITHUB_TOKEN` suffices (main is unprotected) — **no `RELEASE_PAT` needed**.
- The `.7z` mod archive is attached to the Release via `svenstaro/upload-release-action`, and Nexus reuses `new_release_notes` as its changelog (matching CrashLogger).
- `_build.yaml` gains a `ref` input so the release build compiles the exact tagged commit (version stamped into the binary matches the tag).

No `@semantic-release/changelog` / committed `CHANGELOG.md` — matches the mature repos; notes live in the GitHub Release.

## Behavior changes

- ⚠️ Hand-pushed `v*` tags no longer trigger a release — releases are driven by push-to-main.
- ⚠️ The manual draft-prerelease `workflow_dispatch` path is dropped (CrashLogger has no equivalent).

## First release

Merging this will auto-cut **v1.0.1** (a `fix:` exists since `v1.0.0`), bumping `xmake.lua` `1.0.0 → 1.0.1`. Nexus stays **dry-run** until repo variable `NEXUS_AUTO_UPLOAD=true`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Implemented automated release management with semantic versioning
  * Releases are now automatically determined, created, and published to GitHub based on commit messages
  * Build artifacts are automatically attached to releases upon publication
  * Version information is automatically updated throughout the project

<!-- end of auto-generated comment: release notes by coderabbit.ai -->