### PR TITLE
ci: use the draftRelease option for the github plugin

### DIFF
--- a/.releaserc
+++ b/.releaserc
@@ -27,7 +27,7 @@
     [
       "@semantic-release/github",
       {
-        "draft": true
+        "draftRelease": true
       }
     ],
     [


### PR DESCRIPTION
## Bug

In #8 the GitHub Release was meant to be created as a **draft** and promoted to published only after the `package` job attaches the `.7z` (so a failed build can't leave a tagged release with no download — CodeRabbit's finding). The option was set as `"draft": true`, but `@semantic-release/github`'s actual option is **`draftRelease`**. The wrong key was silently ignored, so v1.0.1 published immediately, asset-less, while the build ran.

(v1.0.1 itself came out fine — the build succeeded and the `package` job attached the asset to the already-published release. This only restores the intended safety net for future releases.)

## Fix

`"draft": true` → `"draftRelease": true`. Now the release stays a draft until `package` runs `gh release edit --draft=false` after the upload.

Titled `ci:` (not `fix:`) on purpose: this is a release-pipeline config change with no plugin-code change, so it should **not** cut a new version. `draftRelease` will be exercised on the next real `fix`/`feat`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)