### PR TITLE
feat(inspect): surface pid/port/exe in state, for multi-instance disambiguation

### DIFF
--- a/src/Server.cpp
+++ b/src/Server.cpp
@@ -10,11 +10,14 @@
 #include <winsock2.h>
 #include <ws2tcpip.h>
 
+#include <atomic>
 #include <filesystem>
 #include <fstream>
 
 namespace
 {
+	std::atomic<int> g_boundPort{ 0 };
+
 	// True if 127.0.0.1:port can be bound (i.e. it's free). WSAStartup is ref-counted,
 	// so pairing it with WSACleanup here is safe whether or not winsock is already up.
 	bool PortAvailable(const std::string& a_host, int a_port)
@@ -105,6 +108,7 @@ namespace dvb
 
 		const bool ok = m_mcp->start(false);  // non-blocking; spawns the listener thread
 		if (ok) {
+			g_boundPort.store(chosen);
 			WriteRuntimeInfo(chosen);
 			if (chosen != m_port)
 				logs::info("devbench: configured port {} busy → bound {}", m_port, chosen);
@@ -121,10 +125,16 @@ namespace dvb
 		}
 		m_restAdapter.reset();
 		m_mcpAdapter.reset();
+		g_boundPort.store(0);
 	}
 
 	bool Server::Running() const
 	{
 		return m_mcp && m_mcp->is_running();
+	}
+
+	int BoundPort()
+	{
+		return g_boundPort.load();
 	}
 }

--- a/src/Server.h
+++ b/src/Server.h
@@ -45,4 +45,11 @@ namespace dvb
 		std::unique_ptr<McpAdapter>  m_mcpAdapter;
 		std::unique_ptr<RestAdapter> m_restAdapter;
 	};
+
+	/// The port actually bound by the (single, process-wide) Server instance — may differ
+	/// from the configured port if it was busy, since Start() auto-iterates. 0 before a
+	/// Server has started. Exposed so inspect{kind:"state"} can report it: with multiple
+	/// game instances each on their own port, a caller can tell which one it's actually
+	/// talking to instead of silently misattaching (devbench#16).
+	int BoundPort();
 }

--- a/src/Tools.cpp
+++ b/src/Tools.cpp
@@ -8,6 +8,7 @@
 #include "MainThread.h"
 #include "Papyrus.h"
 #include "Recording.h"
+#include "Server.h"
 #include "ToolExtensions.h"
 #include "ToolRegistry.h"
 #include "Version.h"
@@ -22,6 +23,18 @@ namespace dvb
 {
 	namespace
 	{
+		// Basename of the running exe (SkyrimSE.exe / SkyrimVR.exe), for inspect{kind:"state"} —
+		// with multiple game instances each on their own port, this plus pid/port lets a caller
+		// confirm which one it's actually talking to instead of a silent misattach (devbench#16).
+		std::string ExecutableName()
+		{
+			char        path[MAX_PATH]{};
+			const DWORD len = ::GetModuleFileNameA(nullptr, path, MAX_PATH);
+			if (len == 0 || len == MAX_PATH)
+				return {};
+			return std::filesystem::path(path).filename().string();
+		}
+
 		bool Truthy(const json& a_v)
 		{
 			if (a_v.is_boolean())
@@ -456,7 +469,7 @@ namespace dvb
 			const std::string kind = a_args.value("kind", std::string("state"));
 
 			if (kind == "state") {
-				return MainThread::RunAndWait([]() -> json {
+				json out = MainThread::RunAndWait([]() -> json {
 					auto*      pc = RE::PlayerCharacter::GetSingleton();
 					const bool loaded = pc && pc->Get3D() != nullptr;
 					return json{
@@ -467,6 +480,13 @@ namespace dvb
 						{ "frame", game::CurrentFrame() },
 					};
 				});
+				// pid/port/exe identify which instance answered — with multiple games
+				// running on adjacent auto-iterated ports, a caller can confirm it's
+				// talking to the intended one instead of silently misattaching.
+				out["pid"] = ::GetCurrentProcessId();
+				out["port"] = BoundPort();
+				out["exe"] = ExecutableName();
+				return out;
 			}
 
 			// vm: Papyrus VM health — how loaded the script engine is (spot script lag).
@@ -1356,7 +1376,10 @@ namespace dvb
 			inspect.description =
 				"Read live game/plugin state. Runs on the main thread and returns the value "
 				"synchronously (times out if the game is mid-load / not pumping tasks). kinds: "
-				"'state' → { plugin, version, vr, playerLoaded, frame }; 'vm' → Papyrus VM health "
+				"'state' → { plugin, version, vr, playerLoaded, frame, pid, port, exe } — pid/port/exe "
+				"identify the answering instance, so a multi-instance session (e.g. SE + VR both "
+				"running, on adjacent auto-iterated ports) can confirm it's talking to the intended "
+				"one; 'vm' → Papyrus VM health "
 				"{ loadedTypes, attachedScripts, arrays, runningStacks, frozenStacks, overstressed }; "
 				"'scene' → player context { cell, worldspace, location, position, gameHour, daysPassed, "
 				"weather }; 'mods' → active load order { count, lightCount, total, plugins:[{index, name}], "


### PR DESCRIPTION
## Summary

With multiple game instances running (e.g. SE + VR), the bridge's port
auto-increments (8920, 8921, …) but nothing in the API told a caller
which instance it actually landed on — a misattach (talking to the
wrong game) was silent and only discoverable by cross-checking
externally (`netstat`/`Get-NetTCPConnection`).

`inspect{kind:"state"}` now includes `pid`, `port` (the bound port,
which may differ from the configured one if it was busy), and `exe`
(`SkyrimSE.exe` / `SkyrimVR.exe`) alongside the existing `vr` flag, so
a caller can confirm it's talking to the intended instance instead of
finding out the hard way. `Server::BoundPort()` exposes the
actually-bound port (previously only written to `runtime.json`).

Addresses the state-surfacing part of #16; reconnect/failover and
instance selection are client-side concerns outside this repo (the
MCP client, not devbench itself).

## Validation

- `xmake build devbench` succeeds standalone off `main`.
- `devbench-tests`: 10/10 pass (unaffected — this touches
  `inspect`/`Server`, not registry/content plumbing).
- `clang-format` clean.

Split out of #49 at the user's request, so this lands as its own
reviewable, independently-mergeable change rather than bundled with
unrelated replay/exterior-restore work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017Yi2T7RsF1NNnNNvbDg3XP

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced state inspection with the server’s process ID, active listening port, and running executable name.
  * State information now reports the actual port in use, including when the configured port was unavailable and an alternate port was selected.
  * Updated inspection guidance to document the additional runtime details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->