### PR TITLE
fix: MCP/REST hardening + camera/game/record UX fixes

### DIFF
--- a/src/Recording.cpp
+++ b/src/Recording.cpp
@@ -350,14 +350,19 @@ namespace dvb::Recording
 			const json     scenario = BuildScenario(rec, recordedMs);
 			const fs::path path = WriteScenarioFile(scenario);
 
-			a_events.Publish("record.stopped", json{ { "sampleCount", rec.samples.size() }, { "path", path.string() } });
+			// generic_string(), not string(): a bare `dir / filename` join uses the native
+			// separator (backslash on Windows) while the `dir` literal above keeps its forward
+			// slashes verbatim, so string() mixed both in one path — fragile for callers that
+			// split on '/'. generic_string() normalizes the whole path to forward slashes.
+			const std::string pathStr = path.generic_string();
+			a_events.Publish("record.stopped", json{ { "sampleCount", rec.samples.size() }, { "path", pathStr } });
 			Notify(std::format("devbench: recording stopped — {} samples, {:.1f}s", rec.samples.size(), recordedMs / 1000.0));
-			logs::info("devbench: recording stopped — {} samples, {}ms -> {}", rec.samples.size(), recordedMs, path.string());
+			logs::info("devbench: recording stopped — {} samples, {}ms -> {}", rec.samples.size(), recordedMs, pathStr);
 			return json{
 				{ "action", "stop" },
 				{ "sampleCount", rec.samples.size() },
 				{ "recordedMs", recordedMs },
-				{ "path", path.string() },
+				{ "path", pathStr },
 				{ "meta", scenario["meta"] },
 			};
 		}

--- a/src/RestAdapter.cpp
+++ b/src/RestAdapter.cpp
@@ -51,6 +51,16 @@ namespace dvb
 				WriteJson(res, r.errorCode ? r.errorCode : 500, json{ { "error", r.errorMessage }, { "code", r.errorCode } });
 		});
 
+		// Deliberately GET, not POST: a bodyless POST stalls on httplib's read timeout (see
+		// Server::Start). lastLifecycle tells "listening" from "game data loaded" in one call.
+		a_http.Get("/api/health", [this](const httplib::Request&, httplib::Response& res) {
+			json lastLifecycle;
+			for (const auto& ev : m_events.Since(0))
+				if (ev.topic == "lifecycle")
+					lastLifecycle = ev.payload.value("event", std::string{});
+			WriteJson(res, 200, json{ { "ok", true }, { "lastLifecycle", lastLifecycle } });
+		});
+
 		// Poll recent events (the SSE stream is a later addition).
 		a_http.Get("/api/events", [this](const httplib::Request& req, httplib::Response& res) {
 			uint64_t since = 0;

--- a/src/RestAdapter.cpp
+++ b/src/RestAdapter.cpp
@@ -17,9 +17,52 @@ namespace dvb
 		}
 	}
 
+	namespace
+	{
+		// A malformed lifecycle payload must never clear an already-known-good value —
+		// skip it rather than let .value() throw or silently store an empty string.
+		std::optional<std::string> LifecycleEventName(const json& a_payload)
+		{
+			if (!a_payload.is_object())
+				return std::nullopt;
+			const auto it = a_payload.find("event");
+			if (it == a_payload.end() || !it->is_string())
+				return std::nullopt;
+			return it->get<std::string>();
+		}
+	}
+
 	RestAdapter::RestAdapter(ToolRegistry& a_registry, EventBus& a_events) :
 		m_registry(a_registry), m_events(a_events)
-	{}
+	{
+		// Track the latest lifecycle event directly rather than scanning Since(0) on every
+		// /api/health call: the bus's ring buffer caps at 256 events, so under enough traffic
+		// a real lifecycle event scrolls out and health would wrongly report null even though
+		// one had occurred. Subscribe() only delivers FUTURE events, so also seed from
+		// Since(0) once here — today's call order (Start() before InstallGameEvents) means no
+		// lifecycle event can precede this subscription, but seeding removes that as a silent
+		// invariant this constructor depends on.
+		for (const auto& ev : m_events.Since(0))
+			if (ev.topic == "lifecycle")
+				if (auto name = LifecycleEventName(ev.payload))
+					m_lastLifecycle = std::move(name);
+
+		m_lifecycleSub = m_events.Subscribe([this](const EventBus::Event& a_ev) {
+			if (a_ev.topic != "lifecycle")
+				return;
+			auto name = LifecycleEventName(a_ev.payload);
+			if (!name)
+				return;
+			std::lock_guard lock(m_lifecycleMtx);
+			m_lastLifecycle = std::move(name);
+		});
+	}
+
+	RestAdapter::~RestAdapter()
+	{
+		if (m_lifecycleSub)
+			m_events.Unsubscribe(m_lifecycleSub);
+	}
 
 	void RestAdapter::Mount(httplib::Server& a_http)
 	{
@@ -54,11 +97,12 @@ namespace dvb
 		// Deliberately GET, not POST: a bodyless POST stalls on httplib's read timeout (see
 		// Server::Start). lastLifecycle tells "listening" from "game data loaded" in one call.
 		a_http.Get("/api/health", [this](const httplib::Request&, httplib::Response& res) {
-			json lastLifecycle;
-			for (const auto& ev : m_events.Since(0))
-				if (ev.topic == "lifecycle")
-					lastLifecycle = ev.payload.value("event", std::string{});
-			WriteJson(res, 200, json{ { "ok", true }, { "lastLifecycle", lastLifecycle } });
+			std::optional<std::string> lifecycle;
+			{
+				std::lock_guard lock(m_lifecycleMtx);
+				lifecycle = m_lastLifecycle;
+			}
+			WriteJson(res, 200, json{ { "ok", true }, { "lastLifecycle", lifecycle ? json(*lifecycle) : json(nullptr) } });
 		});
 
 		// Poll recent events (the SSE stream is a later addition).

--- a/src/RestAdapter.h
+++ b/src/RestAdapter.h
@@ -1,5 +1,10 @@
 #pragma once
 
+#include <cstdint>
+#include <mutex>
+#include <optional>
+#include <string>
+
 namespace httplib
 {
 	class Server;
@@ -17,16 +22,22 @@ namespace dvb
 	///
 	///   GET  /api/tools            → registry descriptors (discovery + docs)
 	///   POST /api/tool/<name>      → invoke; body is the arguments object
+	///   GET  /api/health           → {ok, lastLifecycle} liveness/readiness
 	///   GET  /api/events?since=N   → recent event ring (poll)
 	class RestAdapter
 	{
 	public:
 		RestAdapter(ToolRegistry& a_registry, EventBus& a_events);
+		// Unsubscribe from the bus before we're destroyed — mirrors McpAdapter's cutoff.
+		~RestAdapter();
 
 		void Mount(httplib::Server& a_http);
 
 	private:
-		ToolRegistry& m_registry;
-		EventBus&     m_events;
+		ToolRegistry&              m_registry;
+		EventBus&                  m_events;
+		uint64_t                   m_lifecycleSub = 0;
+		mutable std::mutex         m_lifecycleMtx;
+		std::optional<std::string> m_lastLifecycle;
 	};
 }

--- a/src/Server.cpp
+++ b/src/Server.cpp
@@ -101,9 +101,14 @@ namespace dvb
 		// REST facade on the same httplib server (constructed in mcp::server's ctor,
 		// so http() is valid here; cpp-mcp adds its own routes during start()).
 		m_restAdapter = std::make_unique<RestAdapter>(m_registry, m_events);
-		if (auto* http = m_mcp->http())
+		if (auto* http = m_mcp->http()) {
+			// httplib's default 5s read timeout applies even to a bodyless POST (no
+			// Content-Length/chunked header) — it waits for a body that will never come
+			// before giving up with an empty 400. Shorten this so that mistake fails fast
+			// instead of stalling; GET /api/health is the real fix for liveness checks.
+			http->set_read_timeout(2, 0);
 			m_restAdapter->Mount(*http);
-		else
+		} else
 			logs::warn("devbench: cpp-mcp http() returned null; REST facade unavailable");
 
 		const bool ok = m_mcp->start(false);  // non-blocking; spawns the listener thread

--- a/src/ToolRegistry.cpp
+++ b/src/ToolRegistry.cpp
@@ -78,6 +78,13 @@ namespace dvb
 		} catch (const ToolError& e) {
 			logs::warn("tool '{}' failed [{}]: {}", a_name, e.code, e.what());
 			return ToolResult::Failure(e.code, e.what());
+		} catch (const json::type_error& e) {
+			// .value()/.get<T>() throwing type_error specifically means the caller sent an
+			// argument of the wrong JSON type — a 400, not a 500. Deliberately NOT the broader
+			// json::exception (parse_error/out_of_range/other_error can mean something server-
+			// side actually broke, which the generic 500 path below should still catch).
+			logs::warn("tool '{}' bad args: {}", a_name, e.what());
+			return ToolResult::Failure(400, std::format("invalid arguments: {}", e.what()));
 		} catch (const std::exception& e) {
 			logs::warn("tool '{}' threw: {}", a_name, e.what());
 			return ToolResult::Failure(500, e.what());

--- a/src/Tools.cpp
+++ b/src/Tools.cpp
@@ -154,6 +154,12 @@ namespace dvb
 
 		namespace fs = std::filesystem;
 
+		std::string Lower(std::string a_s)
+		{
+			std::transform(a_s.begin(), a_s.end(), a_s.begin(), [](unsigned char c) { return static_cast<char>(std::tolower(c)); });
+			return a_s;
+		}
+
 		// Resolve the saves directory: explicit `dir` arg wins (escape hatch for exotic
 		// setups); else <My Games game folder> / sLocalSavePath (read from the INI; the
 		// 's' prefix guarantees a string), supporting an absolute setting. Running
@@ -211,10 +217,31 @@ namespace dvb
 
 			if (action == "list") {
 				const fs::path saveDir = ResolveSaveDir(a_args);
-				json           saves = json::array();
-				for (const auto& s : EnumerateSaves(saveDir))
-					saves.push_back(s.name);
-				return json{ { "dir", saveDir.string() }, { "count", saves.size() }, { "saves", std::move(saves) } };
+				auto           entries = EnumerateSaves(saveDir);  // already newest-first by mtime
+				if (const std::string filter = a_args.value("filter", std::string{}); !filter.empty()) {
+					const std::string needle = Lower(filter);
+					std::erase_if(entries, [&](const SaveEntry& s) { return Lower(s.name).find(needle) == std::string::npos; });
+				}
+				const size_t matched = entries.size();  // post-filter, pre-limit — see count/truncated below
+				if (a_args.contains("limit")) {
+					const int limit = a_args["limit"].get<int>();
+					if (limit <= 0)
+						throw ToolError(400, std::format("invalid limit '{}' (must be > 0)", limit));
+					if (static_cast<size_t>(limit) < entries.size())
+						entries.resize(limit);
+				}
+				json saves = json::array();
+				for (const auto& s : entries) {
+					const auto sys = std::chrono::clock_cast<std::chrono::system_clock>(s.mtime);
+					saves.push_back(json{ { "name", s.name },
+						{ "mtimeUnix", std::chrono::duration_cast<std::chrono::seconds>(sys.time_since_epoch()).count() } });
+				}
+				// {count, returned, truncated} mirrors inspect's inventory/refs/quests convention:
+				// count is post-filter (how many exist), returned is post-limit (what's in `saves`).
+				return json{ { "dir", saveDir.string() }, { "count", matched }, { "returned", saves.size() },
+					{ "truncated", matched > saves.size() },
+					{ "note", "sorted newest-first; saves[0] is the most recent (loadLast uses it). Pass 'limit' to cap the count." },
+					{ "saves", std::move(saves) } };
 			}
 
 			auto* task = SKSE::GetTaskInterface();
@@ -1588,17 +1615,22 @@ namespace dvb
 		ToolDescriptor game;
 		game.name = "game";
 		game.description =
-			"Save/load and list saves. action='list' enumerates the saves directory and "
-			"returns save names (use one as 'name' for load); 'loadLast' loads the most recent "
-			"save (a settled real-game state — avoids coc's heavy new-game init); 'load'/'save' "
-			"take a 'name' ('load' skips the mod-mismatch confirmation modal). All but 'list' "
-			"are fire-and-forget; watch lifecycle events / inspect playerLoaded for completion.";
+			"Save/load and list saves. action='list' returns { count, returned, truncated, saves: "
+			"[{name, mtimeUnix}, ...] }, sorted newest-first (saves[0] is what 'loadLast' loads) — "
+			"count is post-filter (how many matched), returned/saves are post-limit. 'filter' keeps "
+			"only names containing a substring (case-insensitive; save names embed the location, "
+			"e.g. 'Whiterun'), 'limit' caps how many are returned; 'loadLast' loads the most recent save (a settled "
+			"real-game state — avoids coc's heavy new-game init); 'load'/'save' take a 'name' "
+			"('load' skips the mod-mismatch confirmation modal). All but 'list' are fire-and-forget; "
+			"watch lifecycle events / inspect playerLoaded for completion.";
 		game.inputSchema = json{
 			{ "type", "object" },
 			{ "properties", json{
 								{ "action", json{ { "type", "string" }, { "enum", json::array({ "list", "save", "load", "loadLast" }) }, { "description", "list | save | load | loadLast" } } },
 								{ "name", json{ { "type", "string" }, { "description", "save file name (required for save/load; from action='list')" } } },
 								{ "dir", json{ { "type", "string" }, { "description", "list only: override the saves directory (default resolves from sLocalSavePath)" } } },
+								{ "filter", json{ { "type", "string" }, { "description", "list only: case-insensitive substring to match against save names" } } },
+								{ "limit", json{ { "type", "integer" }, { "description", "list only: cap the number of saves returned (newest-first); must be > 0 if given" } } },
 							} },
 		};
 		a_registry.Register(std::move(game), &GameHandler);

--- a/src/Tools.cpp
+++ b/src/Tools.cpp
@@ -1370,12 +1370,14 @@ namespace dvb
 				std::string error;
 			};
 
-			// runId is a monotonic counter, so the smallest key is the oldest run.
+			// runId is a monotonic counter, so the smallest key is the oldest run. Never erase an
+			// in-flight (!done) one — Finish/Fail would recreate it via operator[], and a poll in
+			// between would 404 on a run that's actually still executing.
 			void Prune()
 			{
 				constexpr size_t kRetention = 128;  // shared by two tools now; headroom over the old 64
-				while (m_runs.size() > kRetention)
-					m_runs.erase(m_runs.begin());
+				for (auto it = m_runs.begin(); m_runs.size() > kRetention && it != m_runs.end();)
+					it = it->second.done ? m_runs.erase(it) : std::next(it);
 			}
 
 			std::atomic<uint64_t>     m_seq{ 0 };

--- a/src/Tools.cpp
+++ b/src/Tools.cpp
@@ -16,6 +16,7 @@
 #include <algorithm>
 #include <chrono>
 #include <filesystem>
+#include <fstream>
 #include <map>
 #include <optional>
 #include <thread>
@@ -208,6 +209,125 @@ namespace dvb
 			"async — watch lifecycle 'postLoadGame' / inspect playerLoaded for completion. "
 			"A content-mismatch MessageBoxMenu (Yes/No) may gate it; check `menu` action=list.";
 
+		// A Pascal-style string in the .ess header: uint16 length + that many raw (non-UTF16,
+		// despite the community name "wstring") bytes.
+		std::optional<std::string> ReadPString(std::ifstream& a_in)
+		{
+			std::uint16_t len = 0;
+			if (!a_in.read(reinterpret_cast<char*>(&len), sizeof(len)))
+				return std::nullopt;
+			std::string s(len, '\0');
+			if (len > 0 && !a_in.read(s.data(), len))
+				return std::nullopt;
+			return s;
+		}
+
+		template <class T>
+		std::optional<T> ReadPod(std::ifstream& a_in)
+		{
+			T value{};
+			if (!a_in.read(reinterpret_cast<char*>(&value), sizeof(value)))
+				return std::nullopt;
+			return value;
+		}
+
+		struct EssHeader
+		{
+			std::string   characterName, location, playTime, race;
+			std::uint32_t level = 0, saveNumber = 0, shotWidth = 0, shotHeight = 0;
+			float         curExp = 0.0f, requiredExp = 0.0f;
+			std::uint64_t fileTime = 0;
+		};
+
+		// Reads the fixed-layout header every Skyrim SE .ess starts with — the same bytes the
+		// vanilla Load menu reads to show name/level/location without loading anything. Verified
+		// byte-for-byte against a live save; stops right after shotHeight (screenshot pixels,
+		// plugin list, and the (possibly compressed) form data that follow are never read).
+		std::optional<EssHeader> ReadEssHeader(const fs::path& a_path)
+		{
+			std::ifstream in(a_path, std::ios::binary);
+			if (!in)
+				return std::nullopt;
+			char magic[13];
+			if (!in.read(magic, sizeof(magic)) || std::string_view(magic, sizeof(magic)) != "TESV_SAVEGAME")
+				return std::nullopt;
+			if (!ReadPod<std::uint32_t>(in) || !ReadPod<std::uint32_t>(in))  // headerSize, version — unused
+				return std::nullopt;
+			EssHeader  h;
+			const auto saveNumber = ReadPod<std::uint32_t>(in);
+			const auto name = ReadPString(in);
+			const auto level = ReadPod<std::uint32_t>(in);
+			const auto location = ReadPString(in);
+			const auto playTime = ReadPString(in);
+			const auto race = ReadPString(in);
+			const auto sex = ReadPod<std::uint16_t>(in);
+			const auto curExp = ReadPod<float>(in);
+			const auto requiredExp = ReadPod<float>(in);
+			const auto fileTime = ReadPod<std::uint64_t>(in);
+			const auto shotWidth = ReadPod<std::uint32_t>(in);
+			const auto shotHeight = ReadPod<std::uint32_t>(in);
+			if (!saveNumber || !name || !level || !location || !playTime || !race || !sex || !curExp || !requiredExp || !fileTime || !shotWidth || !shotHeight)
+				return std::nullopt;
+			h.saveNumber = *saveNumber;
+			h.characterName = *name;
+			h.level = *level;
+			h.location = *location;
+			h.playTime = *playTime;
+			h.race = *race;
+			h.curExp = *curExp;
+			h.requiredExp = *requiredExp;
+			h.fileTime = *fileTime;
+			h.shotWidth = *shotWidth;
+			h.shotHeight = *shotHeight;
+			return h;
+		}
+
+		// FILETIME is 100ns ticks since 1601-01-01; unix epoch is 11644473600s later.
+		std::int64_t FileTimeToUnix(std::uint64_t a_ft)
+		{
+			return static_cast<std::int64_t>(a_ft / 10'000'000ULL) - 11644473600LL;
+		}
+
+		// Enriches `a_saves` (parallel to `a_entries`) by reading each save's own .ess header —
+		// pure file I/O, no engine call, so it works in every game state including the main menu
+		// before anything has ever loaded (BGSSaveLoadManager's API does not: it crashed reading
+		// saveGameList from a pristine main menu, and gave WRONG data — the save's own filename as
+		// "location" — for custom-named saves, once a session existed to call it safely at all).
+		void AttachSaveDetail(const fs::path& a_dir, const std::vector<SaveEntry>& a_entries, json& a_saves, json& a_out)
+		{
+			bool any = false;
+			for (size_t i = 0; i < a_entries.size(); ++i) {
+				const auto header = ReadEssHeader(a_dir / (a_entries[i].name + ".ess"));
+				if (!header)
+					continue;
+				any = true;
+				// saveType isn't stored in the header; infer it from the filename the same way
+				// the game names its own saves (unambiguous prefixes only, else "save").
+				const std::string lower = Lower(a_entries[i].name);
+				const char*       saveType = lower.starts_with("autosave") ? "autosave" : lower.starts_with("quicksave") ? "quicksave" :
+				                                                                                                           "save";
+				a_saves[i]["meta"] = json{
+					{ "characterName", header->characterName },
+					{ "location", header->location },
+					{ "playTime", header->playTime },
+					{ "race", header->race },
+					{ "level", header->level },
+					{ "experience", json{ { "current", header->curExp }, { "required", header->requiredExp } } },
+					{ "saveNumber", header->saveNumber },
+					{ "saveType", saveType },
+					{ "screenshot", json{ { "width", header->shotWidth }, { "height", header->shotHeight } } },
+					{ "fileTimeUnix", header->fileTime ? json(FileTimeToUnix(header->fileTime)) : json(nullptr) },
+				};
+			}
+			a_out["metaAvailable"] = any;
+			if (any)
+				a_out["metaNote"] = nullptr;
+			else if (a_entries.empty())
+				a_out["metaNote"] = "no saves matched 'filter'/'limit' — nothing to read";
+			else
+				a_out["metaNote"] = "none of the matched saves' .ess headers could be read";
+		}
+
 		// game: programmatic save / load / list via BGSSaveLoadManager. loadLast gives a
 		// settled real-save state for testing WITHOUT coc's heavy new-game init. Mutating
 		// actions run on the main thread and are async — see kLoadNote.
@@ -238,10 +358,13 @@ namespace dvb
 				}
 				// {count, returned, truncated} mirrors inspect's inventory/refs/quests convention:
 				// count is post-filter (how many exist), returned is post-limit (what's in `saves`).
-				return json{ { "dir", saveDir.string() }, { "count", matched }, { "returned", saves.size() },
+				json out{ { "dir", saveDir.string() }, { "count", matched }, { "returned", saves.size() },
 					{ "truncated", matched > saves.size() },
-					{ "note", "sorted newest-first; saves[0] is the most recent (loadLast uses it). Pass 'limit' to cap the count." },
-					{ "saves", std::move(saves) } };
+					{ "note", "sorted newest-first; saves[0] is the most recent (loadLast uses it). Pass 'limit' to cap the count." } };
+				if (a_args.value("detail", false))
+					AttachSaveDetail(saveDir, entries, saves, out);
+				out["saves"] = std::move(saves);
+				return out;
 			}
 
 			auto* task = SKSE::GetTaskInterface();
@@ -1619,10 +1742,15 @@ namespace dvb
 			"[{name, mtimeUnix}, ...] }, sorted newest-first (saves[0] is what 'loadLast' loads) — "
 			"count is post-filter (how many matched), returned/saves are post-limit. 'filter' keeps "
 			"only names containing a substring (case-insensitive; save names embed the location, "
-			"e.g. 'Whiterun'), 'limit' caps how many are returned; 'loadLast' loads the most recent save (a settled "
-			"real-game state — avoids coc's heavy new-game init); 'load'/'save' take a 'name' "
-			"('load' skips the mod-mismatch confirmation modal). All but 'list' are fire-and-forget; "
-			"watch lifecycle events / inspect playerLoaded for completion.";
+			"e.g. 'Whiterun'), 'limit' caps how many are returned, 'detail'=true adds a 'meta' "
+			"object per matched save (characterName, location, race, level, experience, playTime, saveNumber, "
+			"saveType [inferred from the filename], screenshot, fileTimeUnix — read directly from "
+			"the save's own .ess header, same bytes the vanilla Load menu shows, so it works even "
+			"before anything has loaded) plus top-level metaAvailable/metaNote if none parsed; "
+			"'loadLast' loads the most recent save (a settled real-game state — avoids coc's "
+			"heavy new-game init); 'load'/'save' take a 'name' ('load' skips the mod-mismatch "
+			"confirmation modal). All but 'list' are fire-and-forget; watch lifecycle events / "
+			"inspect playerLoaded for completion.";
 		game.inputSchema = json{
 			{ "type", "object" },
 			{ "properties", json{

--- a/src/Tools.cpp
+++ b/src/Tools.cpp
@@ -1784,7 +1784,7 @@ namespace dvb
 			{ "properties", json{
 								{ "action", json{ { "type", "string" }, { "enum", json::array({ "list", "save", "load", "loadLast" }) }, { "description", "list | save | load | loadLast" } } },
 								{ "name", json{ { "type", "string" }, { "description", "save file name (required for save/load; from action='list')" } } },
-								{ "dir", json{ { "type", "string" }, { "description", "list only: override the saves directory (default resolves from sLocalSavePath)" } } },
+								{ "dir", json{ { "type", "string" }, { "description", "list/load/loadLast: override the saves directory (default resolves from sLocalSavePath)" } } },
 								{ "filter", json{ { "type", "string" }, { "description", "list only: case-insensitive substring to match against save names" } } },
 								{ "limit", json{ { "type", "integer" }, { "description", "list only: cap the number of saves returned (newest-first); must be > 0 if given" } } },
 								{ "detail", json{ { "type", "boolean" }, { "description", "list only: add per-save character/location/level metadata (default false)" } } },
@@ -1801,8 +1801,9 @@ namespace dvb
 			"| vanity) on the main thread and returns { pov: <applied>, requestedPov } read back "
 			"the same tick — Skyrim's idle-vanity timer can still override it a few ticks later "
 			"while the player is stationary, so poll action='get' if you need certainty after "
-			"idling. action='freecam' (param 'on', default true) toggles free-camera mode; enter "
-			"it before 'drive'. action='drive' (params 'x','y','z','pitch','yaw', all default 0) "
+			"idling. action='freecam' (param 'on', default true) queues toggling free-camera mode "
+			"(fire-and-forget, takes effect a tick later) — poll action='get'.freeCam until true "
+			"before 'drive'. action='drive' (params 'x','y','z','pitch','yaw', all default 0) "
 			"sets the free camera's world transform — requires free-cam mode already on. "
 			"Recordings capture the POV per sample and replay restores it via this tool, since "
 			"what is rendered (and benchmarked) differs by POV.";

--- a/src/Tools.cpp
+++ b/src/Tools.cpp
@@ -1024,18 +1024,27 @@ namespace dvb
 			const std::string pov = a_args.value("pov", std::string{});
 			if (pov != "first" && pov != "third" && pov != "vanity")
 				throw ToolError(400, std::format("invalid pov '{}' (first|third|vanity)", pov));
-			task->AddTask([pov]() {
+			// Apply and read back on the SAME main-thread tick (not fire-and-forget), so the
+			// result reflects reality, not a queue promise Skyrim's idle-vanity timer may revert.
+			return MainThread::RunAndWait([pov]() -> json {
 				auto* cam = RE::PlayerCamera::GetSingleton();
 				if (!cam)
-					return;
+					throw ToolError(500, "PlayerCamera unavailable");
 				if (pov == "first")
 					cam->ForceFirstPerson();
 				else if (pov == "third")
 					cam->ForceThirdPerson();
 				else  // vanity has no Force* helper; push the state by its (runtime-mapped) enum
 					cam->PushCameraState(RE::CameraState::kAutoVanity);
+				std::string applied = "other";
+				if (cam->IsInFirstPerson())
+					applied = "first";
+				else if (cam->IsInThirdPerson())
+					applied = "third";
+				else if (cam->currentState && cam->currentState->id == RE::CameraState::kAutoVanity)
+					applied = "vanity";
+				return json{ { "action", "setPov" }, { "requestedPov", pov }, { "pov", applied } };
 			});
-			return json{ { "queued", true }, { "action", "setPov" }, { "pov", pov } };
 		}
 
 		// ---- scenario: server-side timed replay of a step list -------------------
@@ -1597,16 +1606,28 @@ namespace dvb
 		ToolDescriptor camera;
 		camera.name = "camera";
 		camera.description =
-			"Read or set the player camera point of view. action='get' returns { pov } where pov "
-			"is first | third | vanity | other, read live on the main thread. action='setPov' "
-			"queues a switch (param 'pov': first | third | vanity) onto the main thread "
-			"(fire-and-forget). Recordings capture the POV per sample and replay restores it via "
-			"this tool, since what is rendered (and benchmarked) differs by POV.";
+			"Read or set the player camera. action='get' (default) returns { pov, freeCam, camX, "
+			"camY, camZ, camPitch, camYaw } read live on the main thread, where pov is first | "
+			"third | vanity | other. action='setPov' applies a switch (param 'pov': first | third "
+			"| vanity) on the main thread and returns { pov: <applied>, requestedPov } read back "
+			"the same tick — Skyrim's idle-vanity timer can still override it a few ticks later "
+			"while the player is stationary, so poll action='get' if you need certainty after "
+			"idling. action='freecam' (param 'on', default true) toggles free-camera mode; enter "
+			"it before 'drive'. action='drive' (params 'x','y','z','pitch','yaw', all default 0) "
+			"sets the free camera's world transform — requires free-cam mode already on. "
+			"Recordings capture the POV per sample and replay restores it via this tool, since "
+			"what is rendered (and benchmarked) differs by POV.";
 		camera.inputSchema = json{
 			{ "type", "object" },
 			{ "properties", json{
-								{ "action", json{ { "type", "string" }, { "enum", json::array({ "get", "setPov" }) }, { "description", "get (default) | setPov" } } },
+								{ "action", json{ { "type", "string" }, { "enum", json::array({ "get", "setPov", "freecam", "drive" }) }, { "description", "get (default) | setPov | freecam | drive" } } },
 								{ "pov", json{ { "type", "string" }, { "enum", json::array({ "first", "third", "vanity" }) }, { "description", "setPov: target point of view" } } },
+								{ "on", json{ { "type", "boolean" }, { "description", "freecam: enable (default) or disable free-camera mode" } } },
+								{ "x", json{ { "type", "number" }, { "description", "drive: world X (requires free-cam mode)" } } },
+								{ "y", json{ { "type", "number" }, { "description", "drive: world Y (requires free-cam mode)" } } },
+								{ "z", json{ { "type", "number" }, { "description", "drive: world Z (requires free-cam mode)" } } },
+								{ "pitch", json{ { "type", "number" }, { "description", "drive: free-cam pitch" } } },
+								{ "yaw", json{ { "type", "number" }, { "description", "drive: free-cam yaw" } } },
 							} },
 		};
 		a_registry.Register(std::move(camera), &CameraHandler);

--- a/src/Tools.cpp
+++ b/src/Tools.cpp
@@ -2049,7 +2049,7 @@ namespace dvb
 					return json{ { "queued", true }, { "runId", runId }, { "steps", steps.size() }, { "estMs", estMs } };
 				}
 				if (action == "status" && a_args.contains("runId")) {
-					const uint64_t runId = a_args["runId"].get<uint64_t>();
+					const uint64_t runId = ParseRunId(a_args);
 					if (auto st = RunRegistry::Get().Status(runId))
 						return *st;
 					throw ToolError(404, std::format("unknown replay runId {}", runId));

--- a/src/Tools.cpp
+++ b/src/Tools.cpp
@@ -1288,19 +1288,31 @@ namespace dvb
 			throw ToolError(400, std::format("unknown waitUntil condition '{}' (playerLoaded|noModal|noMenu)", a_cond));
 		}
 
-		// Tracks in-flight/completed async replay runs (record{action:"replay"}, async by default)
-		// so a caller can poll record{action:"status", runId:…} instead of blocking the HTTP
-		// request for the run's duration — mirrors game{action:"load"}'s queued/poll convention.
-		// Entries are pruned once the retention cap is hit so a caller that never polls a
-		// finished run doesn't leak state across a long-lived session.
-		class ReplayRunRegistry
+		// Caller must already know a_args["runId"] is present. A bare get<uint64_t>() on a
+		// negative or non-numeric value throws json::type_error deep inside a handler — this
+		// gives a clean 400 naming the actual bad value instead.
+		uint64_t ParseRunId(const json& a_args)
+		{
+			const json& v = a_args["runId"];
+			if (!v.is_number_unsigned() && !(v.is_number_integer() && v.get<int64_t>() >= 0))
+				throw ToolError(400, std::format("invalid runId '{}' (must be a non-negative integer)", v.dump()));
+			return v.get<uint64_t>();
+		}
+
+		// Tracks in-flight/completed async runs — record{action:"replay"} (async by default) and
+		// scenario{action:"run", async:true} share this registry and its runId space, so a runId
+		// from either polls correctly via either tool's action="status". Entries are pruned once
+		// the retention cap is hit so a caller that never polls a finished run doesn't leak state.
+		class RunRegistry
 		{
 		public:
-			static ReplayRunRegistry& Get()
+			static RunRegistry& Get()
 			{
-				static ReplayRunRegistry inst;
+				static RunRegistry inst;
 				return inst;
 			}
+
+			uint64_t NextId() { return ++m_seq; }
 
 			void Start(uint64_t a_runId)
 			{
@@ -1309,13 +1321,17 @@ namespace dvb
 				Prune();
 			}
 
+			// `st.ok` reflects the result's own "ok" field when present (a scenario/replay run
+			// that completed without throwing but failed an assertion has result.ok=false — that
+			// must not be reported as a top-level ok:true) rather than just "didn't throw".
 			void Finish(uint64_t a_runId, json a_result)
 			{
 				std::lock_guard lock(m_mtx);
 				State&          st = m_runs[a_runId];
 				st.done = true;
-				st.ok = true;
+				st.ok = a_result.is_object() ? a_result.value("ok", true) : true;
 				st.result = std::move(a_result);
+				st.hasResult = true;
 			}
 
 			void Fail(uint64_t a_runId, std::string a_error)
@@ -1327,6 +1343,9 @@ namespace dvb
 				st.error = std::move(a_error);
 			}
 
+			// hasResult (Finish, even with ok:false — a failed assertion, not a thrown exception)
+			// vs error-only (Fail — the run itself threw) are distinct outcomes; conflating them
+			// on `ok` alone would discard the actual transcript for a failed-but-completed run.
 			std::optional<json> Status(uint64_t a_runId)
 			{
 				std::lock_guard lock(m_mtx);
@@ -1336,9 +1355,9 @@ namespace dvb
 				const State& st = it->second;
 				if (!st.done)
 					return json{ { "runId", a_runId }, { "done", false } };
-				if (st.ok)
-					return json{ { "runId", a_runId }, { "done", true }, { "ok", true }, { "result", st.result } };
-				return json{ { "runId", a_runId }, { "done", true }, { "ok", false }, { "error", st.error } };
+				json out{ { "runId", a_runId }, { "done", true }, { "ok", st.ok } };
+				out[st.hasResult ? "result" : "error"] = st.hasResult ? st.result : json(st.error);
+				return out;
 			}
 
 		private:
@@ -1346,6 +1365,7 @@ namespace dvb
 			{
 				bool        done = false;
 				bool        ok = false;
+				bool        hasResult = false;
 				json        result;
 				std::string error;
 			};
@@ -1353,11 +1373,12 @@ namespace dvb
 			// runId is a monotonic counter, so the smallest key is the oldest run.
 			void Prune()
 			{
-				constexpr size_t kRetention = 64;
+				constexpr size_t kRetention = 128;  // shared by two tools now; headroom over the old 64
 				while (m_runs.size() > kRetention)
 					m_runs.erase(m_runs.begin());
 			}
 
+			std::atomic<uint64_t>     m_seq{ 0 };
 			std::mutex                m_mtx;
 			std::map<uint64_t, State> m_runs;
 		};
@@ -1376,13 +1397,10 @@ namespace dvb
 				throw ToolError(400, "repeat capped at 1000");
 			const bool continueOnError = a_args.value("continueOnError", false);
 
-			// Correlates this run's scenario.step / replay.* events: concurrent
-			// runs interleave on the bus, and the id keys them apart. A caller
-			// (the replay wrapper) may pass its own id; standalone runs mint one.
-			static std::atomic<uint64_t> s_runSeq{ 0 };
-			const uint64_t               runId = a_args.value("runId", static_cast<uint64_t>(0)) ?
-			                                         a_args.value("runId", static_cast<uint64_t>(0)) :
-			                                         ++s_runSeq;
+			// Correlates this run's scenario.step / replay.* events: concurrent runs
+			// interleave on the bus, and the id keys them apart. Both callers (the
+			// scenario tool wrapper and record.replay) always supply one.
+			const uint64_t runId = a_args.value("runId", static_cast<uint64_t>(0));
 
 			json       results = json::array();
 			const auto t0 = steady_clock::now();
@@ -1584,6 +1602,16 @@ namespace dvb
 						r["errorCode"] = e.code;
 						r["error"] = e.what();
 						stepFailed = true;
+					} catch (const std::exception& e) {
+						// A malformed step (e.g. non-numeric "wait") throws outside ToolError —
+						// catch it here too so it fails this step, not the whole (possibly
+						// detached-thread) run.
+						if (!r.contains("kind"))
+							r["kind"] = "error";
+						r["ok"] = false;
+						r["errorCode"] = 500;
+						r["error"] = e.what();
+						stepFailed = true;
 					}
 
 					r["elapsedMs"] = duration_cast<milliseconds>(steady_clock::now() - stepStart).count();
@@ -1759,6 +1787,7 @@ namespace dvb
 								{ "dir", json{ { "type", "string" }, { "description", "list only: override the saves directory (default resolves from sLocalSavePath)" } } },
 								{ "filter", json{ { "type", "string" }, { "description", "list only: case-insensitive substring to match against save names" } } },
 								{ "limit", json{ { "type", "integer" }, { "description", "list only: cap the number of saves returned (newest-first); must be > 0 if given" } } },
+								{ "detail", json{ { "type", "boolean" }, { "description", "list only: add per-save character/location/level metadata (default false)" } } },
 							} },
 		};
 		a_registry.Register(std::move(game), &GameHandler);
@@ -1844,7 +1873,8 @@ namespace dvb
 		scenario.name = "scenario";
 		scenario.description =
 			"Run a timed sequence of steps server-side (reproducible tests/benchmarks) and "
-			"return a per-step transcript. Each step is one of: "
+			"return a per-step transcript. action='run' (default, requires 'steps'). Each step is "
+			"one of: "
 			"{\"tool\":\"<name>\",\"args\":{…}} dispatch any registered tool (e.g. console, game); "
 			"{\"wait\":<ms>} fixed pacing; "
 			"{\"waitFor\":<event>,…} block on a Skyrim EVENT — string shorthand "
@@ -1852,23 +1882,77 @@ namespace dvb
 			"\"menuOpened\"/\"menuClosed\" with a \"name\"), or {\"topic\":\"…\",\"match\":{…}}; "
 			"{\"waitUntil\":\"playerLoaded\"|\"noModal\"|\"noMenu\"} poll live state. "
 			"PREFER waitFor over a fixed wait — e.g. wait for postLoadGame to know a load truly "
-			"finished. Optional top-level: repeat (≤1000), continueOnError. waitFor/waitUntil take "
-			"timeoutMs + pollMs. Blocks the request for the run's duration (seconds); keep "
-			"per-step timeouts sane. Publishes a scenario.step event (index/total/kind/tool) "
-			"before each step — poll GET /api/events to follow a blocking run; if the game "
-			"wedges mid-run, the last scenario.step names the culprit step.";
+			"finished. Optional: repeat (≤1000), continueOnError, async. By default action='run' "
+			"BLOCKS the request for the run's duration and returns the transcript directly — the "
+			"primary use is asserting against that return value in the same call. Pass async=true "
+			"to instead get {queued:true, runId, steps} immediately and poll "
+			"action='status'+runId (returns {done:false} while running, or {done:true, ok, "
+			"result} / {done:true, ok:false, error} once finished — runId is shared with "
+			"record{action:'replay'}, so either tool's status action resolves either tool's "
+			"runId). Publishes scenario.started/scenario.step/scenario.finished events (index/"
+			"total/kind/tool on each step) in both modes — poll GET /api/events to follow a run; "
+			"if the game wedges mid-run, the last scenario.step names the culprit step.";
 		scenario.inputSchema = json{
 			{ "type", "object" },
-			{ "required", json::array({ "steps" }) },
 			{ "properties", json{
-								{ "steps", json{ { "type", "array" }, { "description", "ordered steps; each is one of tool/wait/waitFor/waitUntil (see description)" }, { "items", json{ { "type", "object" } } } } },
-								{ "repeat", json{ { "type", "integer" }, { "description", "run the whole step list N times (default 1, max 1000)" } } },
-								{ "continueOnError", json{ { "type", "boolean" }, { "description", "keep going after a failed/timed-out step instead of aborting (default false)" } } },
+								{ "action", json{ { "type", "string" }, { "enum", json::array({ "run", "status" }) }, { "description", "run (default, requires 'steps') | status (requires 'runId')" } } },
+								{ "steps", json{ { "type", "array" }, { "description", "run: ordered steps; each is one of tool/wait/waitFor/waitUntil (see description)" }, { "items", json{ { "type", "object" } } } } },
+								{ "repeat", json{ { "type", "integer" }, { "description", "run: run the whole step list N times (default 1, max 1000)" } } },
+								{ "continueOnError", json{ { "type", "boolean" }, { "description", "run: keep going after a failed/timed-out step instead of aborting (default false)" } } },
+								{ "async", json{ { "type", "boolean" }, { "description", "run: return {queued:true, runId} immediately and run in the background (default false); true does not block" } } },
+								{ "runId", json{ { "type", "integer" }, { "description", "status: poll an async run started earlier (from run's 'runId')" } } },
 							} },
 		};
 		a_registry.Register(std::move(scenario),
-			[&a_registry, &a_events](const json& a_args, const ToolContext& a_ctx) {
-				return ScenarioHandler(a_args, a_ctx, a_registry, a_events);
+			[&a_registry, &a_events](const json& a_args, const ToolContext& a_ctx) -> json {
+				const std::string action = a_args.value("action", std::string("run"));
+				if (action == "status") {
+					if (!a_args.contains("runId"))
+						throw ToolError(400, "action='status' requires 'runId'");
+					const uint64_t runId = ParseRunId(a_args);
+					if (auto st = RunRegistry::Get().Status(runId))
+						return *st;
+					throw ToolError(404, std::format("unknown scenario runId {}", runId));
+				}
+				if (action != "run")
+					throw ToolError(400, std::format("unknown action '{}' (run|status)", action));
+				if (!a_args.contains("steps") || !a_args["steps"].is_array())
+					throw ToolError(400, "action='run' requires a 'steps' array");
+
+				uint64_t runId = a_args.value("runId", static_cast<uint64_t>(0));
+				if (!runId)
+					runId = RunRegistry::Get().NextId();
+				json argsWithId = a_args;
+				argsWithId["runId"] = runId;
+				const size_t numSteps = argsWithId["steps"].size();
+
+				// scenario.started/finished bracket EVERY exit path (thrown or not) in both sync
+				// and async modes, so a poller waiting on the event can never hang.
+				auto runScenario = [&a_registry, &a_events, a_ctx, argsWithId, runId]() -> json {
+					a_events.Publish("scenario.started", json{ { "runId", runId }, { "steps", argsWithId["steps"].size() }, { "repeat", argsWithId.value("repeat", 1) } });
+					json result;
+					try {
+						result = ScenarioHandler(argsWithId, a_ctx, a_registry, a_events);
+					} catch (const std::exception& e) {
+						a_events.Publish("scenario.finished", json{ { "runId", runId }, { "ok", false }, { "error", e.what() } });
+						throw;
+					}
+					a_events.Publish("scenario.finished", json{ { "runId", runId }, { "ok", result.value("ok", false) }, { "stepsRun", result.value("stepsRun", 0) } });
+					return result;
+				};
+
+				if (!a_args.value("async", false))
+					return runScenario();
+
+				RunRegistry::Get().Start(runId);
+				std::thread([runScenario, runId]() {
+					try {
+						RunRegistry::Get().Finish(runId, runScenario());
+					} catch (const std::exception& e) {
+						RunRegistry::Get().Fail(runId, e.what());
+					}
+				}).detach();
+				return json{ { "queued", true }, { "runId", runId }, { "steps", numSteps } };
 			});
 
 		ToolDescriptor record;
@@ -1896,8 +1980,10 @@ namespace dvb
 			"ASYNC BY DEFAULT — mirroring game{action:'load'} — and returns {queued:true, runId, steps, "
 			"estMs} immediately; poll completion via record{action:'status', runId} (returns {done, ok, "
 			"result} once finished, {done:false} while running) or watch replay.started / "
-			"replay.finished on GET /api/events (both carry runId). Pass async:false to block the "
-			"request for the run's duration and get the result object directly instead.";
+			"replay.finished on GET /api/events (both carry runId; the runId space is shared with "
+			"scenario, so a replay's runId also resolves via scenario{action:'status'}). Pass "
+			"async:false to block the request for the run's duration and get the result object "
+			"directly instead.";
 		record.inputSchema = json{
 			{ "type", "object" },
 			{ "properties", json{
@@ -1924,8 +2010,7 @@ namespace dvb
 					for (const auto& s : steps)
 						if (s.contains("wait"))
 							estMs += s["wait"].get<long>();
-					static std::atomic<uint64_t> s_replaySeq{ 0 };
-					const uint64_t               runId = ++s_replaySeq;
+					const uint64_t runId = RunRegistry::Get().NextId();
 					Recording::Notify(std::format("devbench: replaying {} steps (~{:.1f}s)", steps.size(), estMs / 1000.0));
 					logs::info("devbench: replay starting — {} steps, ~{}ms", steps.size(), estMs);
 					a_events.Publish("replay.started", json{ { "runId", runId }, { "steps", steps.size() }, { "estMs", estMs }, { "path", a_args.value("path", std::string{}) } });
@@ -1953,19 +2038,19 @@ namespace dvb
 					if (!a_args.value("async", true))
 						return runReplay();
 
-					ReplayRunRegistry::Get().Start(runId);
+					RunRegistry::Get().Start(runId);
 					std::thread([runReplay, runId]() {
 						try {
-							ReplayRunRegistry::Get().Finish(runId, runReplay());
+							RunRegistry::Get().Finish(runId, runReplay());
 						} catch (const std::exception& e) {
-							ReplayRunRegistry::Get().Fail(runId, e.what());
+							RunRegistry::Get().Fail(runId, e.what());
 						}
 					}).detach();
 					return json{ { "queued", true }, { "runId", runId }, { "steps", steps.size() }, { "estMs", estMs } };
 				}
 				if (action == "status" && a_args.contains("runId")) {
 					const uint64_t runId = a_args["runId"].get<uint64_t>();
-					if (auto st = ReplayRunRegistry::Get().Status(runId))
+					if (auto st = RunRegistry::Get().Status(runId))
 						return *st;
 					throw ToolError(404, std::format("unknown replay runId {}", runId));
 				}


### PR DESCRIPTION
## Summary

11 commits, each independently reviewable/rebasable and independently buildable (spot-checked):

- `build(deps)`: bump vendored `cpp-mcp` to `f1117d5`
- `fix(rest)`: add `GET /api/health` (liveness + last-seen lifecycle stage in one call); bound the ~5s stall a bodyless POST hits on any `/api/tool/<name>` route
- `fix(camera)`: `setPov` reports the actually-applied POV instead of a blind `{queued:true}`; documents `freecam`/`drive` and `get`'s full response shape
- `feat(game)` (filter/mtime/limit): `list` returns each save's `mtimeUnix`, accepts `filter` and `limit` (`limit<=0` is a 400, not silently "return everything" — caught by a fresh-agent UX pass)
- `fix(recording)`: `record{action:stop}`'s `path` no longer mixes `/` and `\`
- `feat(game)` (detail metadata): `list{detail:true}` reads each save's own `.ess` header directly — works in every game state including the main menu. Went through two design iterations (see below).
- `feat(scenario)`: `async` mode (opt-in) with `action=run|status`, sharing `record.replay`'s run registry (renamed `RunRegistry`, retention 64→128); fixes a real pre-existing bug where a run that completed without throwing but failed an assertion was misreported as `ok:true`; catches `std::exception` per step so a malformed step fails cleanly instead of escaping unhandled
- `fix(tools)`: a caller passing the wrong JSON type for any tool's argument threw an uncaught `nlohmann::json::type_error`, reported as a 500 — now mapped to 400 centrally in `ToolRegistry::Invoke`, fixing this for every tool at once
- `docs(game,camera)`: `dir` is shared by load/loadLast, not list-only; `freecam` is fire-and-forget, doc now says so
- `fix(scenario)`: `RunRegistry::Prune()` could evict an in-flight run under load (>128 tracked runs), causing a false 404 on a run that was actually still executing
- `fix(rest)`: `/api/health`'s `lastLifecycle` was derived by scanning the event bus's 256-entry ring buffer — under enough traffic a real lifecycle event scrolls out and health wrongly reports `null`. Now tracked directly via a bus subscription (mirrors `McpAdapter`'s subscribe/unsubscribe lifecycle).

**Design process for the save-metadata feature:** an initial approach via `BGSSaveLoadManager::PopulateSaveList()` was designed, adversarially reviewed (agy-bridge/Gemini) and hardened against every finding, then **crashed live** reading `saveGameList` from a pristine main menu despite `PopulateSaveList()` returning `true` — and even where safely callable, returned wrong data (the save's own filename as "location") for custom-named saves. Switched to direct `.ess` header parsing instead, verified byte-for-byte against a real save; eliminates the crash class entirely.

**Process note:** this branch went through two rounds of independent fresh-agent hands-on UX testing (no prior context, drove the game live through the API) plus a CodeRabbit review pass — each round surfaced real issues (a crash, a silent-unbounded-limit surprise, a raw-500-instead-of-400 contract violation, a ring-buffer eviction bug, an in-flight-run eviction bug) that were fixed and re-verified live before landing. History was reorganized once so each fix folds into the commit it belongs with rather than reading as "shipped broken, patched later."

## Test plan
- [x] `xmake build` clean after every commit; 2 additional commits (the ones touched by conflict resolution during history rebuild) spot-checked as standalone builds
- [x] Live-verified: `GET /api/health` reflects `lastLifecycle`, and survives >256 events pushing it out of the event ring (confirmed the ring itself evicted — `since=0` no longer returns early sequence numbers — while `lastLifecycle` still correctly showed `dataLoaded`)
- [x] Live-verified: bodyless POST now fails in ~2s (was ~5.4s)
- [x] Live-verified: `camera{action:setPov}` returns the actual applied `pov`
- [x] Live-verified: `game{action:list}` filter/limit/detail combinations, including `limit:0`/`limit:-1`/wrong-typed args all now 400 with clean messages, and `detail:true` working correctly from a pristine main menu with byte-verified-correct data
- [x] Live-verified: `record{action:stop}`'s `path` is all forward slashes
- [x] Live-verified: `scenario{async:true}` queuing/polling, two concurrent runs, malformed-step handling in both modes, and cross-tool `runId` resolution with `record.replay` in both directions
- [x] Live-verified: `scenario`'s own `ToolError`-based 400/404 paths are unaffected by the new global type-error handler

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added richer save-game listing with filtering, limits, timestamps, sorting, and optional metadata.
  - Camera POV changes now apply immediately and report the actual resulting POV.
  - Scenario and replay runs now share status tracking and run IDs.

- **Improvements**
  - Health checks report the latest lifecycle state.
  - Recording paths use consistent forward-slash formatting.
  - Server requests avoid prolonged waits for incomplete request bodies.
  - Invalid tool arguments now return clearer errors.

- **Bug Fixes**
  - Improved handling and reporting of scenario step failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->