### PR TITLE
feat(replay): scene assertions and clean transitions

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,6 +114,21 @@ Missing → auto-created with defaults. Invalid → defaults (logged). All keys 
   // Settle delay (ms) after a restore-load before the replayed trajectory runs.
   // Hardware-dependent; not baked into the portable recording file.
   "loadSettleMs": 3000,
+
+  // Scene coupling: how strictly a replay reproduces the recorded entry, by how long
+  // before record-start the save/coc was brokered (stored per recipe as entryPoint.ageMs).
+  //   age <= couplingAnchorMs : "anchored" — restore the entry + re-apply recorded time/weather
+  //   age <= couplingCellMs   : "cell"     — restore the entry
+  //   else                    : "worldspace" — skip the restore; only assert the worldspace
+  // A recipe may override the tier/thresholds in its meta.coupling block.
+  "couplingAnchorMs": 10000,
+  "couplingCellMs": 60000,
+
+  // A raw coc/cow can stream between scenes without the loading-screen teardown some mods
+  // need to free resources (→ CTD). When true, a coc/cow restore first bounces through
+  // cleanTransitionCell to force a clean loading screen. Save-loads already tear down.
+  "cleanTransition": true,
+  "cleanTransitionCell": "QASmoke",
 }
 ```
 
@@ -154,7 +169,13 @@ The `record` tool captures a manual play-through as a replayable scenario file:
    `Data/SKSE/Plugins/devbench/recordings/recording_<stamp>.json` and the path is returned.
 4. Replay with `record action='replay' path='<file>'`. With `restoreScene=true` (default for
    hotkey replay), devbench first re-establishes the entry point (loads the save / `coc`s the
-   cell) and waits for the player before running the trajectory.
+   cell) and waits for the player before running the trajectory. How tightly it reproduces the
+   entry depends on the **coupling tier** (anchored / cell / worldspace), chosen from how long
+   before recording the entry was set up — see `couplingAnchorMs`/`couplingCellMs`. Before the
+   trajectory runs, devbench **asserts** you're in the recorded worldspace/cell and aborts on a
+   mismatch (e.g. `coc` ambiguity landing you in the wrong worldspace), so a replay can't quietly
+   benchmark the wrong scene. A `coc`/`cow` restore bounces through a neutral cell first
+   (`cleanTransition`) to force a loading-screen teardown that some mods need to avoid a CTD.
 
 **In-game hotkeys** (configured in `config.json`, opt-in, both default to disabled):
 

--- a/README.md
+++ b/README.md
@@ -177,6 +177,14 @@ The `record` tool captures a manual play-through as a replayable scenario file:
    benchmark the wrong scene. A `coc`/`cow` restore bounces through a neutral cell first
    (`cleanTransition`) to force a loading-screen teardown that some mods need to avoid a CTD.
 
+A recipe can pin or tune its own coupling in the recording file's `meta.coupling` block,
+overriding the global config thresholds:
+
+```jsonc
+"meta": { "coupling": { "tier": "anchored" } }                 // force a tier, or
+"meta": { "coupling": { "anchorMs": 5000, "cellMs": 30000 } }  // tune the age thresholds
+```
+
 **In-game hotkeys** (configured in `config.json`, opt-in, both default to disabled):
 
 - `recordHotkey` — DXScanCode integer; toggles record start/stop. Ignored while the console is

--- a/src/Config.cpp
+++ b/src/Config.cpp
@@ -36,6 +36,10 @@ namespace dvb
 				{ "autoRunPath", a_cfg.autoRunPath },
 				{ "autoRunRestoreScene", a_cfg.autoRunRestoreScene },
 				{ "loadSettleMs", a_cfg.loadSettleMs },
+				{ "couplingAnchorMs", a_cfg.couplingAnchorMs },
+				{ "couplingCellMs", a_cfg.couplingCellMs },
+				{ "cleanTransition", a_cfg.cleanTransition },
+				{ "cleanTransitionCell", a_cfg.cleanTransitionCell },
 			};
 			out << j.dump(2) << '\n';
 		}
@@ -70,6 +74,10 @@ namespace dvb
 			cfg.autoRunPath = j.value("autoRunPath", cfg.autoRunPath);
 			cfg.autoRunRestoreScene = j.value("autoRunRestoreScene", cfg.autoRunRestoreScene);
 			cfg.loadSettleMs = j.value("loadSettleMs", cfg.loadSettleMs);
+			cfg.couplingAnchorMs = j.value("couplingAnchorMs", cfg.couplingAnchorMs);
+			cfg.couplingCellMs = j.value("couplingCellMs", cfg.couplingCellMs);
+			cfg.cleanTransition = j.value("cleanTransition", cfg.cleanTransition);
+			cfg.cleanTransitionCell = j.value("cleanTransitionCell", cfg.cleanTransitionCell);
 
 			// Migrate forward: if the file predates any key (e.g. an install from before
 			// the record hotkeys existed), rewrite it so the new keys appear with their
@@ -78,7 +86,8 @@ namespace dvb
 			static constexpr const char* kKeys[] = {
 				"enabled", "port", "logLevel", "recordHotkey", "replayHotkey",
 				"recordHotkeyShift", "replayHotkeyShift", "replayPath", "replayRestoreScene",
-				"recordIntervalMs", "autoRunPath", "autoRunRestoreScene", "loadSettleMs"
+				"recordIntervalMs", "autoRunPath", "autoRunRestoreScene", "loadSettleMs",
+				"couplingAnchorMs", "couplingCellMs", "cleanTransition", "cleanTransitionCell"
 			};
 			const bool complete = std::all_of(std::begin(kKeys), std::end(kKeys),
 				[&](const char* k) { return j.contains(k); });

--- a/src/Config.h
+++ b/src/Config.h
@@ -34,6 +34,23 @@ namespace dvb
 		// crash-prone. This is LOCAL/per-machine (settle time is hardware-dependent), not baked
 		// into the portable recording. A replay call may override it with a settleMs arg.
 		int loadSettleMs = 3000;
+
+		// Scene coupling: how strictly a replay must reproduce the recorded entry, chosen by
+		// how long before record-start devbench brokered the save/coc (stored per recipe as
+		// entryPoint.ageMs). A save staged seconds before recording was deliberate; one from
+		// minutes ago was incidental. Tiers (a recipe may override in its meta.coupling block):
+		//   age <= anchorMs : "anchored" — restore the entry + re-apply recorded time/weather.
+		//   age <= cellMs    : "cell"     — restore the entry.
+		//   else             : "worldspace" — skip the entry restore; only assert the worldspace.
+		int couplingAnchorMs = 10000;
+		int couplingCellMs = 60000;
+
+		// A raw coc/cow can stream between scenes without the full loading-screen teardown some
+		// mods rely on to free resources, which can CTD. When true, a coc/cow restore first
+		// bounces through couplingTransitionCell (a known-present interior) to force a clean
+		// loading screen. Save-loads already tear down, so they skip the bounce.
+		bool        cleanTransition = true;
+		std::string cleanTransitionCell = "QASmoke";
 	};
 
 	// Load Data/SKSE/Plugins/devbench/config.json. If the file is missing it is

--- a/src/Recording.cpp
+++ b/src/Recording.cpp
@@ -36,13 +36,20 @@ namespace dvb::Recording
 		// reads it at start. Empty kind → entry unknown (player walked here).
 		struct EntryPoint
 		{
-			std::string kind;   // "save" | "coc" | ""
-			std::string value;  // save name | cell id
+			std::string              kind;   // "save" | "coc" | ""
+			std::string              value;  // save name | cell id
+			steady_clock::time_point at{};   // when brokered — for the coupling age (default-constructed = unknown)
 		};
 		std::mutex g_entryMtx;
 		EntryPoint g_entry;
 		int        g_loadSettleMs = 3000;                     // set from config via SetLoadSettleMs
 		long       g_defaultIntervalMs = kDefaultIntervalMs;  // set from config via SetDefaultIntervalMs
+
+		// Scene-coupling defaults (set from config via SetCoupling). See Recording.h.
+		long        g_anchorMs = 10000;
+		long        g_cellMs = 60000;
+		bool        g_cleanTransition = true;
+		std::string g_cleanTransitionCell = "QASmoke";
 
 		// True while devbench is replaying a scenario (teleporting the player). The pose sampler
 		// skips these ticks: the replay's own setpos/setangle commands — captured via the console
@@ -141,9 +148,14 @@ namespace dvb::Recording
 
 			// Reproducible entry point (save/coc devbench brokered), or a loud "unknown" so
 			// a replay won't silently pretend it can restore the scene.
-			if (const EntryPoint e = CurrentEntry(); !e.kind.empty())
-				m["entryPoint"] = json{ { "kind", e.kind }, { "value", e.value } };
-			else
+			if (const EntryPoint e = CurrentEntry(); !e.kind.empty()) {
+				json ep{ { "kind", e.kind }, { "value", e.value } };
+				// Age of the entry at record-start: small => the save/coc was staged for this
+				// recording (couple it tightly); large => incidental. Drives the replay tier.
+				if (e.at.time_since_epoch().count() != 0)
+					ep["ageMs"] = duration_cast<milliseconds>(steady_clock::now() - e.at).count();
+				m["entryPoint"] = std::move(ep);
+			} else
 				m["entryPoint"] = json{ { "kind", "unknown" }, { "note", "no save/coc brokered by devbench before recording; replay cannot restore the scene — load from a save and re-record, or set entryPoint manually" } };
 			return m;
 		}
@@ -365,14 +377,14 @@ namespace dvb::Recording
 	void NoteLoadEntry(const std::string& a_saveName)
 	{
 		std::lock_guard lock(g_entryMtx);
-		g_entry = EntryPoint{ "save", a_saveName };
+		g_entry = EntryPoint{ "save", a_saveName, steady_clock::now() };
 		logs::info("devbench: entry point captured — save '{}'", a_saveName);
 	}
 
 	void NoteCocEntry(const std::string& a_cellId)
 	{
 		std::lock_guard lock(g_entryMtx);
-		g_entry = EntryPoint{ "coc", a_cellId };
+		g_entry = EntryPoint{ "coc", a_cellId, steady_clock::now() };
 	}
 
 	void NoteConsoleCommand(const std::string& a_command)
@@ -425,6 +437,14 @@ namespace dvb::Recording
 		g_defaultIntervalMs = (a_ms < kMinIntervalMs) ? kMinIntervalMs : a_ms;
 	}
 
+	void SetCoupling(int a_anchorMs, int a_cellMs, bool a_cleanTransition, const std::string& a_transitionCell)
+	{
+		g_anchorMs = (a_anchorMs < 0) ? 0 : a_anchorMs;
+		g_cellMs = (a_cellMs < a_anchorMs) ? a_anchorMs : a_cellMs;  // cell window must cover the anchor window
+		g_cleanTransition = a_cleanTransition;
+		g_cleanTransitionCell = a_transitionCell;
+	}
+
 	json BuildReplaySteps(const json& a_args)
 	{
 		std::string path = a_args.value("path", std::string{});
@@ -462,33 +482,92 @@ namespace dvb::Recording
 
 		json steps = json::array();
 
-		// restoreScene: re-establish the recorded entry point so the trajectory runs in the
-		// scene it was captured in (loading the save also restores its time/weather). Without
-		// it, replay just teleports along the path in whatever scene is currently loaded.
-		if (a_args.value("restoreScene", false)) {
-			const json        meta = rec.value("meta", json::object());
-			const json        entry = meta.value("entryPoint", json::object());
-			const std::string kind = entry.value("kind", std::string{});
-			const std::string value = entry.value("value", std::string{});
+		const json        meta = rec.value("meta", json::object());
+		const json        entry = meta.value("entryPoint", json::object());
+		const std::string kind = entry.value("kind", std::string{});
+		const std::string value = entry.value("value", std::string{});
+
+		// Recorded scene identity (for the assert + tier). Interiors carry no worldspace.
+		const bool          interior = meta.value("interior", false);
+		const std::uint32_t wsFormID = meta.value("worldspaceFormID", static_cast<std::uint32_t>(0));
+		const std::uint32_t cellFormID = meta.value("cellFormID", static_cast<std::uint32_t>(0));
+		const bool          haveScene = interior ? (cellFormID != 0) : (wsFormID != 0);
+
+		// Coupling tier: a recipe may pin it (or its thresholds) in meta.coupling; otherwise
+		// classify entryPoint.ageMs against the config windows. Unknown age (old recipe / a
+		// walked-in entry) → "cell": restore best-effort and assert the scene.
+		const json  coupling = meta.value("coupling", json::object());
+		const long  anchorMs = coupling.value("anchorMs", g_anchorMs);
+		const long  cellMs = coupling.value("cellMs", g_cellMs);
+		std::string tier = coupling.value("tier", std::string{});
+		if (tier.empty()) {
+			if (entry.contains("ageMs")) {
+				const std::int64_t age = entry.value("ageMs", static_cast<std::int64_t>(0));
+				tier = (age <= anchorMs) ? "anchored" : (age <= cellMs) ? "cell" :
+				                                                          "worldspace";
+			} else {
+				tier = "cell";
+			}
+		}
+
+		const bool restoreScene = a_args.value("restoreScene", false);
+		const long settleMs = a_args.value("settleMs", static_cast<long>(g_loadSettleMs));
+		const bool cleanTransition = a_args.value("cleanTransition", g_cleanTransition);
+
+		// Restore the recorded entry, per tier. "worldspace" treats the entry as incidental and
+		// skips the restore — it only requires landing in the recorded worldspace, which the
+		// assert below enforces (the trajectory's own cow/setpos handle the positioning).
+		bool restored = false;
+		if (restoreScene && tier != "worldspace" && !kind.empty() && kind != "unknown") {
 			if (kind == "save" && !value.empty()) {
-				// game load (by name) skips the content-mismatch modal. Wait on the
-				// postLoadGame lifecycle EVENT, not waitUntil playerLoaded: when reloading the
-				// save we're already in, playerLoaded reads true before the reload cycles, so it
-				// would short-circuit; postLoadGame fires only when the load actually completes.
+				// game load (by name) skips the content-mismatch modal and is a full teardown +
+				// loading screen on its own. Wait on postLoadGame, not playerLoaded: reloading the
+				// save we're already in, playerLoaded reads true before the reload cycles.
 				steps.push_back(json{ { "tool", "game" }, { "args", json{ { "action", "load" }, { "name", value } } } });
 				steps.push_back(json{ { "waitFor", "postLoadGame" }, { "timeoutMs", 60000 } });
+				restored = true;
 			} else if (kind == "coc" && !value.empty()) {
+				// A raw coc can stream without the loading-screen teardown some mods rely on to
+				// free resources (→ CTD). Bounce through a neutral interior first to force a clean
+				// loading screen (save-loads already tear down, so they skip this).
+				if (cleanTransition && !g_cleanTransitionCell.empty() && g_cleanTransitionCell != value) {
+					steps.push_back(json{ { "tool", "console" }, { "args", json{ { "action", "exec" }, { "command", "coc " + g_cleanTransitionCell } } } });
+					steps.push_back(json{ { "waitUntil", "playerLoaded" }, { "timeoutMs", 60000 } });
+					if (settleMs > 0)
+						steps.push_back(json{ { "wait", settleMs } });
+				}
 				steps.push_back(json{ { "tool", "console" }, { "args", json{ { "action", "exec" }, { "command", "coc " + value } } } });
 				steps.push_back(json{ { "waitUntil", "playerLoaded" }, { "timeoutMs", 60000 } });
-			} else {
+				restored = true;
+				// anchored: a save-load would restore time/weather, but a coc doesn't — re-apply
+				// the recorded lighting so the shader benchmark stays comparable.
+				if (tier == "anchored") {
+					if (meta.contains("gameHour"))
+						steps.push_back(json{ { "tool", "console" }, { "args", json{ { "action", "exec" }, { "command", std::format("set gamehour to {}", meta.value("gameHour", 12.0)) } } } });
+					if (meta.contains("weatherFormID"))
+						steps.push_back(json{ { "tool", "console" }, { "args", json{ { "action", "exec" }, { "command", std::format("fw {:X}", meta.value("weatherFormID", static_cast<std::uint32_t>(0))) } } } });
+				}
+			}
+			if (restored && settleMs > 0)
+				steps.push_back(json{ { "wait", settleMs } });
+			if (!restored)
 				logs::warn("devbench record(replay): restoreScene requested but entryPoint is '{}' — running trajectory without scene restore",
 					kind.empty() ? "unknown" : kind);
-			}
-			// Settle after the load before teleporting (local/per-machine; overridable per call).
-			// Only when a load was actually prefixed (steps non-empty) — no load, no settle.
-			const long settleMs = a_args.value("settleMs", static_cast<long>(g_loadSettleMs));
-			if (!steps.empty() && settleMs > 0)
-				steps.push_back(json{ { "wait", settleMs } });
+		}
+
+		// Assert we're in the recorded scene before the trajectory runs, so a wrong worldspace
+		// (e.g. coc ambiguity landing in Soul Cairn) aborts the replay instead of producing a
+		// bogus benchmark. Runs even without a restore — catches an in-place replay in the wrong
+		// scene. Coarse by design: the parent cell (interior) or the worldspace (exterior).
+		if (haveScene) {
+			steps.push_back(json{
+				{ "assert", "scene" },
+				{ "interior", interior },
+				{ "worldspaceFormID", wsFormID },
+				{ "cellFormID", cellFormID },
+				{ "worldspace", meta.value("worldspace", std::string{}) },
+				{ "cell", meta.value("cell", std::string{}) },
+			});
 		}
 
 		// Copy the trajectory, injecting a load-settle after any captured cell transition (coc/cow):

--- a/src/Recording.h
+++ b/src/Recording.h
@@ -50,6 +50,12 @@ namespace dvb::Recording
 	/// hotkey). Local/per-machine via config (recordIntervalMs). Clamped to the 10ms floor.
 	void SetDefaultIntervalMs(int a_ms);
 
+	/// Scene-coupling defaults from config: the age thresholds (ms) that map a recipe's
+	/// entryPoint.ageMs to the anchored/cell/worldspace tier, and the clean-transition policy
+	/// (bounce a coc/cow restore through a neutral cell to force a loading-screen teardown).
+	/// A recipe's meta.coupling block and a replay call's args override these.
+	void SetCoupling(int a_anchorMs, int a_cellMs, bool a_cleanTransition, const std::string& a_transitionCell);
+
 	/// Show a corner HUD message (marshaled to the main thread). Used for hotkey feedback
 	/// (record start/stop, replay) since devbench is otherwise headless. No-op if no task interface.
 	void Notify(const std::string& a_msg);

--- a/src/Tools.cpp
+++ b/src/Tools.cpp
@@ -598,8 +598,65 @@ namespace dvb
 								r["error"] = tr.errorMessage;
 								stepFailed = true;
 							}
+						} else if (step.contains("assert")) {
+							const std::string what = step["assert"].get<std::string>();
+							r["kind"] = "assert";
+							r["assert"] = what;
+							if (what != "scene")
+								throw ToolError(400, std::format("unknown assert '{}' (scene)", what));
+							const bool          interior = step.value("interior", false);
+							const std::uint32_t wsWant = step.value("worldspaceFormID", 0u);
+							const std::uint32_t cellWant = step.value("cellFormID", 0u);
+							const long          timeoutMs = step.value("timeoutMs", static_cast<long>(10000));
+							// The scene may still be loading right after a restore — poll until the
+							// player is loaded, read the current worldspace/cell, compare the coarse id.
+							json       check;
+							bool       ready = false;
+							const auto deadline = steady_clock::now() + milliseconds(timeoutMs);
+							do {
+								try {
+									check = MainThread::RunAndWait([interior, wsWant, cellWant]() -> json {
+										auto* pc = RE::PlayerCharacter::GetSingleton();
+										if (!pc || pc->Get3D() == nullptr)
+											return json{ { "ready", false } };
+										std::uint32_t curWs = 0, curCell = 0;
+										if (auto* ws = pc->GetWorldspace())
+											curWs = ws->GetFormID();
+										if (auto* cell = pc->GetParentCell())
+											curCell = cell->GetFormID();
+										const bool ok = interior ? (curCell == cellWant) : (curWs == wsWant);
+										return json{ { "ready", true }, { "ok", ok }, { "worldspaceFormID", curWs }, { "cellFormID", curCell } };
+									},
+										milliseconds(2000));
+								} catch (const ToolError&) {
+									check = json{ { "ready", false } };  // main thread stalled mid-load — keep polling
+								}
+								if (check.value("ready", false)) {
+									ready = true;
+									break;
+								}
+								std::this_thread::sleep_for(milliseconds(250));
+							} while (steady_clock::now() < deadline);
+
+							if (!ready) {
+								r["errorCode"] = 504;
+								r["error"] = "scene assert: player never finished loading";
+								stepFailed = true;
+							} else if (!check.value("ok", false)) {
+								const std::string wantEid = interior ? step.value("cell", std::string{}) : step.value("worldspace", std::string{});
+								r["errorCode"] = 409;
+								r["error"] = std::format("scene mismatch: recorded {} '{}' (0x{:X}), currently in 0x{:X} — aborting replay",
+									interior ? "cell" : "worldspace", wantEid,
+									interior ? cellWant : wsWant,
+									interior ? check.value("cellFormID", 0u) : check.value("worldspaceFormID", 0u));
+								stepFailed = true;
+							} else {
+								r["ok"] = true;
+								r["worldspaceFormID"] = check.value("worldspaceFormID", 0u);
+								r["cellFormID"] = check.value("cellFormID", 0u);
+							}
 						} else {
-							throw ToolError(400, std::format("step {} has none of wait/waitFor/waitUntil/tool", i));
+							throw ToolError(400, std::format("step {} has none of wait/waitFor/waitUntil/tool/assert", i));
 						}
 					} catch (const ToolError& e) {
 						if (!r.contains("kind"))

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -79,6 +79,7 @@ namespace
 				dvb::RegisterCoreTools(g_server->Tools(), g_server->Events());
 				dvb::Recording::SetLoadSettleMs(cfg.loadSettleMs);
 				dvb::Recording::SetDefaultIntervalMs(cfg.recordIntervalMs);
+				dvb::Recording::SetCoupling(cfg.couplingAnchorMs, cfg.couplingCellMs, cfg.cleanTransition, cfg.cleanTransitionCell);
 				dvb::ArmAutoRun(g_server->Tools(), cfg.autoRunPath, cfg.autoRunRestoreScene);
 				dvb::HostApi::Init(g_server->Tools(), g_server->Events());
 				g_server->Start();


### PR DESCRIPTION
Makes replay guard benchmark integrity and reproduce the recorded scene more faithfully. Three changes, one pipeline: `[clean teardown] → restore (per tier) → settle → assert scene → trajectory`.

## 1. Scene assertion — don't benchmark the wrong scene
A new `assert: scene` scenario step compares the live worldspace (exterior) / cell (interior) to the recording's manifest and aborts the replay (`409`) on a mismatch. `BuildReplaySteps` injects it before every trajectory, even with `restoreScene` off — so `coc` ambiguity (the Soul Cairn case) or an in-place replay in the wrong cell fails loud instead of producing meaningless numbers.

## 2. Save/coc coupling by timing
`EntryPoint` now timestamps when devbench brokered the save/coc; recording stamps `entryPoint.ageMs`. Replay classifies it into **anchored / cell / worldspace** tiers (config `couplingAnchorMs`/`couplingCellMs`, overridable per-recipe via `meta.coupling`):
- **anchored** (entry staged seconds before recording) — restore the entry and re-apply the recorded `gameHour`+weather (a `coc`, unlike a save-load, doesn't restore lighting — and lighting is the whole point of a shader benchmark).
- **cell** — restore the entry.
- **worldspace** (entry was incidental) — skip the restore; only assert the worldspace.

## 3. Clean transitions — the cow/coc CTD fix
A `coc`/`cow` restore first bounces through a neutral cell (`cleanTransitionCell`, default `QASmoke`) to force a loading-screen teardown that some mods need to free resources between scenes. Save-loads already tear down, so they skip the bounce. (Investigated a direct LoadingMenu/fast-travel trigger first — CommonLib exposes only marker-based fast travel and `PurgeBufferedCells`, neither a clean arbitrary-coord loading screen — so the bounce is the mechanism.)

## Validation — built + tested live in Skyrim SE via the devbench harness
- **Builds** clean (`build ok`, devbench.dll links).
- **Plugin loads** in-game with the changes; full tool registry intact.
- **Record** stamps `entryPoint.ageMs` (33365 ms observed) + scene manifest.
- **Replay (restoreScene=true)** ran end-to-end `ok=True`: save-load restore → `postLoadGame` → settle → `assert scene ok=True (cell 91555)` → trajectory.
- **Clean transition**: a raw `coc` between two cells **CTD'd** the modlist; the same transition **survived** when bounced through `QASmoke` — confirming the fix.
- **Wrong-scene abort**: replaying a Dragonsreach recipe while in the Bannered Mare aborted at the assert (`409 scene mismatch …`, `stepsRun=1`, trajectory skipped).

🤖 Generated with [Claude Code](https://claude.com/claude-code)