### PR TITLE
feat(server): per-runtime MCP port (SE 8920, VR 8921)

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ Missing → auto-created with defaults. Invalid → defaults (logged). All keys 
 ```jsonc
 {
   "enabled": true, // start the MCP/REST server at all (default true)
-  "port": 8920, // localhost port; auto-iterates if busy (default 8920)
+  "port": 8920, // localhost port for /mcp and /api. Default is per-runtime — SE/AE 8920, VR 8921 — so a fixed MCP client URL is stable; set explicitly to override. Iterates only if the chosen port is busy (rare; logged), bound port in runtime.json.
   "logLevel": "info", // trace|debug|info|warn|error (default "info")
 
   // In-game hotkeys (DXScanCode integers; 0 = disabled). Ignored while the console is open.
@@ -133,9 +133,27 @@ Missing → auto-created with defaults. Invalid → defaults (logged). All keys 
 ```
 
 `enabled: false` skips starting the server entirely. Bind address is fixed to `127.0.0.1`.
-`port` is the _starting_ port: if it's busy devbench auto-iterates to the next free port and
-writes the bound port to `Data/SKSE/Plugins/devbench/runtime.json` (`{ "port": N }`) so
-fixed-URL clients can discover it.
+The port is **deterministic per runtime** — **SE/AE `8920`, VR `8921`** — so a fixed MCP client URL
+never moves; set `port` explicitly to override. If the chosen port is already taken (e.g. a second
+instance of the same runtime), devbench iterates to the next free port (logged) and writes the bound
+port to `Data/SKSE/Plugins/devbench/runtime.json` (`{ "port": N }`) for discovery.
+
+## Connect an MCP client
+
+devbench serves **streamable-HTTP MCP at `POST http://127.0.0.1:<port>/mcp`** — most clients connect
+natively, no extra process:
+
+```sh
+# Claude Code — register both games; the one that's running has live tools, the other shows disconnected
+claude mcp add --transport http devbench-se http://127.0.0.1:8920/mcp   # SE/AE
+claude mcp add --transport http devbench-vr http://127.0.0.1:8921/mcp   # VR
+```
+
+For a **stdio-only** client, bridge with the off-the-shelf `mcp-remote` (no devbench-specific binary):
+`{ "command": "npx", "args": ["-y", "mcp-remote", "http://127.0.0.1:8920/mcp", "--allow-http"] }`. Plain
+HTTP scripts/CI use REST (`/api/tool/<name>`) and need no client config. devbench advertises
+`tools.listChanged` and emits `notifications/tools/list_changed`, so tools that register after connect
+(a mod loading, or the game finishing load) surface without reconnecting.
 
 ## Built-in tools
 

--- a/src/Config.cpp
+++ b/src/Config.cpp
@@ -47,7 +47,12 @@ namespace dvb
 
 	Config LoadConfig()
 	{
-		Config                      cfg;
+		Config cfg;
+		// Deterministic default port per runtime so a fixed MCP client URL never moves: SE/AE 8920,
+		// VR 8921. The two games run from separate Data dirs, so per-runtime ports never collide —
+		// register both client entries (devbench-se :8920, devbench-vr :8921); the game that's off
+		// just shows disconnected. An explicit "port" in config.json overrides this.
+		cfg.port = REL::Module::IsVR() ? 8921 : 8920;
 		const std::filesystem::path path = "Data/SKSE/Plugins/devbench/config.json";
 
 		std::ifstream file(path);

--- a/src/Config.h
+++ b/src/Config.h
@@ -10,7 +10,7 @@ namespace dvb
 	struct Config
 	{
 		bool        enabled = true;     ///< start the MCP/REST server at all
-		int         port = 8920;        ///< localhost port for /mcp and /api
+		int         port = 8920;        ///< localhost port for /mcp and /api (default SE/AE 8920, VR 8921 — LoadConfig)
 		std::string logLevel = "info";  ///< trace|debug|info|warn|error (spdlog level)
 
 		// In-game hotkeys (DXScanCode; 0 = disabled). Let recording/replay run with no


### PR DESCRIPTION
Fixes the stable-endpoint half of #37's "client on while game off / port moved" friction. Independent of #38 (server/config layer, not the tools layer).

## Problem
The port silently auto-incremented when the default was busy (SE grabs 8920 → VR slides to 8921, order-dependent), so a fixed MCP client URL moved unpredictably — the main reason a stable client config didn't "just work."

## Change
- **Deterministic default port by runtime: SE/AE `8920`, VR `8921`.** The two games run from separate Data dirs, so per-runtime ports never collide — a fixed client URL per game never moves. Register both client entries (`devbench-se → :8920`, `devbench-vr → :8921`); the game that's off just shows disconnected.
- An explicit `port` in `config.json` still overrides exactly.
- Port iteration remains **only as a logged fallback** for the rare same-runtime collision (two SE / two VR); `runtime.json` records the bound port for discovery.

## Why not a proxy/handoff
A single canonical port multiplexing both live games would need an always-on broker process (a shipped binary) and a `game` selector on every tool. Not worth it for the one-game-at-a-time MCP use case — two fixed entries is simpler and exe-free. (Discussed in #37.)

## Docs
README gains a "Connect an MCP client" section (native `claude mcp add --transport http` for both games; `npx mcp-remote` stdio fallback; REST needs no config). Global agent doc updated separately.

## Verification
Builds clean (releasedbg). The port pick is `REL::Module::IsVR() ? 8921 : 8920` at config load. Concurrent SE+VR-on-distinct-ports wasn't live-exercised this pass (one game was up at a time), but the logic is a deterministic default with the existing collision fallback unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)