### PR TITLE
ci(release): archive only the plugin dll/pdb

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -105,14 +105,13 @@ jobs:
           set -euo pipefail
           tag="${{ needs.semantic-release.outputs.new_release_git_tag }}"
           stage="devbench-${tag}"
-          mkdir -p "$stage/SKSE/Plugins" "$stage/Developer"
+          # User archive ships only the plugin; docs/license live in the repo and the
+          # GitHub Release page, and the C-ABI dev API is consumed from source, not from
+          # the Nexus download.
+          mkdir -p "$stage/SKSE/Plugins"
           cp bin/devbench.dll bin/devbench.pdb "$stage/SKSE/Plugins/"
           # No config.json: the plugin auto-creates a self-documenting one on first run,
           # so shipping one would only risk clobbering a user's settings on reinstall.
-          # Docs + license for the in-mod folder.
-          cp README.md ROADMAP.md COPYING EXCEPTIONS "$stage/"
-          # MIT C-ABI glue for developers who want to register their own tools.
-          cp include/DevBenchAPI.h include/DevBenchAPI.cpp include/DevBenchAPI.LICENSE.txt "$stage/Developer/"
           7z a -t7z -mx=9 "${stage}.7z" "$stage"
           echo "archive=${stage}.7z" >> "$GITHUB_OUTPUT"
           echo "Built ${stage}.7z:"


### PR DESCRIPTION
Slims the release `.7z` down to just the plugin, matching the cleanup applied to the sibling [imgui-vr-helper](https://github.com/alandtse/imgui-vr-helper) repo.

## What changes
The packaged archive previously shipped, alongside `SKSE/Plugins/devbench.{dll,pdb}`:
- `README.md`, `ROADMAP.md`, `COPYING`, `EXCEPTIONS` at the archive root
- a `Developer/` folder with the MIT C-ABI pack (`DevBenchAPI.{h,cpp}` + license)

None of that is loaded by the game, so it was dev/doc cruft landing in users' `Data` folders. This drops it; the archive is now `devbench-<tag>/SKSE/Plugins/devbench.{dll,pdb}` only.

## Where it still lives
- Docs/license: the repo and the GitHub Release page.
- C-ABI dev API: consumed from source (the `include/` headers), not the Nexus download.

## Note
GPL-3.0 technically wants `COPYING` conveyed with the binary. The Release page links the source + license; if you'd rather keep `COPYING` in the archive for strict compliance, I can add just that one file back.