### PR TITLE
feat(mcp): discoverable extensions + listChanged

### DIFF
--- a/README.md
+++ b/README.md
@@ -289,10 +289,14 @@ if (dvb->GetBuildNumber() >= 10500)                                 // RegisterT
 ```
 
 Driven as `inspect kind="yourmod.loadtimes"` (same handler contract — it receives the full base-tool
-args), discovered via `inspect kind=extensions`. For menus, `RegisterToolExtension("menu", name, …)`
-(or the older `RegisterMenuHandler`, 1.4.0+) registers a `menu invoke name=<name>` handler, listed
-under `menu list`'s `registered`. Opening/closing/listing menus already works generically — only
-custom interaction/data needs a handler.
+args). **Discoverable on the first call:** registering a kind rebuilds the `inspect` tool so your key
+appears in its `kind` enum + description in `tools/list` (a `notifications/tools/list_changed` is
+emitted, so a client that connected before your mod loaded refreshes) — no `kind=extensions` round-trip
+needed. Pass a `"description"` in the descriptor; it's shown inline. For menus,
+`RegisterToolExtension("menu", name, …)` (or the older `RegisterMenuHandler`, 1.4.0+) registers a
+`menu invoke name=<name>` handler — also surfaced in the `menu` tool's description and `menu list`'s
+`registered`; `menu open` on a registered name returns a 400 pointing you at `invoke`. Opening/closing/
+listing engine menus already works generically — only custom interaction/data needs a handler.
 
 ### Design your tools the agentic-renderdoc way
 

--- a/src/McpAdapter.cpp
+++ b/src/McpAdapter.cpp
@@ -40,6 +40,12 @@ namespace dvb
 				// only surfaces what(), so fold the status code into the message.
 				throw std::runtime_error("[" + std::to_string(r.errorCode) + "] " + r.errorMessage);
 			});
+
+			// A tool was added or replaced (e.g. a mod registered an inspect kind / menu, which also
+			// re-registers the enriched base-tool descriptor). Tell connected clients to re-list.
+			if (m_announceChanges)
+				m_server.broadcast_notification(mcp::request::create_notification(
+					"notifications/tools/list_changed", json::object()));
 		};
 
 		for (const auto& desc : m_registry.List())
@@ -49,6 +55,7 @@ namespace dvb
 		// call register_tool from the main/message thread post-start; safe in practice
 		// because consumers register at kPostLoad, before any MCP client connects.
 		m_registry.SetRegistrationListener(registerOne);
+		m_announceChanges = true;  // past initial wiring — future (re)registrations notify clients
 
 		// Forward bus events to connected MCP clients as notifications.
 		m_sub = m_events.Subscribe([this](const EventBus::Event& a_ev) {

--- a/src/McpAdapter.h
+++ b/src/McpAdapter.h
@@ -33,5 +33,8 @@ namespace dvb
 		EventBus&     m_events;
 		mcp::server&  m_server;
 		uint64_t      m_sub = 0;
+		// Initial wiring registers every existing tool; only AFTER that do (re)registrations mean a
+		// real change worth a notifications/tools/list_changed broadcast. Set true at the end of Wire().
+		bool m_announceChanges = false;
 	};
 }

--- a/src/Server.cpp
+++ b/src/Server.cpp
@@ -86,7 +86,10 @@ namespace dvb
 
 		m_mcp = std::make_unique<mcp::server>(cfg);
 		m_mcp->set_server_info(cfg.name, cfg.version);
-		m_mcp->set_capabilities(json{ { "tools", json::object() }, { "logging", json::object() } });
+		// tools.listChanged: tools are added at runtime (cross-plugin consumers register kinds/menus),
+		// so advertise the capability and emit notifications/tools/list_changed when the set changes —
+		// a client that connected before a mod (or the game) finished loading then refreshes its list.
+		m_mcp->set_capabilities(json{ { "tools", json{ { "listChanged", true } } }, { "logging", json::object() } });
 
 		// MCP tools + notifications.
 		m_mcpAdapter = std::make_unique<McpAdapter>(m_registry, m_events, *m_mcp);

--- a/src/ToolExtensions.cpp
+++ b/src/ToolExtensions.cpp
@@ -24,17 +24,32 @@ namespace dvb::ToolExtensions
 
 		std::mutex                              g_mutex;
 		std::unordered_map<std::string, Bucket> g_tools;  // lowercased baseTool → Bucket
+		ChangeListener                          g_onChange;
+	}
+
+	void SetChangeListener(ChangeListener a_listener)
+	{
+		std::lock_guard<std::mutex> lock(g_mutex);
+		g_onChange = std::move(a_listener);
 	}
 
 	bool Register(std::string a_baseTool, std::string a_key, json a_descriptor, ToolHandler a_handler)
 	{
-		const std::string           tool = Lower(a_baseTool);
-		const std::string           key = Lower(a_key);
-		std::lock_guard<std::mutex> lock(g_mutex);
-		Bucket&                     b = g_tools[tool];
-		const bool                  replaced = b.byKey.find(key) != b.byKey.end();
-		b.byKey[key] = Entry{ std::move(a_descriptor), std::move(a_handler) };
-		b.displayKey[key] = std::move(a_key);
+		const std::string original = a_baseTool;
+		const std::string tool = Lower(a_baseTool);
+		const std::string key = Lower(a_key);
+		ChangeListener    onChange;
+		bool              replaced;
+		{
+			std::lock_guard<std::mutex> lock(g_mutex);
+			Bucket&                     b = g_tools[tool];
+			replaced = b.byKey.find(key) != b.byKey.end();
+			b.byKey[key] = Entry{ std::move(a_descriptor), std::move(a_handler) };
+			b.displayKey[key] = std::move(a_key);
+			onChange = g_onChange;
+		}
+		if (onChange)
+			onChange(original);  // outside the lock — listener re-enters the registry
 		return !replaced;
 	}
 

--- a/src/ToolExtensions.h
+++ b/src/ToolExtensions.h
@@ -25,6 +25,13 @@ namespace dvb::ToolExtensions
 	/// Returns false if it replaced an existing entry. Thread-safe.
 	bool Register(std::string a_baseTool, std::string a_key, json a_descriptor, ToolHandler a_handler);
 
+	/// Notified (with the original-cased base-tool name) after each successful Register, so the host
+	/// can rebuild that base tool's descriptor — the registered keys then surface in `tools/list`
+	/// (enum + description) instead of only via a runtime discovery call. Called outside the internal
+	/// lock. Set once at startup; thread-safe.
+	using ChangeListener = std::function<void(const std::string& a_baseTool)>;
+	void SetChangeListener(ChangeListener a_listener);
+
 	/// The entry registered under (`baseTool`, `key`), or nullopt. Thread-safe.
 	std::optional<Entry> Find(std::string_view a_baseTool, std::string_view a_key);
 

--- a/src/Tools.cpp
+++ b/src/Tools.cpp
@@ -272,6 +272,10 @@ namespace dvb
 				const std::string name = a_args.value("name", std::string{});
 				if (name.empty())
 					throw ToolError(400, "action 'open' requires a 'name' (menu to show)");
+				// 'open' is engine menus only. A registered (mod) menu isn't an engine menu — point at
+				// 'invoke' so the first wrong guess names the right call instead of silently no-op'ing.
+				if (ToolExtensions::Find("menu", name))
+					throw ToolError(400, std::format("'{}' is a registered (mod) menu — use action='invoke', name='{}' (not 'open')", name, name));
 				auto* task = SKSE::GetTaskInterface();
 				if (!task)
 					throw ToolError(500, "SKSE TaskInterface unavailable");
@@ -1281,6 +1285,107 @@ namespace dvb
 		}
 	}
 
+	namespace
+	{
+		// A human summary of the registered (mod) extension keys for a base tool, appended to that
+		// tool's description so a registered kind/menu is discoverable on the FIRST call (it shows in
+		// tools/list) instead of via a separate discovery round-trip. Empty when nothing is registered.
+		std::string RegisteredExtensionSummary(std::string_view a_baseTool, std::string_view a_noun)
+		{
+			const auto keys = ToolExtensions::Keys(a_baseTool);
+			if (keys.empty())
+				return {};
+			std::string s = std::format(" Registered (mod) {}: ", a_noun);
+			for (std::size_t i = 0; i < keys.size(); ++i) {
+				std::string desc;
+				if (auto e = ToolExtensions::Find(a_baseTool, keys[i]))
+					desc = e->descriptor.value("description", std::string{});
+				s += keys[i];
+				if (!desc.empty())
+					s += " — " + desc;
+				s += (i + 1 < keys.size()) ? "; " : ".";
+			}
+			return s;
+		}
+
+		// inspect/menu descriptors are REBUILT (not frozen at startup) so registered keys appear in
+		// tools/list. RegisterCoreTools registers these initially; the ToolExtensions change-listener
+		// re-registers them when a mod adds a kind/menu (which also fires tools/list_changed).
+		ToolDescriptor BuildInspectDescriptor()
+		{
+			ToolDescriptor inspect;
+			inspect.name = "inspect";
+			inspect.description =
+				"Read live game/plugin state. Runs on the main thread and returns the value "
+				"synchronously (times out if the game is mid-load / not pumping tasks). kinds: "
+				"'state' → { plugin, version, vr, playerLoaded, frame }; 'vm' → Papyrus VM health "
+				"{ loadedTypes, attachedScripts, arrays, runningStacks, frozenStacks, overstressed }; "
+				"'scene' → player context { cell, worldspace, location, position, gameHour, daysPassed, "
+				"weather }; 'mods' → active load order { count, lightCount, total, plugins:[{index, name}], "
+				"lightPlugins:[…] }; 'player' → player snapshot { name, level, sex, gold, race, "
+				"actorValues:{health,magicka,stamina,carryWeight each {current,max}}, equipped:{right,left,ammo} }; "
+				"'inventory' → items held by the player (or a container 'formId') { owner, count, items:[{formId, "
+				"name, formType, count, value, weight, equipped}] } (filters: 'formType', 'limit'); "
+				"'quests' → journal (running/completed) { count, quests:[{formId, name, stage, type, active, "
+				"completed, objectives:[{index, text, state}]}] } ('limit'); "
+				"'effects' → active magic effects on the player (or an actor 'formId') { target, count, "
+				"activeEffects:[{spell, effect, magnitude, duration, elapsed}] }; "
+				"'refs' → identify reference(s) sharing one shape { formId, formType, name, "
+				"editorId, base, position } — pass 'formId' for one form, 'selected'=true for the "
+				"console/crosshair ref (set via prid), or neither to enumerate loaded refs in the grid "
+				"(optional 'formType' filter, 'radius' from player, 'limit' default 100). A consumer mod "
+				"can add a custom kind via the C-ABI RegisterToolExtension (e.g. load-timing data); "
+				"'extensions' lists those registered kinds + descriptors, and kind=<registered> dispatches.";
+			inspect.description += RegisteredExtensionSummary("inspect", "kinds");
+			inspect.readOnly = true;
+			json kinds = json::array({ "state", "vm", "scene", "mods", "player", "inventory", "quests", "effects", "refs", "extensions" });
+			for (const auto& k : ToolExtensions::Keys("inspect"))
+				kinds.push_back(k);
+			inspect.inputSchema = json{
+				{ "type", "object" },
+				{ "properties", json{
+									{ "kind", json{ { "type", "string" }, { "enum", kinds }, { "description", "state | vm | scene | mods | player | inventory | quests | effects | refs | extensions (or a registered mod kind — listed here + via kind=extensions)" } } },
+									{ "formId", json{ { "type", "string" }, { "description", "refs: identify this form; inventory: the container ref to read (default player); effects: the actor to read (default player) (hex formId, e.g. 0x14, or EditorID)" } } },
+									{ "selected", json{ { "type", "boolean" }, { "description", "refs: identify the console-selected / crosshair ref instead" } } },
+									{ "formType", json{ { "type", "string" }, { "description", "refs/inventory: keep only entries whose type matches (e.g. Actor, Weapon, Potion)" } } },
+									{ "radius", json{ { "type", "number" }, { "description", "refs enumerate: only refs within this distance of the player (0 = whole loaded grid)" } } },
+									{ "limit", json{ { "type", "integer" }, { "description", "refs/inventory: max entries to return (default 100)" } } },
+								} },
+			};
+			return inspect;
+		}
+
+		ToolDescriptor BuildMenuDescriptor()
+		{
+			ToolDescriptor menu;
+			menu.name = "menu";
+			menu.description =
+				"Inspect, open, answer, or dismiss menus. action='list' returns { openMenus, "
+				"messageBoxOpen, registered } tracked live from menu open/close events. 'describe' returns the "
+				"active MessageBoxMenu as { messageBoxOpen, bodyText, buttons:[…], cancelIndex } (read "
+				"the buttons, then pick one), or with a 'name' the registered menu's descriptor. 'accept' "
+				"answers a MessageBoxMenu by button 'index' "
+				"(default 0) — runs its callback and dismisses it (this is how you clear a Yes/No modal, "
+				"e.g. the content-mismatch dialog gating a load; kHide does NOT). 'open' shows an ENGINE menu by "
+				"'name' via the UI queue (kShow) — opens hub menus from a plain name (TweenMenu, "
+				"'Journal Menu', MagicMenu, MapMenu, StatsMenu, InventoryMenu, FavoritesMenu); context "
+				"menus that need a target ref (ContainerMenu/BarterMenu/BookMenu) won't open this way. "
+				"'close' hides a menu by 'name' via the UI queue (kHide). 'invoke' dispatches to a "
+				"consumer-registered (mod) menu by 'name' — NOT 'open' (mod menus aren't engine menus). A mod "
+				"exposes its menu via the C-ABI RegisterMenuHandler; 'list' returns those under 'registered'.";
+			menu.description += RegisteredExtensionSummary("menu", "menus (invoke with action='invoke', name=<x>)");
+			menu.inputSchema = json{
+				{ "type", "object" },
+				{ "properties", json{
+									{ "action", json{ { "type", "string" }, { "enum", json::array({ "list", "describe", "accept", "open", "close", "invoke" }) }, { "description", "list | describe | accept | open | close | invoke" } } },
+									{ "name", json{ { "type", "string" }, { "description", "open/close: ENGINE menu to show/hide (e.g. TweenMenu). invoke/describe: a registered mod menu (see list .registered, or this tool's description)." } } },
+									{ "index", json{ { "type", "integer" }, { "description", "accept: 0-based button index to select (default 0). See describe's buttons/cancelIndex." } } },
+								} },
+			};
+			return menu;
+		}
+	}
+
 	void RegisterCoreTools(ToolRegistry& a_registry, EventBus& a_events)
 	{
 		ToolDescriptor console;
@@ -1337,68 +1442,22 @@ namespace dvb
 		};
 		a_registry.Register(std::move(camera), &CameraHandler);
 
-		ToolDescriptor inspect;
-		inspect.name = "inspect";
-		inspect.description =
-			"Read live game/plugin state. Runs on the main thread and returns the value "
-			"synchronously (times out if the game is mid-load / not pumping tasks). kinds: "
-			"'state' → { plugin, version, vr, playerLoaded, frame }; 'vm' → Papyrus VM health "
-			"{ loadedTypes, attachedScripts, arrays, runningStacks, frozenStacks, overstressed }; "
-			"'scene' → player context { cell, worldspace, location, position, gameHour, daysPassed, "
-			"weather }; 'mods' → active load order { count, lightCount, total, plugins:[{index, name}], "
-			"lightPlugins:[…] }; 'player' → player snapshot { name, level, sex, gold, race, "
-			"actorValues:{health,magicka,stamina,carryWeight each {current,max}}, equipped:{right,left,ammo} }; "
-			"'inventory' → items held by the player (or a container 'formId') { owner, count, items:[{formId, "
-			"name, formType, count, value, weight, equipped}] } (filters: 'formType', 'limit'); "
-			"'quests' → journal (running/completed) { count, quests:[{formId, name, stage, type, active, "
-			"completed, objectives:[{index, text, state}]}] } ('limit'); "
-			"'effects' → active magic effects on the player (or an actor 'formId') { target, count, "
-			"activeEffects:[{spell, effect, magnitude, duration, elapsed}] }; "
-			"'refs' → identify reference(s) sharing one shape { formId, formType, name, "
-			"editorId, base, position } — pass 'formId' for one form, 'selected'=true for the "
-			"console/crosshair ref (set via prid), or neither to enumerate loaded refs in the grid "
-			"(optional 'formType' filter, 'radius' from player, 'limit' default 100). A consumer mod "
-			"can add a custom kind via the C-ABI RegisterToolExtension (e.g. load-timing data); "
-			"'extensions' lists those registered kinds + descriptors, and kind=<registered> dispatches.";
-		inspect.readOnly = true;
-		inspect.inputSchema = json{
-			{ "type", "object" },
-			{ "properties", json{
-								{ "kind", json{ { "type", "string" }, { "enum", json::array({ "state", "vm", "scene", "mods", "player", "inventory", "quests", "effects", "refs", "extensions" }) }, { "description", "state | vm | scene | mods | player | inventory | quests | effects | refs | extensions (also a consumer-registered kind — see kind=extensions)" } } },
-								{ "formId", json{ { "type", "string" }, { "description", "refs: identify this form; inventory: the container ref to read (default player); effects: the actor to read (default player) (hex formId, e.g. 0x14, or EditorID)" } } },
-								{ "selected", json{ { "type", "boolean" }, { "description", "refs: identify the console-selected / crosshair ref instead" } } },
-								{ "formType", json{ { "type", "string" }, { "description", "refs/inventory: keep only entries whose type matches (e.g. Actor, Weapon, Potion)" } } },
-								{ "radius", json{ { "type", "number" }, { "description", "refs enumerate: only refs within this distance of the player (0 = whole loaded grid)" } } },
-								{ "limit", json{ { "type", "integer" }, { "description", "refs/inventory: max entries to return (default 100)" } } },
-							} },
-		};
-		a_registry.Register(std::move(inspect), &InspectHandler);
+		// inspect/menu are rebuilt (not frozen) so registered mod kinds/menus show in tools/list.
+		a_registry.Register(BuildInspectDescriptor(), &InspectHandler);
+		a_registry.Register(BuildMenuDescriptor(), &MenuHandler);
 
-		ToolDescriptor menu;
-		menu.name = "menu";
-		menu.description =
-			"Inspect, open, answer, or dismiss menus. action='list' returns { openMenus, "
-			"messageBoxOpen } tracked live from menu open/close events. 'describe' returns the "
-			"active MessageBoxMenu as { messageBoxOpen, bodyText, buttons:[…], cancelIndex } (read "
-			"the buttons, then pick one). 'accept' answers a MessageBoxMenu by button 'index' "
-			"(default 0) — runs its callback and dismisses it (this is how you clear a Yes/No modal, "
-			"e.g. the content-mismatch dialog gating a load; kHide does NOT). 'open' shows a menu by "
-			"'name' via the UI queue (kShow) — opens hub menus from a plain name (TweenMenu, "
-			"'Journal Menu', MagicMenu, MapMenu, StatsMenu, InventoryMenu, FavoritesMenu); context "
-			"menus that need a target ref (ContainerMenu/BarterMenu/BookMenu) won't open this way. "
-			"'close' hides a menu by 'name' via the UI queue (kHide). 'invoke' dispatches to a "
-			"consumer-registered menu handler by 'name' (a mod exposes its menu's interaction via the "
-			"C-ABI RegisterMenuHandler instead of adding its own tool); 'list' returns those under "
-			"'registered', and 'describe' with a 'name' returns that handler's descriptor.";
-		menu.inputSchema = json{
-			{ "type", "object" },
-			{ "properties", json{
-								{ "action", json{ { "type", "string" }, { "enum", json::array({ "list", "describe", "accept", "open", "close", "invoke" }) }, { "description", "list | describe | accept | open | close | invoke" } } },
-								{ "name", json{ { "type", "string" }, { "description", "open/close: menu to show/hide (e.g. TweenMenu). invoke: a registered menu (see list .registered). describe: a registered menu to return its descriptor." } } },
-								{ "index", json{ { "type", "integer" }, { "description", "accept: 0-based button index to select (default 0). See describe's buttons/cancelIndex." } } },
-							} },
-		};
-		a_registry.Register(std::move(menu), &MenuHandler);
+		// When a mod registers a kind/menu, rebuild that base tool's descriptor so the new key is
+		// discoverable on the first call (the registry's registration path re-registers it with the
+		// adapters and fires tools/list_changed). Captures the registry by pointer — it outlives this
+		// function (owned by the Server).
+		ToolExtensions::SetChangeListener([reg = &a_registry](const std::string& a_baseTool) {
+			std::string base = a_baseTool;
+			std::transform(base.begin(), base.end(), base.begin(), [](unsigned char c) { return static_cast<char>(std::tolower(c)); });
+			if (base == "inspect")
+				reg->Register(BuildInspectDescriptor(), &InspectHandler);
+			else if (base == "menu")
+				reg->Register(BuildMenuDescriptor(), &MenuHandler);
+		});
 
 		ToolDescriptor papyrus;
 		papyrus.name = "papyrus";

--- a/tests/http/test_inspect.py
+++ b/tests/http/test_inspect.py
@@ -231,6 +231,19 @@ def test_extensions_list_and_dispatch(client, inspect):
     assert body.get("echo", {}).get("foo") == 7, body
 
 
+def test_kind_enum_includes_registered_extension(client, inspect):
+    # The host registers a `devbench.selftest` inspect extension via RegisterToolExtension. The
+    # inspect tool's `kind` enum is REBUILT to include registered keys, so they're discoverable in
+    # tools/list (first-call-correct) instead of only via a kind=extensions round-trip.
+    enum = inspect.get("inputSchema", {}).get("properties", {}).get("kind", {}).get("enum", [])
+    assert isinstance(enum, list) and enum, inspect
+    if "devbench.selftest" not in enum:
+        pytest.skip("devbench.selftest inspect extension not registered on this build")
+    assert "devbench.selftest" in enum, enum
+    # and the static built-in kinds are still present
+    assert {"state", "mods", "refs", "extensions"}.issubset(set(enum)), enum
+
+
 def test_unknown_kind_400(client, inspect):
     require_enum(inspect, "kind", "extensions")  # feature present → unknown kind is a clean 400
     status, body = client.call("inspect", {"kind": "NoSuchKindXYZ"})


### PR DESCRIPTION
Fixes the discoverability half of #37.

## Problem
Registered (mod) `inspect` kinds / `menu`s were invisible to `tools/list` — an agent had to guess the verb/param shape (the issue's "4 wasted MCP round-trips before real work").

## Change
- **Dynamic base-tool schemas:** `inspect`/`menu` descriptors are rebuilt when a mod registers a key (`ToolExtensions` change-listener → `BuildInspectDescriptor`/`BuildMenuDescriptor` → re-register via the existing registration path). The registered key now appears in the tool's `kind` enum + description **in `tools/list`** — first-call-correct, no `kind=extensions` round-trip.
- **`tools.listChanged`:** advertise the capability and emit `notifications/tools/list_changed` on registry change, so a client that connected before a mod (or the game) finished loading refreshes its list. (This is also the foundation the stable-endpoint PR builds on.)
- **`menu open <registered>` → 400** that names the working call (`use action='invoke'`) — kills the exact mis-guess in the issue.

## Scope / non-goals
- The stable-endpoint work (canonical 8920/8921 ports + handoff) is a **separate** PR (server/port layer). This PR is the tools/registry/adapter layer only — independent off `main`.
- `menu describe name=X` already returned the registered descriptor; the issue's `{}` was a consumer registering an empty descriptor (CS-side), so unchanged here.

## Tests / verification
- `test_kind_enum_includes_registered_extension`: the host's `devbench.selftest` inspect extension now appears in the `inspect` tool's `kind` enum (validates the rebuild end-to-end), built-ins still present.
- Builds clean (releasedbg). Live MCP behavior (the `list_changed` push to a connected client) wasn't exercised without a running game + connected client; the registry/adapter path it reuses is the same one consumer top-level tools already use at runtime.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Newly registered inspect kinds and menu handlers now automatically appear in tools/list with instant notifications after registration.

* **Bug Fixes**
  * Menu tool now properly rejects `action="open"` for registered menus, directing users to use `action="invoke"` instead.

* **Documentation**
  * Updated documentation clarifying RegisterToolExtension behavior for inspect and menu extensions.

* **Tests**
  * Added test coverage for dynamically registered extensions in inspect tool schema.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->