### PR TITLE
test(http): live HTTP integration suite (skip-safe, game-driven)

### DIFF
--- a/tests/http/.gitignore
+++ b/tests/http/.gitignore
@@ -1,0 +1,3 @@
+__pycache__/
+.pytest_cache/
+*.pyc

--- a/tests/http/README.md
+++ b/tests/http/README.md
@@ -1,0 +1,72 @@
+# devbench HTTP integration tests
+
+A starter pytest suite that drives the devbench REST API against a **running**
+Skyrim with the plugin loaded. It is **CI-safe**: when no game/server is
+reachable, the whole suite is _skipped_ (never failed), and individual tests are
+skipped when the capability they exercise isn't present in the live build.
+
+## Requirements
+
+```sh
+pip install -r requirements.txt
+```
+
+(`pytest`, `requests` — Python 3.9+.)
+
+## Running
+
+```sh
+pytest tests/http -v
+```
+
+If you have multiple game instances or a non-default port, point the suite at
+the right server explicitly:
+
+```sh
+# PowerShell
+$env:DEVBENCH_URL = "http://127.0.0.1:8921"; pytest tests/http -v
+
+# bash
+DEVBENCH_URL=http://127.0.0.1:8921 pytest tests/http -v
+```
+
+## How discovery works
+
+The base URL is resolved in this order (first hit wins):
+
+1. **`DEVBENCH_URL`** environment variable (e.g. `http://127.0.0.1:8921`).
+2. **`runtime.json`** published by a running instance at
+   `<GameData>/SKSE/Plugins/devbench/runtime.json` (`{"port": <int>}`) — known
+   Steam SE/VR `Data` paths are probed. The plugin writes this so fixed-URL
+   clients can find an auto-incremented port.
+3. **Port probe** of `127.0.0.1:8920..8925` (the default 8920 auto-increments
+   when busy, e.g. multiple game instances).
+
+A candidate is only accepted once `POST /api/tool/inspect {"kind":"state"}`
+returns JSON carrying a `plugin` field (liveness check).
+
+## Skip rules (why the suite stays green)
+
+- **No server reachable** → entire session skipped.
+- **No in-world save loaded** → tests marked `@pytest.mark.requires_player` are
+  skipped (checked via `inspect{kind:state}.playerLoaded`). The suite never
+  loads a save itself — the human/another agent controls game state.
+- **Capability absent on this branch** → a test skips when its tool is missing
+  from `GET /api/tools`, or when a needed action/kind is absent from the live
+  `inputSchema` enum (e.g. `menu` `open`).
+
+## Layout
+
+| File              | Covers                                                                                 |
+| ----------------- | -------------------------------------------------------------------------------------- |
+| `conftest.py`     | discovery, `base_url`/`client`/`tool_schema` fixtures, `requires_player`, skip helpers |
+| `test_smoke.py`   | discovery (`/api/tools`, `inspect` present) + console/camera/game smoke                |
+| `test_inspect.py` | `inspect` state / vm / scene / refs                                                    |
+| `test_papyrus.py` | `papyrus` list / describe / call (globals + members) + error                           |
+| `test_menu.py`    | `menu` list, and the open→list→close round-trip (guarded)                              |
+
+## Environment variables
+
+| Variable       | Effect                                                               |
+| -------------- | -------------------------------------------------------------------- |
+| `DEVBENCH_URL` | Skip discovery and use this base URL (e.g. `http://127.0.0.1:8921`). |

--- a/tests/http/conftest.py
+++ b/tests/http/conftest.py
@@ -1,0 +1,241 @@
+"""Shared fixtures for the devbench HTTP integration suite.
+
+The suite is CI-safe: when no game/server is reachable the entire session is
+SKIPPED (never failed). It also skips individual tests whose tool — or a needed
+action/kind — is absent from the *live* schema, so the suite stays green across
+branches that add or drop capabilities.
+
+Discovery order for the base URL (first hit wins):
+  1. env var DEVBENCH_URL  (e.g. http://127.0.0.1:8921)
+  2. runtime.json under known Skyrim SE / VR Data paths ({"port": <int>})
+  3. probe 127.0.0.1:8920..8925
+
+Liveness is confirmed by POSTing {"kind":"state"} to /api/tool/inspect and
+checking the response is JSON carrying a `plugin` field.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+from typing import Any, Iterable
+
+import pytest
+import requests
+
+# Short timeouts keep the suite snappy when the server is up and fail fast when
+# it is not. Game reads run on the main thread (which can stall mid-frame,
+# especially in VR), so the liveness probe is forgiving and retried.
+PROBE_TIMEOUT = 5.0
+PROBE_RETRIES = 2
+CALL_TIMEOUT = 15.0
+
+PORT_RANGE = range(8920, 8926)  # 8920..8925 inclusive
+
+
+# --------------------------------------------------------------------------- #
+# Port / base-URL discovery
+# --------------------------------------------------------------------------- #
+def _runtime_json_candidates() -> Iterable[Path]:
+    """Likely <GameData>/SKSE/Plugins/devbench/runtime.json locations.
+
+    Covers the common Steam install roots for Skyrim SE and VR. Missing paths
+    are simply skipped by the caller — this is best-effort discovery.
+    """
+    rel = Path("SKSE") / "Plugins" / "devbench" / "runtime.json"
+    data_dirs = [
+        r"C:\Program Files (x86)\Steam\steamapps\common\Skyrim Special Edition\Data",
+        r"C:\Program Files (x86)\Steam\steamapps\common\SkyrimVR\Data",
+        r"E:\SteamLibrary\steamapps\common\Skyrim Special Edition\Data",
+        r"E:\SteamLibrary\steamapps\common\SkyrimVR\Data",
+        r"D:\SteamLibrary\steamapps\common\Skyrim Special Edition\Data",
+        r"D:\SteamLibrary\steamapps\common\SkyrimVR\Data",
+    ]
+    for d in data_dirs:
+        yield Path(d) / rel
+
+
+def _read_runtime_port() -> int | None:
+    for path in _runtime_json_candidates():
+        try:
+            if not path.is_file():
+                continue
+            data = json.loads(path.read_text(encoding="utf-8"))
+            port = int(data["port"])
+            if 1 <= port <= 65535:
+                return port
+        except (OSError, ValueError, KeyError, TypeError):
+            continue
+    return None
+
+
+def _is_live(base_url: str) -> bool:
+    """True if base_url's inspect{kind:state} returns JSON with a `plugin` field.
+
+    Retried a few times: a connection *refused* fails fast (no server), but a
+    live main thread stalled mid-frame can exceed a single probe timeout.
+    """
+    for _ in range(PROBE_RETRIES + 1):
+        try:
+            resp = requests.post(
+                f"{base_url}/api/tool/inspect",
+                json={"kind": "state"},
+                timeout=PROBE_TIMEOUT,
+            )
+        except requests.ConnectionError:
+            return False  # nothing listening — no point retrying this URL
+        except requests.RequestException:
+            continue  # timeout/other — main thread may be busy, retry
+        if resp.status_code != 200:
+            return False
+        try:
+            body = resp.json()
+        except ValueError:
+            return False
+        return isinstance(body, dict) and "plugin" in body
+    return False
+
+
+def _discover_base_url() -> str | None:
+    # 1. Explicit override.
+    env = os.environ.get("DEVBENCH_URL")
+    if env:
+        env = env.rstrip("/")
+        return env if _is_live(env) else None
+
+    # 2. runtime.json published by a running instance.
+    port = _read_runtime_port()
+    if port is not None:
+        url = f"http://127.0.0.1:{port}"
+        if _is_live(url):
+            return url
+
+    # 3. Probe the default range (handles the port auto-increment).
+    for p in PORT_RANGE:
+        url = f"http://127.0.0.1:{p}"
+        if _is_live(url):
+            return url
+    return None
+
+
+# --------------------------------------------------------------------------- #
+# Session-scoped fixtures
+# --------------------------------------------------------------------------- #
+@pytest.fixture(scope="session")
+def base_url() -> str:
+    """Discovered devbench base URL, or skip the whole suite if unreachable."""
+    url = _discover_base_url()
+    if url is None:
+        pytest.skip(
+            "no reachable devbench server "
+            "(set DEVBENCH_URL, or start Skyrim with the plugin on 8920..8925)"
+        )
+    return url
+
+
+class Client:
+    """Thin requests wrapper that returns (status_code, parsed_json)."""
+
+    def __init__(self, base_url: str):
+        self.base_url = base_url
+        self._session = requests.Session()
+
+    def tools(self) -> list[dict[str, Any]]:
+        resp = self._session.get(f"{self.base_url}/api/tools", timeout=CALL_TIMEOUT)
+        assert resp.status_code == 200, f"GET /api/tools -> {resp.status_code}"
+        return resp.json()
+
+    def call(self, tool: str, args: dict[str, Any] | None = None,
+             timeout: float = CALL_TIMEOUT) -> tuple[int, Any]:
+        resp = self._session.post(
+            f"{self.base_url}/api/tool/{tool}",
+            json=args if args is not None else {},
+            timeout=timeout,
+        )
+        try:
+            body = resp.json()
+        except ValueError:
+            body = None
+        return resp.status_code, body
+
+    def ok(self, tool: str, args: dict[str, Any] | None = None,
+           timeout: float = CALL_TIMEOUT) -> Any:
+        """Call a tool, assert HTTP 200, and return the JSON result."""
+        status, body = self.call(tool, args, timeout=timeout)
+        assert status == 200, f"{tool}({args}) -> {status}: {body}"
+        return body
+
+
+@pytest.fixture(scope="session")
+def client(base_url: str) -> Client:
+    return Client(base_url)
+
+
+@pytest.fixture(scope="session")
+def tool_schema(client: Client) -> dict[str, dict[str, Any]]:
+    """Live tool descriptors keyed by name: {name: {description, inputSchema, ...}}."""
+    return {d["name"]: d for d in client.tools()}
+
+
+@pytest.fixture(scope="session")
+def player_loaded(client: Client) -> bool:
+    """Whether an in-world save is loaded (inspect{kind:state}.playerLoaded)."""
+    try:
+        body = client.ok("inspect", {"kind": "state"})
+    except (AssertionError, requests.RequestException):
+        return False
+    return bool(isinstance(body, dict) and body.get("playerLoaded"))
+
+
+# --------------------------------------------------------------------------- #
+# Skip helpers (importable by test modules)
+# --------------------------------------------------------------------------- #
+def require_tool(tool_schema: dict[str, dict[str, Any]], name: str) -> dict[str, Any]:
+    """Return the descriptor for `name`, or skip if it's not in the live schema."""
+    if name not in tool_schema:
+        pytest.skip(f"tool '{name}' not present in live /api/tools")
+    return tool_schema[name]
+
+
+def schema_enum(descriptor: dict[str, Any], prop: str) -> list[Any]:
+    """Enum values declared for an input property, or [] if none/unknown."""
+    try:
+        return list(descriptor["inputSchema"]["properties"][prop]["enum"])
+    except (KeyError, TypeError):
+        return []
+
+
+def require_enum(descriptor: dict[str, Any], prop: str, value: str) -> None:
+    """Skip unless `value` is in the input property's enum.
+
+    A missing enum is treated as "unconstrained" (no skip) — only an explicit
+    enum that omits the value triggers a skip.
+    """
+    values = schema_enum(descriptor, prop)
+    if values and value not in values:
+        pytest.skip(f"action/kind '{value}' not in live schema enum for '{prop}' ({values})")
+
+
+# --------------------------------------------------------------------------- #
+# requires_player marker / fixture
+# --------------------------------------------------------------------------- #
+def pytest_configure(config: pytest.Config) -> None:
+    config.addinivalue_line(
+        "markers",
+        "requires_player: test needs an in-world save loaded; skipped if playerLoaded is false",
+    )
+
+
+@pytest.fixture
+def requires_player(player_loaded: bool) -> None:
+    """Skip the test unless an in-world save is currently loaded."""
+    if not player_loaded:
+        pytest.skip("no in-world save loaded (inspect{kind:state}.playerLoaded == false)")
+
+
+@pytest.fixture(autouse=True)
+def _auto_requires_player(request: pytest.FixtureRequest) -> None:
+    """Honor the @pytest.mark.requires_player marker without an explicit fixture."""
+    if request.node.get_closest_marker("requires_player"):
+        request.getfixturevalue("requires_player")

--- a/tests/http/pytest.ini
+++ b/tests/http/pytest.ini
@@ -1,0 +1,6 @@
+[pytest]
+# Run from this directory so `from conftest import ...` resolves.
+testpaths = .
+addopts = -ra
+markers =
+    requires_player: test needs an in-world save loaded; skipped if playerLoaded is false

--- a/tests/http/requirements.txt
+++ b/tests/http/requirements.txt
@@ -1,0 +1,2 @@
+pytest>=7.0
+requests>=2.28

--- a/tests/http/test_inspect.py
+++ b/tests/http/test_inspect.py
@@ -1,0 +1,106 @@
+"""Tests for the `inspect` tool (live game-state reads)."""
+
+from __future__ import annotations
+
+import numbers
+
+import pytest
+
+from conftest import require_enum, require_tool
+
+
+def _is_number(v) -> bool:
+    return isinstance(v, numbers.Number) and not isinstance(v, bool)
+
+
+@pytest.fixture
+def inspect(tool_schema):
+    return require_tool(tool_schema, "inspect")
+
+
+def test_state(client, inspect):
+    require_enum(inspect, "kind", "state")
+    body = client.ok("inspect", {"kind": "state"})
+    assert isinstance(body, dict), body
+    assert body.get("plugin") == "devbench", body
+    assert "version" in body, body
+    assert isinstance(body.get("vr"), bool), body
+    assert isinstance(body.get("playerLoaded"), bool), body
+    assert "frame" in body, body
+
+
+def test_vm(client, inspect):
+    require_enum(inspect, "kind", "vm")
+    body = client.ok("inspect", {"kind": "vm"})
+    assert body.get("available") is True, body
+    assert isinstance(body.get("loadedTypes"), int) and body["loadedTypes"] > 0, body
+    for field in ("attachedScripts", "arrays", "runningStacks", "frozenStacks"):
+        assert isinstance(body.get(field), int), (field, body)
+    assert isinstance(body.get("overstressed"), bool), body
+
+
+@pytest.mark.requires_player
+def test_scene(client, inspect):
+    require_enum(inspect, "kind", "scene")
+    body = client.ok("inspect", {"kind": "scene"})
+    assert body.get("playerLoaded") is True, body
+
+    cell = body.get("cell")
+    assert isinstance(cell, dict), body
+    assert "formId" in cell and "formType" in cell and "name" in cell, cell
+
+    pos = body.get("position")
+    assert isinstance(pos, list) and len(pos) == 3, body
+    assert all(_is_number(c) for c in pos), pos
+
+    hour = body.get("gameHour")
+    assert _is_number(hour) and 0 <= hour < 24, body
+
+    assert isinstance(body.get("weather"), dict), body
+
+
+@pytest.mark.requires_player
+def test_refs_player_by_formid(client, inspect):
+    require_enum(inspect, "kind", "refs")
+    body = client.ok("inspect", {"kind": "refs", "formId": "0x14"})
+    assert body.get("count") == 1, body
+    refs = body.get("refs")
+    assert isinstance(refs, list) and len(refs) == 1, body
+    ref = refs[0]
+    assert ref.get("formId") == "0x00000014", ref
+    assert ref.get("base", {}).get("formType") == "NPC_", ref
+    actor = ref.get("actor")
+    assert isinstance(actor, dict), ref
+    assert _is_number(actor.get("health")), actor
+    assert _is_number(actor.get("level")), actor
+
+
+@pytest.mark.requires_player
+def test_refs_actors_in_radius(client, inspect):
+    require_enum(inspect, "kind", "refs")
+    body = client.ok(
+        "inspect",
+        {"kind": "refs", "formType": "Actor", "radius": 100000, "limit": 200},
+    )
+    assert isinstance(body.get("count"), int) and body["count"] >= 1, body
+    refs = body.get("refs")
+    assert isinstance(refs, list) and refs, body
+
+    # Every ref that is actually an actor must carry an `actor` snapshot.
+    for ref in refs:
+        ftype = (ref.get("formType") or "")
+        btype = (ref.get("base", {}) or {}).get("formType", "")
+        if "ACHR" in ftype or "ACHR" in btype or "NPC_" in btype:
+            assert isinstance(ref.get("actor"), dict), ref
+
+    assert any((r.get("base", {}) or {}).get("name") for r in refs), \
+        "expected at least one actor ref with a base.name"
+
+
+@pytest.mark.requires_player
+def test_refs_enumerate(client, inspect):
+    require_enum(inspect, "kind", "refs")
+    body = client.ok("inspect", {"kind": "refs"})
+    assert isinstance(body.get("count"), int) and body["count"] > 0, body
+    assert isinstance(body.get("refs"), list), body
+    assert isinstance(body.get("truncated"), bool), body

--- a/tests/http/test_menu.py
+++ b/tests/http/test_menu.py
@@ -1,0 +1,56 @@
+"""Tests for the `menu` tool.
+
+The 'open' action is build-dependent (absent in some branches); the open/close
+round-trip test guards on the live action enum and skips when 'open' is missing.
+"""
+
+from __future__ import annotations
+
+import time
+
+import pytest
+
+from conftest import require_enum, require_tool, schema_enum
+
+
+@pytest.fixture
+def menu(tool_schema):
+    return require_tool(tool_schema, "menu")
+
+
+def test_list(client, menu):
+    require_enum(menu, "action", "list")
+    body = client.ok("menu", {"action": "list"})
+    assert isinstance(body, dict), body
+    assert isinstance(body.get("openMenus"), list), body
+    assert isinstance(body.get("messageBoxOpen"), bool), body
+
+
+@pytest.mark.requires_player
+def test_open_tween_roundtrip(client, menu):
+    require_enum(menu, "action", "list")
+    if "open" not in schema_enum(menu, "action"):
+        pytest.skip("menu 'open' action not in live schema enum")
+
+    target = "TweenMenu"
+
+    def list_menus():
+        return client.ok("menu", {"action": "list"}).get("openMenus", [])
+
+    def wait_for(predicate, attempts=10, delay=0.3):
+        for _ in range(attempts):
+            menus = list_menus()
+            if predicate(menus):
+                return menus
+            time.sleep(delay)
+        return list_menus()
+
+    # Open, then confirm it shows up (UI queue is async — poll).
+    client.ok("menu", {"action": "open", "name": target})
+    opened = wait_for(lambda m: target in m)
+    assert target in opened, f"{target} not in openMenus after open: {opened}"
+
+    # Close, then confirm it's gone.
+    client.ok("menu", {"action": "close", "name": target})
+    closed = wait_for(lambda m: target not in m)
+    assert target not in closed, f"{target} still in openMenus after close: {closed}"

--- a/tests/http/test_papyrus.py
+++ b/tests/http/test_papyrus.py
@@ -1,0 +1,120 @@
+"""Tests for the `papyrus` tool (list / describe / call into the live VM)."""
+
+from __future__ import annotations
+
+import numbers
+
+import pytest
+
+from conftest import require_enum, require_tool
+
+
+def _is_number(v) -> bool:
+    return isinstance(v, numbers.Number) and not isinstance(v, bool)
+
+
+@pytest.fixture
+def papyrus(tool_schema):
+    return require_tool(tool_schema, "papyrus")
+
+
+def test_list_filter_utility(client, papyrus):
+    require_enum(papyrus, "action", "list")
+    body = client.ok("papyrus", {"action": "list", "filter": "utility"})
+    assert isinstance(body.get("total"), int) and body["total"] >= 1, body
+    scripts = body.get("scripts")
+    assert isinstance(scripts, list), body
+    assert any("utility" in s.lower() for s in scripts), scripts
+
+
+def test_describe_utility(client, papyrus):
+    require_enum(papyrus, "action", "describe")
+    body = client.ok("papyrus", {"action": "describe", "script": "Utility"})
+    globals_ = body.get("globalFunctions")
+    assert isinstance(globals_, list) and globals_, body
+    match = [f for f in globals_ if f.get("name") == "GetCurrentGameTime"]
+    assert match, "Utility.GetCurrentGameTime not found in globalFunctions"
+    fn = match[0]
+    assert fn.get("returnType") == "float", fn
+    assert fn.get("params") == [], fn
+
+
+@pytest.mark.requires_player
+def test_call_utility_getcurrentgametime(client, papyrus):
+    require_enum(papyrus, "action", "call")
+    body = client.ok(
+        "papyrus",
+        {"action": "call", "script": "Utility", "function": "GetCurrentGameTime"},
+    )
+    assert body.get("called") is True, body
+    assert _is_number(body.get("returned")), body
+    assert body.get("returnedType") == "float", body
+
+
+@pytest.mark.requires_player
+def test_call_game_getplayer(client, papyrus):
+    require_enum(papyrus, "action", "call")
+    body = client.ok(
+        "papyrus",
+        {"action": "call", "script": "Game", "function": "GetPlayer"},
+    )
+    assert body.get("returned", {}).get("formId") == "0x00000014", body
+    assert body.get("returnedType") == "Actor", body
+
+
+def test_call_game_getgamesettingfloat(client, papyrus):
+    require_enum(papyrus, "action", "call")
+    body = client.ok(
+        "papyrus",
+        {
+            "action": "call",
+            "script": "Game",
+            "function": "GetGameSettingFloat",
+            "args": ["fJumpHeightMin"],
+        },
+    )
+    assert _is_number(body.get("returned")), body
+
+
+@pytest.mark.requires_player
+def test_call_member_getactorvalue_health(client, papyrus):
+    require_enum(papyrus, "action", "call")
+    body = client.ok(
+        "papyrus",
+        {
+            "action": "call",
+            "script": "Actor",
+            "function": "GetActorValue",
+            "self": {"form": "0x14"},
+            "args": ["Health"],
+        },
+    )
+    assert _is_number(body.get("returned")), body
+
+
+@pytest.mark.requires_player
+def test_call_member_getnumitems(client, papyrus):
+    require_enum(papyrus, "action", "call")
+    body = client.ok(
+        "papyrus",
+        {
+            "action": "call",
+            "script": "ObjectReference",
+            "function": "GetNumItems",
+            "self": {"form": "0x14"},
+        },
+    )
+    returned = body.get("returned")
+    assert isinstance(returned, int) and not isinstance(returned, bool), body
+    assert returned >= 0, body
+
+
+def test_call_bogus_function_errors(client, papyrus):
+    require_enum(papyrus, "action", "call")
+    status, body = client.call(
+        "papyrus",
+        {"action": "call", "script": "Utility", "function": "NoSuchFunctionXYZ"},
+    )
+    assert status == 400, (status, body)
+    assert isinstance(body, dict) and "error" in body, body
+    assert body.get("code") == 400, body

--- a/tests/http/test_smoke.py
+++ b/tests/http/test_smoke.py
@@ -1,0 +1,62 @@
+"""Discovery + light smoke tests for console / game / camera."""
+
+from __future__ import annotations
+
+import pytest
+
+from conftest import require_enum, require_tool
+
+
+# --------------------------------------------------------------------------- #
+# Discovery
+# --------------------------------------------------------------------------- #
+def test_tools_listing_nonempty(client):
+    tools = client.tools()
+    assert isinstance(tools, list) and tools, "GET /api/tools returned an empty list"
+    for d in tools:
+        assert "name" in d, d
+        assert "description" in d, d
+        assert "inputSchema" in d, d
+        assert "readOnly" in d, d
+
+
+def test_inspect_present(tool_schema):
+    assert "inspect" in tool_schema, sorted(tool_schema)
+
+
+# --------------------------------------------------------------------------- #
+# console
+# --------------------------------------------------------------------------- #
+def test_console_exec_queued(client, tool_schema):
+    desc = require_tool(tool_schema, "console")
+    require_enum(desc, "action", "exec")
+    body = client.ok("console", {"action": "exec", "command": "getpos x"})
+    assert body.get("queued") is True, body
+    assert body.get("command") == "getpos x", body
+
+
+# --------------------------------------------------------------------------- #
+# camera
+# --------------------------------------------------------------------------- #
+def test_camera_get_pov(client, tool_schema):
+    desc = require_tool(tool_schema, "camera")
+    require_enum(desc, "action", "get")
+    body = client.ok("camera", {"action": "get"})
+    assert isinstance(body, dict), body
+    assert "pov" in body, body
+    # pov is a string (first|third|vanity|other) once a camera exists; may be
+    # null at the main menu — accept either rather than flaking on game state.
+    assert body["pov"] is None or isinstance(body["pov"], str), body
+
+
+# --------------------------------------------------------------------------- #
+# game
+# --------------------------------------------------------------------------- #
+def test_game_list_saves(client, tool_schema):
+    desc = require_tool(tool_schema, "game")
+    require_enum(desc, "action", "list")
+    body = client.ok("game", {"action": "list"})
+    assert isinstance(body, dict), body
+    assert isinstance(body.get("saves"), list), body
+    assert isinstance(body.get("count"), int), body
+    assert body["count"] == len(body["saves"]), body


### PR DESCRIPTION
## What

A pytest suite under `tests/http/` that drives a **running game** over devbench's REST API and asserts on responses — the live/e2e tier, distinct from the host-independent `devbench-tests` (Catch2, no game).

## CI-safe by design

- **Discovery:** `DEVBENCH_URL` → each game's `runtime.json` → probe `8920..8925`, so it follows the port auto-increment when multiple instances run.
- **Skip, never fail, when there's no game:** the whole session skips if no server answers; individual tests skip when `playerLoaded` is false or a tool/action/kind isn't in the live `/api/tools` schema (forward-compatible across branches).

## Coverage

`inspect` (state/vm/scene/refs), `papyrus` (list/describe/call — globals + members), `menu` (list + open/close round-trip when the action exists), and `console`/`game`/`camera` smoke + tool discovery. Doubles as a template for mod authors to test their own C-ABI-registered tools.

## Run

```
pip install -r tests/http/requirements.txt
pytest tests/http -v          # add DEVBENCH_URL=http://127.0.0.1:<port> to skip discovery
```

Validated against a mock matching the source contract: 20 passed, 1 skipped (the `menu open` round-trip skips when the live schema lacks `open`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added HTTP REST API integration test suite with automated tests covering inspect, menu, and papyrus tool endpoints.
  * Added smoke tests for API discovery, tool listing, and endpoint validation.
  * Included test fixtures and helpers for CI-safe execution with automatic server discovery.

* **Documentation**
  * Added comprehensive README documenting test setup, dependencies, configuration, and expected behaviors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->