### PR TITLE
test(http): scenario recipes — navigation + follow-a-moving-NPC

### DIFF
--- a/tests/http/pytest.ini
+++ b/tests/http/pytest.ini
@@ -4,3 +4,4 @@ testpaths = .
 addopts = -ra
 markers =
     requires_player: test needs an in-world save loaded; skipped if playerLoaded is false
+    slow: long-running e2e test (drives the game for tens of seconds); deselect with -m "not slow"

--- a/tests/http/recipes/dragonsreach_navigate.json
+++ b/tests/http/recipes/dragonsreach_navigate.json
@@ -1,0 +1,890 @@
+{
+  "meta": {
+    "description": "Navigate Whiterun Dragonsreach (~29s). Self-contained via coc; derived from a devbench recording, no save dependency.",
+    "cell": "WhiterunDragonsreach",
+    "sourceRecording": "recording_1780255555.json"
+  },
+  "steps": [
+    {
+      "tool": "console",
+      "args": {
+        "action": "exec",
+        "command": "coc WhiterunDragonsreach"
+      }
+    },
+    {
+      "waitUntil": "playerLoaded"
+    },
+    {
+      "wait": 3000
+    },
+    {
+      "args": {
+        "action": "exec",
+        "command": "player.setpos x -448.00"
+      },
+      "tool": "console"
+    },
+    {
+      "args": {
+        "action": "exec",
+        "command": "player.setpos y -128.00"
+      },
+      "tool": "console"
+    },
+    {
+      "args": {
+        "action": "exec",
+        "command": "player.setpos z -318.00"
+      },
+      "tool": "console"
+    },
+    {
+      "args": {
+        "action": "exec",
+        "command": "player.setangle z 319.68"
+      },
+      "tool": "console"
+    },
+    {
+      "wait": 1000
+    },
+    {
+      "args": {
+        "action": "exec",
+        "command": "player.setpos x -448.00"
+      },
+      "tool": "console"
+    },
+    {
+      "args": {
+        "action": "exec",
+        "command": "player.setpos y -128.00"
+      },
+      "tool": "console"
+    },
+    {
+      "args": {
+        "action": "exec",
+        "command": "player.setpos z -318.00"
+      },
+      "tool": "console"
+    },
+    {
+      "args": {
+        "action": "exec",
+        "command": "player.setangle z 319.68"
+      },
+      "tool": "console"
+    },
+    {
+      "wait": 1000
+    },
+    {
+      "args": {
+        "action": "exec",
+        "command": "player.setpos x -444.91"
+      },
+      "tool": "console"
+    },
+    {
+      "args": {
+        "action": "exec",
+        "command": "player.setpos y 27.92"
+      },
+      "tool": "console"
+    },
+    {
+      "args": {
+        "action": "exec",
+        "command": "player.setpos z -318.00"
+      },
+      "tool": "console"
+    },
+    {
+      "args": {
+        "action": "exec",
+        "command": "player.setangle z 1.37"
+      },
+      "tool": "console"
+    },
+    {
+      "wait": 1000
+    },
+    {
+      "args": {
+        "action": "exec",
+        "command": "player.setpos x -436.47"
+      },
+      "tool": "console"
+    },
+    {
+      "args": {
+        "action": "exec",
+        "command": "player.setpos y 380.05"
+      },
+      "tool": "console"
+    },
+    {
+      "args": {
+        "action": "exec",
+        "command": "player.setpos z -318.00"
+      },
+      "tool": "console"
+    },
+    {
+      "args": {
+        "action": "exec",
+        "command": "player.setangle z 1.37"
+      },
+      "tool": "console"
+    },
+    {
+      "wait": 1000
+    },
+    {
+      "args": {
+        "action": "exec",
+        "command": "player.setpos x -427.64"
+      },
+      "tool": "console"
+    },
+    {
+      "args": {
+        "action": "exec",
+        "command": "player.setpos y 727.52"
+      },
+      "tool": "console"
+    },
+    {
+      "args": {
+        "action": "exec",
+        "command": "player.setpos z -275.86"
+      },
+      "tool": "console"
+    },
+    {
+      "args": {
+        "action": "exec",
+        "command": "player.setangle z 1.37"
+      },
+      "tool": "console"
+    },
+    {
+      "wait": 1000
+    },
+    {
+      "args": {
+        "action": "exec",
+        "command": "player.setpos x -418.07"
+      },
+      "tool": "console"
+    },
+    {
+      "args": {
+        "action": "exec",
+        "command": "player.setpos y 1080.62"
+      },
+      "tool": "console"
+    },
+    {
+      "args": {
+        "action": "exec",
+        "command": "player.setpos z -167.78"
+      },
+      "tool": "console"
+    },
+    {
+      "args": {
+        "action": "exec",
+        "command": "player.setangle z 1.37"
+      },
+      "tool": "console"
+    },
+    {
+      "wait": 1000
+    },
+    {
+      "args": {
+        "action": "exec",
+        "command": "player.setpos x -408.89"
+      },
+      "tool": "console"
+    },
+    {
+      "args": {
+        "action": "exec",
+        "command": "player.setpos y 1428.27"
+      },
+      "tool": "console"
+    },
+    {
+      "args": {
+        "action": "exec",
+        "command": "player.setpos z -78.00"
+      },
+      "tool": "console"
+    },
+    {
+      "args": {
+        "action": "exec",
+        "command": "player.setangle z 1.37"
+      },
+      "tool": "console"
+    },
+    {
+      "wait": 1000
+    },
+    {
+      "args": {
+        "action": "exec",
+        "command": "player.setpos x -400.16"
+      },
+      "tool": "console"
+    },
+    {
+      "args": {
+        "action": "exec",
+        "command": "player.setpos y 1792.40"
+      },
+      "tool": "console"
+    },
+    {
+      "args": {
+        "action": "exec",
+        "command": "player.setpos z -79.65"
+      },
+      "tool": "console"
+    },
+    {
+      "args": {
+        "action": "exec",
+        "command": "player.setangle z 1.37"
+      },
+      "tool": "console"
+    },
+    {
+      "wait": 1000
+    },
+    {
+      "args": {
+        "action": "exec",
+        "command": "player.setpos x -498.81"
+      },
+      "tool": "console"
+    },
+    {
+      "args": {
+        "action": "exec",
+        "command": "player.setpos y 2121.67"
+      },
+      "tool": "console"
+    },
+    {
+      "args": {
+        "action": "exec",
+        "command": "player.setpos z -71.96"
+      },
+      "tool": "console"
+    },
+    {
+      "args": {
+        "action": "exec",
+        "command": "player.setangle z 37.96"
+      },
+      "tool": "console"
+    },
+    {
+      "wait": 1000
+    },
+    {
+      "args": {
+        "action": "exec",
+        "command": "player.setpos x -390.86"
+      },
+      "tool": "console"
+    },
+    {
+      "args": {
+        "action": "exec",
+        "command": "player.setpos y 2423.97"
+      },
+      "tool": "console"
+    },
+    {
+      "args": {
+        "action": "exec",
+        "command": "player.setpos z -79.65"
+      },
+      "tool": "console"
+    },
+    {
+      "args": {
+        "action": "exec",
+        "command": "player.setangle z 138.61"
+      },
+      "tool": "console"
+    },
+    {
+      "wait": 1000
+    },
+    {
+      "args": {
+        "action": "exec",
+        "command": "player.setpos x -373.08"
+      },
+      "tool": "console"
+    },
+    {
+      "args": {
+        "action": "exec",
+        "command": "player.setpos y 2651.31"
+      },
+      "tool": "console"
+    },
+    {
+      "args": {
+        "action": "exec",
+        "command": "player.setpos z -16.85"
+      },
+      "tool": "console"
+    },
+    {
+      "args": {
+        "action": "exec",
+        "command": "player.setangle z 174.81"
+      },
+      "tool": "console"
+    },
+    {
+      "wait": 1000
+    },
+    {
+      "args": {
+        "action": "exec",
+        "command": "player.setpos x -509.39"
+      },
+      "tool": "console"
+    },
+    {
+      "args": {
+        "action": "exec",
+        "command": "player.setpos y 2865.18"
+      },
+      "tool": "console"
+    },
+    {
+      "args": {
+        "action": "exec",
+        "command": "player.setpos z 7.67"
+      },
+      "tool": "console"
+    },
+    {
+      "args": {
+        "action": "exec",
+        "command": "player.setangle z 208.82"
+      },
+      "tool": "console"
+    },
+    {
+      "wait": 1000
+    },
+    {
+      "args": {
+        "action": "exec",
+        "command": "player.setpos x -667.92"
+      },
+      "tool": "console"
+    },
+    {
+      "args": {
+        "action": "exec",
+        "command": "player.setpos y 2562.49"
+      },
+      "tool": "console"
+    },
+    {
+      "args": {
+        "action": "exec",
+        "command": "player.setpos z 24.76"
+      },
+      "tool": "console"
+    },
+    {
+      "args": {
+        "action": "exec",
+        "command": "player.setangle z 207.77"
+      },
+      "tool": "console"
+    },
+    {
+      "wait": 1000
+    },
+    {
+      "args": {
+        "action": "exec",
+        "command": "player.setpos x -894.50"
+      },
+      "tool": "console"
+    },
+    {
+      "args": {
+        "action": "exec",
+        "command": "player.setpos y 2296.62"
+      },
+      "tool": "console"
+    },
+    {
+      "args": {
+        "action": "exec",
+        "command": "player.setpos z -79.65"
+      },
+      "tool": "console"
+    },
+    {
+      "args": {
+        "action": "exec",
+        "command": "player.setangle z 224.54"
+      },
+      "tool": "console"
+    },
+    {
+      "wait": 1000
+    },
+    {
+      "args": {
+        "action": "exec",
+        "command": "player.setpos x -1135.75"
+      },
+      "tool": "console"
+    },
+    {
+      "args": {
+        "action": "exec",
+        "command": "player.setpos y 2033.77"
+      },
+      "tool": "console"
+    },
+    {
+      "args": {
+        "action": "exec",
+        "command": "player.setpos z -78.00"
+      },
+      "tool": "console"
+    },
+    {
+      "args": {
+        "action": "exec",
+        "command": "player.setangle z 236.09"
+      },
+      "tool": "console"
+    },
+    {
+      "wait": 1000
+    },
+    {
+      "args": {
+        "action": "exec",
+        "command": "player.setpos x -1478.34"
+      },
+      "tool": "console"
+    },
+    {
+      "args": {
+        "action": "exec",
+        "command": "player.setpos y 1944.75"
+      },
+      "tool": "console"
+    },
+    {
+      "args": {
+        "action": "exec",
+        "command": "player.setpos z -72.12"
+      },
+      "tool": "console"
+    },
+    {
+      "args": {
+        "action": "exec",
+        "command": "player.setangle z 262.56"
+      },
+      "tool": "console"
+    },
+    {
+      "wait": 1000
+    },
+    {
+      "args": {
+        "action": "exec",
+        "command": "player.setpos x -1823.40"
+      },
+      "tool": "console"
+    },
+    {
+      "args": {
+        "action": "exec",
+        "command": "player.setpos y 1851.67"
+      },
+      "tool": "console"
+    },
+    {
+      "args": {
+        "action": "exec",
+        "command": "player.setpos z -79.65"
+      },
+      "tool": "console"
+    },
+    {
+      "args": {
+        "action": "exec",
+        "command": "player.setangle z 261.21"
+      },
+      "tool": "console"
+    },
+    {
+      "wait": 1000
+    },
+    {
+      "args": {
+        "action": "exec",
+        "command": "player.setpos x -2160.67"
+      },
+      "tool": "console"
+    },
+    {
+      "args": {
+        "action": "exec",
+        "command": "player.setpos y 1749.78"
+      },
+      "tool": "console"
+    },
+    {
+      "args": {
+        "action": "exec",
+        "command": "player.setpos z -79.65"
+      },
+      "tool": "console"
+    },
+    {
+      "args": {
+        "action": "exec",
+        "command": "player.setangle z 193.27"
+      },
+      "tool": "console"
+    },
+    {
+      "wait": 1000
+    },
+    {
+      "args": {
+        "action": "exec",
+        "command": "player.setpos x -2381.00"
+      },
+      "tool": "console"
+    },
+    {
+      "args": {
+        "action": "exec",
+        "command": "player.setpos y 1706.02"
+      },
+      "tool": "console"
+    },
+    {
+      "args": {
+        "action": "exec",
+        "command": "player.setpos z -79.63"
+      },
+      "tool": "console"
+    },
+    {
+      "args": {
+        "action": "exec",
+        "command": "player.setangle z 95.62"
+      },
+      "tool": "console"
+    },
+    {
+      "wait": 1000
+    },
+    {
+      "args": {
+        "action": "exec",
+        "command": "player.setpos x -2111.61"
+      },
+      "tool": "console"
+    },
+    {
+      "args": {
+        "action": "exec",
+        "command": "player.setpos y 1793.60"
+      },
+      "tool": "console"
+    },
+    {
+      "args": {
+        "action": "exec",
+        "command": "player.setpos z -79.65"
+      },
+      "tool": "console"
+    },
+    {
+      "args": {
+        "action": "exec",
+        "command": "player.setangle z 73.21"
+      },
+      "tool": "console"
+    },
+    {
+      "wait": 1000
+    },
+    {
+      "args": {
+        "action": "exec",
+        "command": "player.setpos x -1761.41"
+      },
+      "tool": "console"
+    },
+    {
+      "args": {
+        "action": "exec",
+        "command": "player.setpos y 1845.30"
+      },
+      "tool": "console"
+    },
+    {
+      "args": {
+        "action": "exec",
+        "command": "player.setpos z -79.65"
+      },
+      "tool": "console"
+    },
+    {
+      "args": {
+        "action": "exec",
+        "command": "player.setangle z 82.97"
+      },
+      "tool": "console"
+    },
+    {
+      "wait": 1000
+    },
+    {
+      "args": {
+        "action": "exec",
+        "command": "player.setpos x -1404.06"
+      },
+      "tool": "console"
+    },
+    {
+      "args": {
+        "action": "exec",
+        "command": "player.setpos y 1875.50"
+      },
+      "tool": "console"
+    },
+    {
+      "args": {
+        "action": "exec",
+        "command": "player.setpos z -68.40"
+      },
+      "tool": "console"
+    },
+    {
+      "args": {
+        "action": "exec",
+        "command": "player.setangle z 94.42"
+      },
+      "tool": "console"
+    },
+    {
+      "wait": 1000
+    },
+    {
+      "args": {
+        "action": "exec",
+        "command": "player.setpos x -1142.10"
+      },
+      "tool": "console"
+    },
+    {
+      "args": {
+        "action": "exec",
+        "command": "player.setpos y 1661.02"
+      },
+      "tool": "console"
+    },
+    {
+      "args": {
+        "action": "exec",
+        "command": "player.setpos z -78.00"
+      },
+      "tool": "console"
+    },
+    {
+      "args": {
+        "action": "exec",
+        "command": "player.setangle z 159.91"
+      },
+      "tool": "console"
+    },
+    {
+      "wait": 1000
+    },
+    {
+      "args": {
+        "action": "exec",
+        "command": "player.setpos x -1038.46"
+      },
+      "tool": "console"
+    },
+    {
+      "args": {
+        "action": "exec",
+        "command": "player.setpos y 1321.21"
+      },
+      "tool": "console"
+    },
+    {
+      "args": {
+        "action": "exec",
+        "command": "player.setpos z -78.74"
+      },
+      "tool": "console"
+    },
+    {
+      "args": {
+        "action": "exec",
+        "command": "player.setangle z 163.55"
+      },
+      "tool": "console"
+    },
+    {
+      "wait": 1000
+    },
+    {
+      "args": {
+        "action": "exec",
+        "command": "player.setpos x -988.15"
+      },
+      "tool": "console"
+    },
+    {
+      "args": {
+        "action": "exec",
+        "command": "player.setpos y 964.34"
+      },
+      "tool": "console"
+    },
+    {
+      "args": {
+        "action": "exec",
+        "command": "player.setpos z -78.48"
+      },
+      "tool": "console"
+    },
+    {
+      "args": {
+        "action": "exec",
+        "command": "player.setangle z 174.22"
+      },
+      "tool": "console"
+    },
+    {
+      "wait": 1000
+    },
+    {
+      "args": {
+        "action": "exec",
+        "command": "player.setpos x -915.94"
+      },
+      "tool": "console"
+    },
+    {
+      "args": {
+        "action": "exec",
+        "command": "player.setpos y 619.75"
+      },
+      "tool": "console"
+    },
+    {
+      "args": {
+        "action": "exec",
+        "command": "player.setpos z -74.12"
+      },
+      "tool": "console"
+    },
+    {
+      "args": {
+        "action": "exec",
+        "command": "player.setangle z 167.24"
+      },
+      "tool": "console"
+    },
+    {
+      "wait": 1000
+    },
+    {
+      "args": {
+        "action": "exec",
+        "command": "player.setpos x -905.30"
+      },
+      "tool": "console"
+    },
+    {
+      "args": {
+        "action": "exec",
+        "command": "player.setpos y 302.25"
+      },
+      "tool": "console"
+    },
+    {
+      "args": {
+        "action": "exec",
+        "command": "player.setpos z -320.30"
+      },
+      "tool": "console"
+    },
+    {
+      "args": {
+        "action": "exec",
+        "command": "player.setangle z 124.66"
+      },
+      "tool": "console"
+    },
+    {
+      "wait": 1000
+    },
+    {
+      "args": {
+        "action": "exec",
+        "command": "player.setpos x -938.95"
+      },
+      "tool": "console"
+    },
+    {
+      "args": {
+        "action": "exec",
+        "command": "player.setpos y 176.38"
+      },
+      "tool": "console"
+    },
+    {
+      "args": {
+        "action": "exec",
+        "command": "player.setpos z -318.00"
+      },
+      "tool": "console"
+    },
+    {
+      "args": {
+        "action": "exec",
+        "command": "player.setangle z 87.63"
+      },
+      "tool": "console"
+    },
+    {
+      "wait": 1000
+    }
+  ]
+}

--- a/tests/http/recipes/follow_nelkir.json
+++ b/tests/http/recipes/follow_nelkir.json
@@ -1,0 +1,90 @@
+{
+  "meta": {
+    "description": "Follow Nelkir (a child NPC who wanders Whiterun Dragonsreach) via repeated player.moveto. moveto is ref-relative, so this static recipe tracks the NPC wherever he walks. coc makes it save-agnostic.",
+    "npc": "0x1A67B",
+    "npcName": "Nelkir",
+    "cell": "WhiterunDragonsreach"
+  },
+  "steps": [
+    {
+      "tool": "console",
+      "args": {
+        "action": "exec",
+        "command": "coc WhiterunDragonsreach"
+      }
+    },
+    {
+      "waitUntil": "playerLoaded"
+    },
+    {
+      "wait": 3000
+    },
+    {
+      "tool": "console",
+      "args": {
+        "action": "exec",
+        "command": "player.moveto 0x1A67B"
+      }
+    },
+    {
+      "wait": 2500
+    },
+    {
+      "tool": "console",
+      "args": {
+        "action": "exec",
+        "command": "player.moveto 0x1A67B"
+      }
+    },
+    {
+      "wait": 2500
+    },
+    {
+      "tool": "console",
+      "args": {
+        "action": "exec",
+        "command": "player.moveto 0x1A67B"
+      }
+    },
+    {
+      "wait": 2500
+    },
+    {
+      "tool": "console",
+      "args": {
+        "action": "exec",
+        "command": "player.moveto 0x1A67B"
+      }
+    },
+    {
+      "wait": 2500
+    },
+    {
+      "tool": "console",
+      "args": {
+        "action": "exec",
+        "command": "player.moveto 0x1A67B"
+      }
+    },
+    {
+      "wait": 2500
+    },
+    {
+      "tool": "console",
+      "args": {
+        "action": "exec",
+        "command": "player.moveto 0x1A67B"
+      }
+    },
+    {
+      "wait": 2500
+    },
+    {
+      "tool": "console",
+      "args": {
+        "action": "exec",
+        "command": "player.moveto 0x1A67B"
+      }
+    }
+  ]
+}

--- a/tests/http/test_follow_npc.py
+++ b/tests/http/test_follow_npc.py
@@ -1,0 +1,79 @@
+"""Follow-a-moving-NPC recipe: identify an NPC, track it, verify it moved.
+
+`recipes/follow_nelkir.json` `coc`s into Whiterun Dragonsreach and repeatedly
+`player.moveto`s Nelkir — a child NPC who wanders the hall. Because `moveto` is
+ref-relative, a *static* step list still tracks the NPC wherever he walks.
+
+The test proves the full loop the bench cares about:
+  - identify the NPC's live position via `inspect refs formId=…`,
+  - run the recipe (the `scenario` follow),
+  - assert the player ended on the NPC (it followed),
+  - assert the NPC actually moved during a sample window (it's a *moving* target;
+    skips if the NPC happens to be idle, so it never flakes).
+
+Marked `slow` (~18s) + `requires_player`.
+"""
+
+from __future__ import annotations
+
+import json
+import math
+import time
+from pathlib import Path
+
+import pytest
+
+from conftest import require_tool
+
+RECIPE = Path(__file__).parent / "recipes" / "follow_nelkir.json"
+NPC = "0x1A67B"  # Nelkir, a Dragonsreach wanderer (Skyrim.esm ref, stable across saves)
+PLAYER = "0x14"
+
+
+def _pos(client, formid):
+    _, body = client.call("inspect", {"kind": "refs", "formId": formid})
+    if not isinstance(body, dict) or not body.get("count"):
+        return None
+    return body["refs"][0].get("position")
+
+
+def _dist2d(a, b):
+    return math.dist(a[:2], b[:2])
+
+
+@pytest.mark.slow
+@pytest.mark.requires_player
+def test_follow_moving_npc(client, tool_schema):
+    require_tool(tool_schema, "scenario")
+    require_tool(tool_schema, "console")
+    require_tool(tool_schema, "inspect")
+
+    recipe = json.loads(RECIPE.read_text(encoding="utf-8"))
+
+    # Run the follow recipe (coc in + repeated moveto). It blocks ~18s.
+    body = client.ok("scenario", {"steps": recipe["steps"], "continueOnError": True}, timeout=90.0)
+    assert body.get("ok") is True, body
+    assert body.get("stepsRun") == len(recipe["steps"]), body
+
+    time.sleep(0.8)  # let the final moveto apply
+    npc = _pos(client, NPC)
+    if npc is None:
+        pytest.skip(f"NPC {NPC} not present in this save")
+    player = _pos(client, PLAYER)
+    assert player is not None, "player ref unresolved"
+
+    # Followed: the recipe ends on a moveto, so the player should be on the NPC.
+    followed = _dist2d(player, npc)
+    assert followed < 300, f"player {followed:.0f}u from NPC after follow: player={player} npc={npc}"
+
+    # Moving: sample the NPC over a window. If idle right now, skip (don't flake) —
+    # but when it moves, this confirms we tracked a genuinely moving target.
+    a = _pos(client, NPC)
+    time.sleep(4.0)
+    b = _pos(client, NPC)
+    if a is None or b is None:
+        pytest.skip("NPC vanished mid-sample")
+    moved = _dist2d(a, b)
+    if moved < 15:
+        pytest.skip(f"NPC idle right now ({moved:.0f}u) — can't assert a moving target")
+    assert moved >= 15, f"expected the NPC to be moving, saw {moved:.0f}u"

--- a/tests/http/test_scenario.py
+++ b/tests/http/test_scenario.py
@@ -1,0 +1,45 @@
+"""Scenario-tool test: replay a portable navigation recipe end-to-end.
+
+`recipes/dragonsreach_navigate.json` is a ~31s recipe derived from a devbench
+recording but made save-agnostic: it `coc`s into Whiterun Dragonsreach, waits
+for the load, then replays the recorded player.setpos/setangle navigation. So it
+runs against *any* loaded save, not just the one it was recorded on.
+
+This is the heaviest e2e test (it really drives the game for ~31s), so it is
+marked `slow` — deselect with `-m "not slow"`.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from conftest import require_tool
+
+RECIPE = Path(__file__).parent / "recipes" / "dragonsreach_navigate.json"
+
+
+@pytest.mark.slow
+@pytest.mark.requires_player
+def test_navigate_dragonsreach_recipe(client, tool_schema):
+    require_tool(tool_schema, "scenario")
+    require_tool(tool_schema, "console")  # the recipe dispatches console steps
+
+    recipe = json.loads(RECIPE.read_text(encoding="utf-8"))
+    steps = recipe["steps"]
+    assert len(steps) > 50, "recipe should be the full navigation, not a stub"
+
+    # The scenario blocks server-side for the recipe's duration (~31s) — give the
+    # HTTP call room beyond that.
+    body = client.ok(
+        "scenario",
+        {"steps": steps, "continueOnError": True},
+        timeout=120.0,
+    )
+    assert body.get("ok") is True, body
+    assert body.get("aborted") in (False, None), body
+    assert body.get("stepsRun") == len(steps), body
+    # It actually drove the game for roughly the recorded duration.
+    assert body.get("elapsedMs", 0) >= 10_000, body


### PR DESCRIPTION
Expands the HTTP test bench (#17) with **`scenario`-tool** coverage via two portable, save-agnostic recipes.

## Recipes
1. **`recipes/dragonsreach_navigate.json`** (~31s) — derived from a real recording (`recording_1780255555.json`); `coc`s into Whiterun Dragonsreach, then replays the recorded `setpos`/`setangle` navigation. `test_scenario.py` asserts the run (`ok`, all steps, not aborted).
2. **`recipes/follow_nelkir.json`** (~18s) — **follow a moving NPC**: identify Nelkir (a Dragonsreach wanderer) via `inspect refs`, then `scenario`-repeat `player.moveto 0x1A67B`. `moveto` is ref-relative, so a *static* step list tracks the NPC wherever he walks. `test_follow_npc.py` runs it, asserts the player ended on the NPC (followed), and confirms the NPC was actually moving (skips if idle — never flakes).

## Why this shape (per the dir review)
Your `recordings/*.json` are excellent *personal* benchmark recipes but are save-specific via `meta` (cell/coords). Prefixing `coc <cell>` makes them portable. And `player.moveto <ref>` is the trick that lets a static recipe follow a *moving* target.

## Validation (live, SE 1.6.x)
- Navigation: 143 steps, `ok`, 31.0s, no crash.
- Follow: 16 steps, player tracked Nelkir to ~25-40u while he walked 46-93u between iterations; no crash.
- Tests marked `slow` + `requires_player`; skip-safe. Run fast set: `pytest tests/http -m "not slow"`.

Note: best landed after #18 (the papyrus CTD fix) — `main`'s `test_papyrus.py` bogus-function test still hits the unresolved-global CTD until #18 lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)