### PR TITLE
test(http): self-contained suite bootstrap

### DIFF
--- a/tests/http/README.md
+++ b/tests/http/README.md
@@ -48,12 +48,29 @@ returns JSON carrying a `plugin` field (liveness check).
 ## Skip rules (why the suite stays green)
 
 - **No server reachable** → entire session skipped.
-- **No in-world save loaded** → tests marked `@pytest.mark.requires_player` are
-  skipped (checked via `inspect{kind:state}.playerLoaded`). The suite never
-  loads a save itself — the human/another agent controls game state.
+- **No in-world save loaded** → the suite **bootstraps one itself** (see below),
+  so `@pytest.mark.requires_player` tests run; they skip only if the bootstrap is
+  disabled (`DEVBENCH_BOOTSTRAP=off`) or fails.
 - **Capability absent on this branch** → a test skips when its tool is missing
   from `GET /api/tools`, or when a needed action/kind is absent from the live
   `inputSchema` enum (e.g. `menu` `open`).
+
+## Self-contained bootstrap
+
+If a server is reachable but at the **main menu**, the suite drives the game into
+a playable state itself (an already-loaded game is used as-is and never
+disturbed). Controlled by `DEVBENCH_BOOTSTRAP`:
+
+| Value           | Behavior                                                                               |
+| --------------- | -------------------------------------------------------------------------------------- |
+| `coc` (default) | Run the `recipes/bootstrap.json` recipe (`coc` into a cell + wait) — save-independent. |
+| `save`          | Load `DEVBENCH_SAVE`, or the most recent save if unset.                                |
+| `off`           | Don't drive the game; `requires_player` tests skip (the old "human controls state").   |
+
+`DEVBENCH_COC_CELL` overrides the `coc` target (default `WhiterunDragonsreach`).
+The `coc` path reuses the same recipe loader + `scenario` runner the recipe tests
+use (`load_recipe`/`run_recipe` in `conftest.py`) — there's one place that knows
+how to play a recipe.
 
 ## Layout
 

--- a/tests/http/conftest.py
+++ b/tests/http/conftest.py
@@ -5,6 +5,11 @@ SKIPPED (never failed). It also skips individual tests whose tool — or a neede
 action/kind — is absent from the *live* schema, so the suite stays green across
 branches that add or drop capabilities.
 
+Self-contained: if a server is reachable but sitting at the main menu, the suite
+drives the game into a playable state itself (see DEVBENCH_BOOTSTRAP below) so
+requires_player tests run instead of skipping. An already-loaded game is used
+as-is. Set DEVBENCH_BOOTSTRAP=off to keep the old "human controls state" behavior.
+
 Discovery order for the base URL (first hit wins):
   1. env var DEVBENCH_URL  (e.g. http://127.0.0.1:8921)
   2. runtime.json under known Skyrim SE / VR Data paths ({"port": <int>})
@@ -18,6 +23,7 @@ from __future__ import annotations
 
 import json
 import os
+import time
 from pathlib import Path
 from typing import Any, Iterable
 
@@ -178,14 +184,133 @@ def tool_schema(client: Client) -> dict[str, dict[str, Any]]:
     return {d["name"]: d for d in client.tools()}
 
 
-@pytest.fixture(scope="session")
-def player_loaded(client: Client) -> bool:
-    """Whether an in-world save is loaded (inspect{kind:state}.playerLoaded)."""
+# --------------------------------------------------------------------------- #
+# Recipes — the portable scenario JSONs under recipes/ are the bench's reusable
+# game-driving artifacts. One loader + one runner, shared by the recipe tests AND
+# the env bootstrap below, so "how to play a recipe" lives in exactly one place.
+# --------------------------------------------------------------------------- #
+RECIPES_DIR = Path(__file__).parent / "recipes"
+
+
+def load_recipe(name: str) -> dict[str, Any]:
+    """Load recipes/<name>.json."""
+    return json.loads((RECIPES_DIR / f"{name}.json").read_text(encoding="utf-8"))
+
+
+def run_recipe(client: "Client", recipe: "str | dict[str, Any]", *,
+               timeout: float = 120.0, continue_on_error: bool = True) -> tuple[int, Any]:
+    """Play a recipe's steps through the `scenario` tool. `recipe` is a name or a
+    loaded dict. Returns (status, body) — the single place that knows how to run one."""
+    if isinstance(recipe, str):
+        recipe = load_recipe(recipe)
+    return client.call(
+        "scenario",
+        {"steps": recipe["steps"], "continueOnError": continue_on_error},
+        timeout=timeout,
+    )
+
+
+# --------------------------------------------------------------------------- #
+# Environment bootstrap — drive the game into a playable state itself, so
+# requires_player tests run whether the game starts at the main menu or in-world.
+#
+#   DEVBENCH_BOOTSTRAP = coc (default) | save | off
+#     coc  — `coc <cell>` from the main menu (save-independent; starts a fresh
+#            session). Cell from DEVBENCH_COC_CELL (default "WhiterunDragonsreach").
+#     save — load DEVBENCH_SAVE, or the most recent save if unset.
+#     off  — never drive the game; tests skip if no save is loaded (old behavior).
+#
+# Bootstrapping only happens FROM THE MAIN MENU — an already-loaded game is used
+# as-is and never disturbed. In CI (no server) the suite is skipped before this
+# ever runs.
+# --------------------------------------------------------------------------- #
+BOOTSTRAP_TIMEOUT = 90.0
+DEFAULT_COC_CELL = "WhiterunDragonsreach"  # vanilla, light, present in any load order
+
+
+def _state_player_loaded(client: Client) -> bool:
     try:
         body = client.ok("inspect", {"kind": "state"})
     except (AssertionError, requests.RequestException):
         return False
     return bool(isinstance(body, dict) and body.get("playerLoaded"))
+
+
+def _most_recent_save(client: Client) -> str | None:
+    """Best-effort newest save name from `game list` (first entry), or None."""
+    try:
+        _, body = client.call("game", {"action": "list"})
+        saves = body.get("saves") if isinstance(body, dict) else None
+        return saves[0] if isinstance(saves, list) and saves else None
+    except requests.RequestException:
+        return None
+
+
+def _clear_gating_modal(client: Client) -> None:
+    """A load can be gated by a content-mismatch Yes/No box — accept it so the
+    load proceeds. Best-effort: only acts when a MessageBoxMenu is actually open."""
+    try:
+        _, body = client.call("menu", {"action": "list"})
+        if isinstance(body, dict) and body.get("messageBoxOpen"):
+            client.call("menu", {"action": "accept", "index": 0})
+    except requests.RequestException:
+        pass
+
+
+def _wait_player(client: Client, retrigger=None, timeout: float = BOOTSTRAP_TIMEOUT) -> bool:
+    """Poll until a player is loaded; clear gating modals; retrigger once midway
+    (a load/coc issued at the main menu sometimes doesn't take on the first try)."""
+    deadline = time.time() + timeout
+    retried = False
+    while time.time() < deadline:
+        _clear_gating_modal(client)
+        if _state_player_loaded(client):
+            return True
+        if retrigger and not retried and (deadline - time.time()) < timeout - 25:
+            retrigger()
+            retried = True
+        time.sleep(3)
+    return False
+
+
+def _bootstrap(client: Client) -> bool:
+    mode = os.environ.get("DEVBENCH_BOOTSTRAP", "coc").lower()
+    if mode == "off":
+        return False
+    if mode == "save":
+        name = os.environ.get("DEVBENCH_SAVE") or _most_recent_save(client)
+        if not name:
+            return False
+        load = lambda: client.call("game", {"action": "load", "name": name})  # noqa: E731
+        load()
+        return _wait_player(client, retrigger=load)
+    # default "coc": reuse the portable `bootstrap` recipe (coc + waitUntil playerLoaded)
+    # through the scenario engine — the same machinery the recipe tests use.
+    cell = os.environ.get("DEVBENCH_COC_CELL", DEFAULT_COC_CELL)
+    try:
+        recipe = load_recipe("bootstrap")
+        for step in recipe.get("steps", []):
+            cmd = step.get("args", {}).get("command", "")
+            if step.get("tool") == "console" and cmd.startswith("coc "):
+                step["args"]["command"] = f"coc {cell}"
+        status, _ = run_recipe(client, recipe, timeout=BOOTSTRAP_TIMEOUT)
+        if status == 200 and _state_player_loaded(client):
+            return True
+    except (OSError, KeyError, requests.RequestException):
+        pass  # no scenario tool / recipe missing → fall back to driving it directly
+    coc = lambda: client.call("console", {"command": f"coc {cell}"})  # noqa: E731
+    coc()
+    return _wait_player(client, retrigger=coc)
+
+
+@pytest.fixture(scope="session")
+def player_loaded(client: Client) -> bool:
+    """True once an in-world save is loaded. If the game is at the main menu, drive
+    it into a playable state per DEVBENCH_BOOTSTRAP (default: coc) so the suite is
+    self-contained; an already-loaded game is used as-is."""
+    if _state_player_loaded(client):
+        return True
+    return _bootstrap(client)
 
 
 # --------------------------------------------------------------------------- #
@@ -223,15 +348,18 @@ def require_enum(descriptor: dict[str, Any], prop: str, value: str) -> None:
 def pytest_configure(config: pytest.Config) -> None:
     config.addinivalue_line(
         "markers",
-        "requires_player: test needs an in-world save loaded; skipped if playerLoaded is false",
+        "requires_player: test needs an in-world save; the suite bootstraps one "
+        "(DEVBENCH_BOOTSTRAP) and only skips if that's disabled or fails",
     )
 
 
 @pytest.fixture
 def requires_player(player_loaded: bool) -> None:
-    """Skip the test unless an in-world save is currently loaded."""
+    """Skip only if no player is loaded and the bootstrap couldn't establish one
+    (DEVBENCH_BOOTSTRAP=off, or it timed out)."""
     if not player_loaded:
-        pytest.skip("no in-world save loaded (inspect{kind:state}.playerLoaded == false)")
+        pytest.skip("no player loaded and bootstrap did not establish one "
+                    "(DEVBENCH_BOOTSTRAP=off or it failed)")
 
 
 @pytest.fixture(autouse=True)

--- a/tests/http/recipes/bootstrap.json
+++ b/tests/http/recipes/bootstrap.json
@@ -1,0 +1,9 @@
+{
+  "meta": {
+    "description": "Bench bootstrap: coc into a known cell from the main menu, then wait until the player is loaded. The cell is overridden by DEVBENCH_COC_CELL; run via the scenario tool by conftest when the game starts at the main menu."
+  },
+  "steps": [
+    { "tool": "console", "args": { "command": "coc WhiterunDragonsreach" } },
+    { "waitUntil": "playerLoaded", "timeoutMs": 60000 }
+  ]
+}

--- a/tests/http/test_follow_npc.py
+++ b/tests/http/test_follow_npc.py
@@ -16,16 +16,13 @@ Marked `slow` (~18s) + `requires_player`.
 
 from __future__ import annotations
 
-import json
 import math
 import time
-from pathlib import Path
 
 import pytest
 
-from conftest import require_tool
+from conftest import load_recipe, require_tool, run_recipe
 
-RECIPE = Path(__file__).parent / "recipes" / "follow_nelkir.json"
 NPC = "0x1A67B"  # Nelkir, a Dragonsreach wanderer (Skyrim.esm ref, stable across saves)
 PLAYER = "0x14"
 
@@ -48,10 +45,11 @@ def test_follow_moving_npc(client, tool_schema):
     require_tool(tool_schema, "console")
     require_tool(tool_schema, "inspect")
 
-    recipe = json.loads(RECIPE.read_text(encoding="utf-8"))
+    recipe = load_recipe("follow_nelkir")
 
     # Run the follow recipe (coc in + repeated moveto). It blocks ~18s.
-    body = client.ok("scenario", {"steps": recipe["steps"], "continueOnError": True}, timeout=90.0)
+    status, body = run_recipe(client, recipe, timeout=90.0)
+    assert status == 200, body
     assert body.get("ok") is True, body
     assert body.get("stepsRun") == len(recipe["steps"]), body
 

--- a/tests/http/test_scenario.py
+++ b/tests/http/test_scenario.py
@@ -11,14 +11,9 @@ marked `slow` — deselect with `-m "not slow"`.
 
 from __future__ import annotations
 
-import json
-from pathlib import Path
-
 import pytest
 
-from conftest import require_tool
-
-RECIPE = Path(__file__).parent / "recipes" / "dragonsreach_navigate.json"
+from conftest import load_recipe, require_tool, run_recipe
 
 
 @pytest.mark.slow
@@ -27,17 +22,14 @@ def test_navigate_dragonsreach_recipe(client, tool_schema):
     require_tool(tool_schema, "scenario")
     require_tool(tool_schema, "console")  # the recipe dispatches console steps
 
-    recipe = json.loads(RECIPE.read_text(encoding="utf-8"))
+    recipe = load_recipe("dragonsreach_navigate")
     steps = recipe["steps"]
     assert len(steps) > 50, "recipe should be the full navigation, not a stub"
 
     # The scenario blocks server-side for the recipe's duration (~31s) — give the
     # HTTP call room beyond that.
-    body = client.ok(
-        "scenario",
-        {"steps": steps, "continueOnError": True},
-        timeout=120.0,
-    )
+    status, body = run_recipe(client, recipe, timeout=120.0)
+    assert status == 200, body
     assert body.get("ok") is True, body
     assert body.get("aborted") in (False, None), body
     assert body.get("stepsRun") == len(steps), body


### PR DESCRIPTION
## Self-contained suite

The HTTP suite no longer skips `requires_player` tests when the game sits at the main menu — it **drives the game into a playable state itself**, then runs them. An already-loaded game is used as-is (never disturbed), and CI with no server still skips the whole suite first, so this is purely additive.

Controlled by `DEVBENCH_BOOTSTRAP`:

| Value | Behavior |
|---|---|
| `coc` (default) | Run `recipes/bootstrap.json` (`coc` into a cell + wait) — **save-independent** |
| `save` | Load `DEVBENCH_SAVE`, or the most recent save if unset |
| `off` | Don't drive the game (the old "human controls state" behavior) |

`DEVBENCH_COC_CELL` overrides the cell (default `WhiterunDragonsreach`). Confirmed live that both `coc` and `game load` work from a cold main menu via devbench.

## DRY: one recipe runner

`conftest.py` now has a single `load_recipe` / `run_recipe` pair — the one place that knows how to play a recipe through the `scenario` tool. Used by:
- the **bootstrap** `coc` path (reuses the scenario engine + the new `recipes/bootstrap.json`), and
- **`test_scenario.py`** and **`test_follow_npc.py`**, which dropped their duplicated load-file + post-scenario + assert boilerplate.

So recipes are reused, not re-implemented per test.

## Verified

From a **cold main menu** (`DEVBENCH_URL` → the menu instance):
- bootstrap coc'd in; all 9 `test_papyrus.py` tests (incl. `requires_player`) **ran and passed**,
- non-slow suite: **22 passed**,
- both refactored recipe tests (`test_scenario`, `test_follow_npc`): **2 passed**.

No C++ changes; test-infra only (no release impact).

🤖 Generated with [Claude Code](https://claude.com/claude-code)