### PR TITLE
ci: add Dependabot for GitHub Actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,16 @@
+# Keep GitHub Actions references fresh. devbench pins action versions by major tag
+# rather than commit SHA — a deliberate, repo-wide choice (see PR #8) — so Dependabot
+# proposes version bumps weekly instead of us tracking them by hand. Updates are
+# grouped into a single PR and use a Conventional Commit prefix so the PR-title lint
+# (.github/workflows/pr-lint.yaml) passes.
+version: 2
+updates:
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+    groups:
+      github-actions:
+        patterns: ["*"]
+    commit-message:
+      prefix: ci


### PR DESCRIPTION
## Why

Follow-up to [#8](https://github.com/alandtse/devbench/pull/8). CodeRabbit flagged that the release workflow uses mutable action tags (`@v6`, `@v2`) rather than commit SHAs. SHA-pinning was declined there because **nothing in the stack** (CrashLogger, nexus-workflows, community-shaders, or devbench's own `_build.yaml`/`build.yaml`) pins SHAs — doing it in one file would be inconsistent, and the right place to manage action freshness is a repo-wide tool.

## What

Adds [.github/dependabot.yml](.github/dependabot.yml) for the `github-actions` ecosystem:

- **Weekly** checks across all workflows (`.github/workflows/*`).
- **Grouped** into a single PR (`github-actions` group, `patterns: ["*"]`) to avoid PR spam.
- **`ci:` commit prefix** so Dependabot's PR titles pass the existing PR-title lint ([pr-lint.yaml](.github/workflows/pr-lint.yaml) → `amannn/action-semantic-pull-request`).

This keeps versions current automatically without hand-pinning SHAs — the deliberate, documented stack-wide choice.

## Notes

- devbench is the first repo in the stack with a Dependabot config; if this pattern works out it's worth replicating to the siblings.
- Scoped to GitHub Actions only. The `commonlibsse-ng` git submodule is intentionally left out (it moves fast; manual control is preferable there) — easy to add a `gitsubmodule` entry later if wanted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enabled automated weekly dependency updates for GitHub Actions through Dependabot configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->