### PR TITLE
fix(recording): use loadLast for quicksave/autosave entryPoints

### DIFF
--- a/src/Recording.cpp
+++ b/src/Recording.cpp
@@ -540,10 +540,16 @@ namespace dvb::Recording
 		bool restored = false;
 		if (restoreScene && tier != "worldspace" && !kind.empty() && kind != "unknown") {
 			if (kind == "save" && !value.empty()) {
-				// game load (by name) skips the content-mismatch modal and is a full teardown +
-				// loading screen on its own. Wait on postLoadGame, not playerLoaded: reloading the
-				// save we're already in, playerLoaded reads true before the reload cycles.
-				steps.push_back(json{ { "tool", "game" }, { "args", json{ { "action", "load" }, { "name", value } } } });
+				// Quicksave/autosave names are rolling — the slot name changes on every save, so
+				// the recorded value stales. Load most-recent instead. Named saves are stable.
+				// Wait postLoadGame not playerLoaded: if already in-game, playerLoaded is true
+				// before the reload completes.
+				const bool isRollingSlot =
+					value.compare(0, 9, "Quicksave") == 0 || value.compare(0, 8, "Autosave") == 0;
+				if (isRollingSlot)
+					steps.push_back(json{ { "tool", "game" }, { "args", json{ { "action", "loadLast" } } } });
+				else
+					steps.push_back(json{ { "tool", "game" }, { "args", json{ { "action", "load" }, { "name", value } } } });
 				steps.push_back(json{ { "waitFor", "postLoadGame" }, { "timeoutMs", 60000 } });
 				restored = true;
 			} else if (kind == "coc" && !value.empty()) {


### PR DESCRIPTION
## Summary

- Quicksave and autosave slot names are rolling — the engine writes a new name on every F5/autosave press
- The stem captured at record time (`Quicksave0_Alan_042`) is stale at replay: `Load(stale, false)` silently no-ops, `postLoadGame` never fires, and the replay hangs at the main menu for the full 60-second timeout
- Fix: detect quicksave/autosave prefix at `BuildReplaySteps` time and emit `loadLast` instead — which finds the current file by filesystem mtime, matching what the game's own Continue button does
- Named saves (`kSave`) have stable stems and continue to load by name

## Test plan

- [ ] Record with a quicksave as entry point (load quicksave, then start recording)
- [ ] Make another quicksave after recording (to advance the slot name)
- [ ] Replay from the main menu with `restoreScene: true` — should load and proceed instead of timing out
- [ ] Record with a named save as entry point — replay should still load the exact named save

Fixes #42.

🤖 Generated with [Claude Code](https://claude.com/claude-code)