### PR TITLE
feat(menu): in-game recordings menus (SMF + FUCK)

### DIFF
--- a/src/Config.cpp
+++ b/src/Config.cpp
@@ -45,6 +45,36 @@ namespace dvb
 		}
 	}
 
+	void SaveHotkeys(int a_recordKey, bool a_recordShift, int a_replayKey, bool a_replayShift)
+	{
+		const std::filesystem::path path = "Data/SKSE/Plugins/devbench/config.json";
+		json                        j = json::object();
+		if (std::ifstream in(path); in) {
+			try {
+				j = json::parse(in, nullptr, /*allow_exceptions=*/true, /*ignore_comments=*/true);
+			} catch (...) {
+				j = json::object();  // corrupt file → still write a valid one with the new binds
+			}
+		}
+		j["recordHotkey"] = a_recordKey;
+		j["recordHotkeyShift"] = a_recordShift;
+		j["replayHotkey"] = a_replayKey;
+		j["replayHotkeyShift"] = a_replayShift;
+
+		std::error_code ec;
+		std::filesystem::create_directories(path.parent_path(), ec);
+		const std::filesystem::path tmp = path.string() + ".tmp";
+		if (std::ofstream out(tmp, std::ios::trunc); out)
+			out << j.dump(2) << '\n';
+		else {
+			logs::warn("devbench: could not write hotkeys to {}", tmp.string());
+			return;
+		}
+		std::filesystem::rename(tmp, path, ec);  // atomic replace; no torn read
+		if (ec)
+			logs::warn("devbench: could not replace config.json ({})", ec.message());
+	}
+
 	Config LoadConfig()
 	{
 		Config cfg;

--- a/src/Config.h
+++ b/src/Config.h
@@ -57,4 +57,9 @@ namespace dvb
 	// auto-created with the current defaults (so users/agents discover the keys); a
 	// parse error → defaults (logged). Never throws.
 	Config LoadConfig();
+
+	// Persist just the four hotkey keys into config.json, preserving every other key. Written from
+	// the render thread (in-menu rebind), so it writes a temp file then renames it over the target
+	// (atomic replace) — a concurrent reader never sees a half-written file. Never throws.
+	void SaveHotkeys(int a_recordKey, bool a_recordShift, int a_replayKey, bool a_replayShift);
 }

--- a/src/InputHotkeys.cpp
+++ b/src/InputHotkeys.cpp
@@ -6,6 +6,7 @@
 
 #include <RE/Skyrim.h>
 
+#include <atomic>
 #include <string>
 #include <thread>
 
@@ -14,12 +15,14 @@ namespace dvb
 	namespace
 	{
 		ToolRegistry* g_registry = nullptr;
-		int           g_recordKey = 0;
-		int           g_replayKey = 0;
-		bool          g_recordShift = false;  // hotkey requires Shift held
-		bool          g_replayShift = false;
-		std::string   g_replayPath;
-		bool          g_replayRestore = true;
+		// Atomic: the sink reads on the main/input thread, the FUCK rebind writes from the render
+		// thread. replayPath/replayRestore are never rebound in-menu, so they stay plain.
+		std::atomic<int>  g_recordKey{ 0 };
+		std::atomic<int>  g_replayKey{ 0 };
+		std::atomic<bool> g_recordShift{ false };  // hotkey requires Shift held
+		std::atomic<bool> g_replayShift{ false };
+		std::string       g_replayPath;
+		bool              g_replayRestore = true;
 
 		// Current Shift state via the OS (matches CS's InputCombo::MatchesKeyboardCombo) —
 		// robust regardless of whether/when Shift events arrive on the input sink, which is
@@ -42,6 +45,12 @@ namespace dvb
 				} catch (...) {
 				}
 			}).detach();
+		}
+
+		void FireRecordHotkey() { FireAsync(json{ { "action", "toggle" } }); }
+		void FireReplayHotkey()
+		{
+			FireAsync(json{ { "action", "replay" }, { "path", g_replayPath }, { "restoreScene", g_replayRestore } });
 		}
 
 		bool ConsoleOpen()
@@ -68,15 +77,17 @@ namespace dvb
 						continue;
 					const int  code = static_cast<int>(btn->GetIDCode());
 					const bool shift = ShiftHeld();
-					if (g_recordKey && code == g_recordKey && (!g_recordShift || shift)) {
+					const int  recKey = g_recordKey.load(), repKey = g_replayKey.load();
+					const bool recShift = g_recordShift.load(), repShift = g_replayShift.load();
+					if (recKey && code == recKey && (!recShift || shift)) {
 						logs::info("devbench: record hotkey fired (key={}, shift={})", code, shift);
-						FireAsync(json{ { "action", "toggle" } });
-					} else if (g_replayKey && code == g_replayKey && (!g_replayShift || shift)) {
+						FireRecordHotkey();
+					} else if (repKey && code == repKey && (!repShift || shift)) {
 						logs::info("devbench: replay hotkey fired (key={}, shift={})", code, shift);
-						FireAsync(json{ { "action", "replay" }, { "path", g_replayPath }, { "restoreScene", g_replayRestore } });
-					} else if ((g_recordKey && code == g_recordKey) || (g_replayKey && code == g_replayKey)) {
+						FireReplayHotkey();
+					} else if ((recKey && code == recKey) || (repKey && code == repKey)) {
 						logs::debug("devbench: hotkey base key {} down, shift={} (req rec={}/rep={})",
-							code, shift, g_recordShift, g_replayShift);
+							code, shift, recShift, repShift);
 					}
 				}
 				return RE::BSEventNotifyControl::kContinue;
@@ -91,18 +102,40 @@ namespace dvb
 		if (a_config.recordHotkey == 0 && a_config.replayHotkey == 0)
 			return;  // opt-in; nothing configured
 		g_registry = &a_registry;
-		g_recordKey = a_config.recordHotkey;
-		g_replayKey = a_config.replayHotkey;
-		g_recordShift = a_config.recordHotkeyShift;
-		g_replayShift = a_config.replayHotkeyShift;
+		g_recordKey.store(a_config.recordHotkey);
+		g_replayKey.store(a_config.replayHotkey);
+		g_recordShift.store(a_config.recordHotkeyShift);
+		g_replayShift.store(a_config.replayHotkeyShift);
 		g_replayPath = a_config.replayPath;
 		g_replayRestore = a_config.replayRestoreScene;
 		if (auto* idm = RE::BSInputDeviceManager::GetSingleton()) {
 			idm->AddEventSink(&g_inputSink);
 			logs::info("devbench: input hotkeys installed (record={} shift={}, replay={} shift={})",
-				g_recordKey, g_recordShift, g_replayKey, g_replayShift);
+				g_recordKey.load(), g_recordShift.load(), g_replayKey.load(), g_replayShift.load());
 		} else {
 			logs::warn("devbench: BSInputDeviceManager unavailable — input hotkeys NOT installed");
 		}
+	}
+
+	void SetRecordHotkey(int a_scancode, bool a_shift)
+	{
+		g_recordKey.store(a_scancode);
+		g_recordShift.store(a_shift);
+		SaveHotkeys(g_recordKey.load(), g_recordShift.load(), g_replayKey.load(), g_replayShift.load());
+	}
+
+	void SetReplayHotkey(int a_scancode, bool a_shift)
+	{
+		g_replayKey.store(a_scancode);
+		g_replayShift.store(a_shift);
+		SaveHotkeys(g_recordKey.load(), g_recordShift.load(), g_replayKey.load(), g_replayShift.load());
+	}
+
+	void GetHotkeys(int& a_recordKey, bool& a_recordShift, int& a_replayKey, bool& a_replayShift)
+	{
+		a_recordKey = g_recordKey.load();
+		a_recordShift = g_recordShift.load();
+		a_replayKey = g_replayKey.load();
+		a_replayShift = g_replayShift.load();
 	}
 }

--- a/src/InputHotkeys.h
+++ b/src/InputHotkeys.h
@@ -10,4 +10,12 @@ namespace dvb
 	// path). No-op if neither hotkey is set. The hotkeys reuse the registered `record` tool,
 	// so they share exactly the API/MCP code path.
 	void InstallInputHotkeys(ToolRegistry& a_registry, const Config& a_config);
+
+	// Live rebind (from the in-game FUCK menu): update the sink's key/shift atomically and persist
+	// to config.json. shift = require Shift held; scancode 0 disables that hotkey.
+	void SetRecordHotkey(int a_scancode, bool a_shift);
+	void SetReplayHotkey(int a_scancode, bool a_shift);
+
+	// Read the live hotkey binds (for the menu's read-only display / rebind seeding).
+	void GetHotkeys(int& a_recordKey, bool& a_recordShift, int& a_replayKey, bool& a_replayShift);
 }

--- a/src/RecordingsMenu.cpp
+++ b/src/RecordingsMenu.cpp
@@ -1,10 +1,7 @@
-// devbench's optional in-game menu, hosted by SKSE Menu Framework 3.
-//
-// This TU is PCH-FREE and must stay that way: the SMF client header exposes cimgui-style typedefs
-// (ImGuiMCP) that cannot coexist with the real imgui.h the main PCH pulls in. All drawing goes
-// through ImGuiMCP (the HOST's ImGui context, resolved via GetProcAddress) — never a local imgui.
-// Because SMF resolves every call at runtime, the whole module is inert when the framework DLL is
-// absent (SKSEMenuFramework::IsInstalled() gates registration).
+// devbench's optional in-game menu, hosted by SKSE Menu Framework 3. PCH-FREE and must stay so: the
+// SMF header's cimgui ImGuiMCP typedefs can't coexist with the real imgui.h in the main PCH. All
+// drawing goes through ImGuiMCP (host context via GetProcAddress); inert when SMF is absent
+// (SKSEMenuFramework::IsInstalled() gates registration).
 
 #define WIN32_LEAN_AND_MEAN
 #define NOMINMAX

--- a/src/RecordingsMenu.cpp
+++ b/src/RecordingsMenu.cpp
@@ -68,16 +68,18 @@ namespace dvb::UI
 			dvb::RunTool("record", args);
 		}
 
-		void Validate(const std::string& a_file, bool a_value)
+		void Validate(const std::string& a_file, bool a_value, bool a_invalidate = true)
 		{
 			dvb::RunTool("recordings", json{ { "action", "validate" }, { "file", a_file }, { "value", a_value } });
-			dvb::InvalidateRecordingsCache();
+			if (a_invalidate)
+				dvb::InvalidateRecordingsCache();
 		}
 
-		void Delete(const std::string& a_file)
+		void Delete(const std::string& a_file, bool a_invalidate = true)
 		{
 			dvb::RunTool("recordings", json{ { "action", "delete" }, { "file", a_file } });
-			dvb::InvalidateRecordingsCache();
+			if (a_invalidate)
+				dvb::InvalidateRecordingsCache();
 		}
 
 		// Pre-table per-recording block layout, kept as the fallback when the host lacks the table
@@ -114,13 +116,17 @@ namespace dvb::UI
 		void RenderActionBar(const json& a_list)
 		{
 			ImGuiMCP::BeginDisabled(s_selected.empty());
-			if (ImGuiMCP::Button("Validate selected"))
+			if (ImGuiMCP::Button("Validate selected")) {
 				for (const auto& f : s_selected)
-					Validate(f, true);
+					Validate(f, true, false);
+				dvb::InvalidateRecordingsCache();
+			}
 			ImGuiMCP::SameLine();
-			if (ImGuiMCP::Button("Unvalidate selected"))
+			if (ImGuiMCP::Button("Unvalidate selected")) {
 				for (const auto& f : s_selected)
-					Validate(f, false);
+					Validate(f, false, false);
+				dvb::InvalidateRecordingsCache();
+			}
 			ImGuiMCP::SameLine();
 			if (ImGuiMCP::Button("Delete selected"))
 				s_confirmDelete = true;
@@ -131,7 +137,8 @@ namespace dvb::UI
 				ImGuiMCP::SameLine();
 				if (ImGuiMCP::Button("Yes##confdel")) {
 					for (const auto& f : s_selected)
-						Delete(f);
+						Delete(f, false);
+					dvb::InvalidateRecordingsCache();
 					s_selected.clear();
 					s_confirmDelete = false;
 				}

--- a/src/RecordingsMenu.cpp
+++ b/src/RecordingsMenu.cpp
@@ -13,13 +13,14 @@
 
 #include "SKSEMenuFramework.h"
 
-#include "InputHotkeys.h"    // dvb::GetHotkeys (read-only keybinds display)
+#include "InputHotkeys.h"    // dvb::GetHotkeys (read-only hotkey display)
 #include "Json.h"            // dvb::json (nlohmann) — unrelated to imgui, safe in this TU
 #include "RecordingsView.h"  // dvb::ui row model
 #include "Server.h"          // dvb::RunTool / OpenRecordingsFolder
 
 #include <set>
 #include <string>
+#include <vector>
 
 namespace logger = SKSE::log;
 
@@ -34,10 +35,58 @@ namespace dvb::UI
 		// Menu state (single SMF page → function-local statics are fine).
 		char                  s_filter[128]{};
 		std::set<std::string> s_selected;
-		bool                  s_confirmDelete = false;
+		bool                  s_confirmBulkDelete = false;
+		std::string           s_confirmDeleteFile;  // the row awaiting a delete confirm
 		ui::SortKey           s_sortKey = ui::SortKey::Name;
 		bool                  s_sortAsc = true;
-		std::string           s_lastError;  // last failed action, shown red until the next action
+		std::string           s_lastError, s_lastStatus;  // last action outcome (red / green)
+
+		void Tooltip(const char* a_text)
+		{
+			if (ImGuiMCP::IsItemHovered())
+				ImGuiMCP::SetTooltip("%s", a_text);
+		}
+
+		void SetStatus(const std::string& a_s)
+		{
+			s_lastStatus = a_s;
+			s_lastError.clear();
+		}
+		void SetError(const std::string& a_e)
+		{
+			s_lastError = a_e;
+			s_lastStatus.clear();
+		}
+
+		// Action wrappers over the shared imgui-free helpers — each sets the status/error line.
+		void ReplayAction(const std::string& a_path)
+		{
+			if (const std::string e = ui::Replay(a_path); e.empty())
+				SetStatus("Replay started");
+			else
+				SetError("Replay failed: " + e);
+		}
+		void ValidateAction(const std::string& a_file, bool a_value)
+		{
+			if (const std::string e = ui::Validate(a_file, a_value); e.empty())
+				SetStatus((a_value ? "Validated " : "Unvalidated ") + a_file);
+			else
+				SetError("Validate failed: " + e);
+		}
+		void DeleteAction(const std::string& a_file)
+		{
+			if (const std::string e = ui::Delete(a_file); e.empty())
+				SetStatus("Deleted " + a_file);
+			else
+				SetError("Delete failed: " + e);
+		}
+		void ReportBulk(int a_fail, int a_total, const char* a_verb, const std::string& a_first)
+		{
+			if (a_fail == 0)
+				SetStatus(std::to_string(a_total) + " " + a_verb);
+			else
+				SetError(std::to_string(a_fail) + " of " + std::to_string(a_total) + " " + a_verb + " failed: " + a_first);
+		}
 
 		// The SMF host resolves each ImGuiMCP call via GetProcAddress; the table/sort exports may be
 		// absent on an older host. Probe a fresh module handle (the header's cached one can be NULL
@@ -59,11 +108,6 @@ namespace dvb::UI
 			return smf && ::GetProcAddress(smf, "igInputTextWithHint");
 		}
 
-		// Thin wrappers over the shared imgui-free helpers that capture any error for the page.
-		void ReplayPath(const std::string& a_path) { s_lastError = ui::Replay(a_path); }
-		void Validate(const std::string& a_file, bool a_value, bool a_invalidate = true) { s_lastError = ui::Validate(a_file, a_value, a_invalidate); }
-		void Delete(const std::string& a_file, bool a_invalidate = true) { s_lastError = ui::Delete(a_file, a_invalidate); }
-
 		// Pre-table per-recording block layout, kept as the fallback when the host lacks the table
 		// exports. (Was the whole of RenderRecordings before the table rework.)
 		void RenderRecordingsLegacy(const json& a_recs, const std::string& a_dir)
@@ -83,61 +127,76 @@ namespace dvb::UI
 				ImGuiMCP::TextColored(validated ? kGreen : kGrey, validated ? "| validated" : "| unvalidated");
 
 				if (ImGuiMCP::Button((std::string("Replay") + id).c_str()))
-					ReplayPath(a_dir + "/" + file);
+					ReplayAction(a_dir + "/" + file);
 				ImGuiMCP::SameLine();
 				if (ImGuiMCP::Button((std::string(validated ? "Unvalidate" : "Validate") + id).c_str()))
-					Validate(file, !validated);
+					ValidateAction(file, !validated);
 				ImGuiMCP::SameLine();
 				if (ImGuiMCP::Button((std::string("Delete") + id).c_str()))
-					Delete(file);
+					DeleteAction(file);
 				ImGuiMCP::Separator();
 			}
 		}
 
-		// Bulk action bar over the current selection; a delete needs a second (confirm) click.
-		void RenderActionBar(const json& a_list)
+		// Select-all + bulk action bar over the currently-filtered rows.
+		void RenderActionBar(const std::vector<ui::Row>& a_rows)
 		{
+			if (ImGuiMCP::Button("All"))
+				for (const auto& r : a_rows)
+					s_selected.insert(r.file);
+			ImGuiMCP::SameLine();
+			if (ImGuiMCP::Button("None"))
+				s_selected.clear();
+			ImGuiMCP::SameLine();
+			ImGuiMCP::Text("(%d selected)", static_cast<int>(s_selected.size()));
+
 			ImGuiMCP::BeginDisabled(s_selected.empty());
+			ImGuiMCP::SameLine();
 			if (ImGuiMCP::Button("Validate selected")) {
-				s_lastError.clear();
+				int         fail = 0;
+				std::string first;
 				for (const auto& f : s_selected)
-					if (const auto e = ui::Validate(f, true, false); s_lastError.empty())
-						s_lastError = e;
+					if (const std::string e = ui::Validate(f, true, false); !e.empty() && (++fail, first.empty()))
+						first = e;
 				dvb::InvalidateRecordingsCache();
+				ReportBulk(fail, static_cast<int>(s_selected.size()), "validated", first);
 			}
 			ImGuiMCP::SameLine();
 			if (ImGuiMCP::Button("Unvalidate selected")) {
-				s_lastError.clear();
+				int         fail = 0;
+				std::string first;
 				for (const auto& f : s_selected)
-					if (const auto e = ui::Validate(f, false, false); s_lastError.empty())
-						s_lastError = e;
+					if (const std::string e = ui::Validate(f, false, false); !e.empty() && (++fail, first.empty()))
+						first = e;
 				dvb::InvalidateRecordingsCache();
+				ReportBulk(fail, static_cast<int>(s_selected.size()), "unvalidated", first);
 			}
 			ImGuiMCP::SameLine();
 			if (ImGuiMCP::Button("Delete selected"))
-				s_confirmDelete = true;
+				s_confirmBulkDelete = true;
 			ImGuiMCP::EndDisabled();
-			if (s_confirmDelete && !s_selected.empty()) {
+			if (s_confirmBulkDelete && !s_selected.empty()) {
 				ImGuiMCP::SameLine();
 				ImGuiMCP::TextColored(kRed, "delete %d?", static_cast<int>(s_selected.size()));
 				ImGuiMCP::SameLine();
 				if (ImGuiMCP::Button("Yes##confdel")) {
-					s_lastError.clear();
+					int         fail = 0;
+					std::string first;
 					for (const auto& f : s_selected)
-						if (const auto e = ui::Delete(f, false); s_lastError.empty())
-							s_lastError = e;
+						if (const std::string e = ui::Delete(f, false); !e.empty() && (++fail, first.empty()))
+							first = e;
 					dvb::InvalidateRecordingsCache();
+					ReportBulk(fail, static_cast<int>(s_selected.size()), "deleted", first);
 					s_selected.clear();
-					s_confirmDelete = false;
+					s_confirmBulkDelete = false;
 				}
 				ImGuiMCP::SameLine();
 				if (ImGuiMCP::Button("No##confdel"))
-					s_confirmDelete = false;
+					s_confirmBulkDelete = false;
 			}
 			ImGuiMCP::SameLine();
 			if (ImGuiMCP::Button("Open folder"))
 				dvb::OpenRecordingsFolder();
-			(void)a_list;
 		}
 
 		ui::SortKey ColumnToSort(unsigned a_userID)
@@ -149,8 +208,6 @@ namespace dvb::UI
 				return ui::SortKey::Start;
 			case 4:
 				return ui::SortKey::Time;
-			case 5:
-				return ui::SortKey::Format;
 			case 6:
 				return ui::SortKey::Validated;
 			default:
@@ -158,33 +215,64 @@ namespace dvb::UI
 			}
 		}
 
+		void RenderRowActions(const ui::Row& a_row, const std::string& a_dir)
+		{
+			const std::string id = "##" + a_row.file;
+			if (ImGuiMCP::Button(("Replay" + id).c_str()))
+				ReplayAction(a_dir + "/" + a_row.file);
+			Tooltip("Replay this recording.");
+			ImGuiMCP::SameLine();
+			if (ImGuiMCP::Button(((a_row.validated ? "Unvalidate" : "Validate") + id).c_str()))
+				ValidateAction(a_row.file, !a_row.validated);
+			Tooltip("Mark this recording validated / not.");
+			ImGuiMCP::SameLine();
+			// Per-row delete needs a confirm too (bulk delete already does).
+			if (s_confirmDeleteFile == a_row.file) {
+				if (ImGuiMCP::Button(("Yes" + id).c_str())) {
+					DeleteAction(a_row.file);
+					s_selected.erase(a_row.file);
+					s_confirmDeleteFile.clear();
+				}
+				ImGuiMCP::SameLine();
+				if (ImGuiMCP::Button(("No" + id).c_str()))
+					s_confirmDeleteFile.clear();
+			} else {
+				if (ImGuiMCP::Button(("Delete" + id).c_str()))
+					s_confirmDeleteFile = a_row.file;
+				Tooltip("Delete this recording (asks to confirm).");
+			}
+		}
+
 		void RenderRecordingsTable(const json& a_list, const std::string& a_dir)
 		{
 			static const bool s_filterOk = FilterExportOk();
+			ImGuiMCP::Text("Filter");
+			ImGuiMCP::SameLine();
 			if (s_filterOk)
-				ImGuiMCP::InputTextWithHint("##filter", "filter name / where / start", s_filter, sizeof s_filter);
+				ImGuiMCP::InputTextWithHint("##filter", "name / where / start", s_filter, sizeof s_filter);
 			else
 				ImGuiMCP::TextColored(kGrey, "(filter unavailable on this menu-framework build)");
 
-			RenderActionBar(a_list);
+			// One build per frame; the table reads sort specs to update s_sortKey for the next frame.
+			const auto rows = ui::BuildRows(a_list, s_filter, s_sortKey, s_sortAsc);
+			RenderActionBar(rows);
 
 			constexpr ImGuiMCP::ImGuiTableFlags flags = ImGuiMCP::ImGuiTableFlags_Resizable |
 			                                            ImGuiMCP::ImGuiTableFlags_Sortable |
 			                                            ImGuiMCP::ImGuiTableFlags_RowBg |
 			                                            ImGuiMCP::ImGuiTableFlags_ScrollY |
 			                                            ImGuiMCP::ImGuiTableFlags_BordersInnerH;
-			// Fill the rest of the page rather than a fixed 320px box (ScrollY needs a height).
+			// Fill the rest of the page rather than a fixed box (ScrollY needs a height).
 			ImGuiMCP::ImVec2 avail{ 0.0f, 0.0f };
 			ImGuiMCP::GetContentRegionAvail(&avail);
-			if (!ImGuiMCP::BeginTable("recs", 8, flags, ImGuiMCP::ImVec2(0.0f, avail.y)))
+			if (!ImGuiMCP::BeginTable("recs", 7, flags, ImGuiMCP::ImVec2(0.0f, avail.y)))
 				return;
-			ImGuiMCP::TableSetupColumn("##sel", ImGuiMCP::ImGuiTableColumnFlags_NoSort, 0.0f, 0);
+			ImGuiMCP::TableSetupColumn("Sel", ImGuiMCP::ImGuiTableColumnFlags_NoSort, 0.0f, 0);
 			ImGuiMCP::TableSetupColumn("Name", ImGuiMCP::ImGuiTableColumnFlags_DefaultSort, 0.0f, 1);
 			ImGuiMCP::TableSetupColumn("Where", 0, 0.0f, 2);
 			ImGuiMCP::TableSetupColumn("Start", 0, 0.0f, 3);
 			ImGuiMCP::TableSetupColumn("Time", 0, 0.0f, 4);
-			ImGuiMCP::TableSetupColumn("Fmt", 0, 0.0f, 5);
-			ImGuiMCP::TableSetupColumn("Val", 0, 0.0f, 6);
+			ImGuiMCP::TableSetupColumn("Valid", 0, 0.0f, 6);
 			ImGuiMCP::TableSetupColumn("Actions", ImGuiMCP::ImGuiTableColumnFlags_NoSort, 0.0f, 7);
 			ImGuiMCP::TableSetupScrollFreeze(0, 1);
 			ImGuiMCP::TableHeadersRow();
@@ -194,7 +282,20 @@ namespace dvb::UI
 				s_sortAsc = specs->Specs[0].SortDirection != ImGuiMCP::ImGuiSortDirection_Descending;
 			}
 
-			for (const auto& row : ui::BuildRows(a_list, s_filter, s_sortKey, s_sortAsc)) {
+			if (rows.empty()) {
+				ImGuiMCP::TableNextRow();
+				ImGuiMCP::TableNextColumn();
+				if (s_filter[0])
+					ImGuiMCP::TextColored(kGrey, "No matches for \"%s\"", s_filter);
+				else {
+					int  recKey = 0, repKey = 0;
+					bool recShift = false, repShift = false;
+					dvb::GetHotkeys(recKey, recShift, repKey, repShift);
+					ImGuiMCP::TextColored(kGrey, "No recordings yet — press %s to record.", ui::KeyName(recKey).c_str());
+				}
+			}
+
+			for (const auto& row : rows) {
 				ImGuiMCP::TableNextRow();
 				ImGuiMCP::TableNextColumn();
 				bool sel = s_selected.count(row.file) > 0;
@@ -206,31 +307,22 @@ namespace dvb::UI
 				}
 				ImGuiMCP::TableNextColumn();
 				ImGuiMCP::Text("%s", row.name.c_str());
+				Tooltip(("format: " + row.format).c_str());
 				ImGuiMCP::TableNextColumn();
 				ImGuiMCP::Text("%s", row.where.c_str());
 				ImGuiMCP::TableNextColumn();
 				if (row.restorable)
 					ImGuiMCP::Text("%s", row.startText.c_str());
-				else
+				else {
 					ImGuiMCP::TextColored(kRed, "%s", row.startText.c_str());
+					Tooltip("No save/coc entry captured — replay can't restore the starting scene; comparisons may be unreliable.");
+				}
 				ImGuiMCP::TableNextColumn();
 				ImGuiMCP::Text("%s", row.timeText.c_str());
 				ImGuiMCP::TableNextColumn();
-				ImGuiMCP::Text("%s", row.format.c_str());
-				ImGuiMCP::TableNextColumn();
 				ImGuiMCP::TextColored(row.validated ? kGreen : kGrey, row.validated ? "yes" : "no");
 				ImGuiMCP::TableNextColumn();
-				const std::string id = "##" + row.file;
-				if (ImGuiMCP::Button(("Replay" + id).c_str()))
-					ReplayPath(a_dir + "/" + row.file);
-				ImGuiMCP::SameLine();
-				if (ImGuiMCP::Button(((row.validated ? "Unval" : "Val") + id).c_str()))
-					Validate(row.file, !row.validated);
-				ImGuiMCP::SameLine();
-				if (ImGuiMCP::Button(("Del" + id).c_str())) {
-					Delete(row.file);
-					s_selected.erase(row.file);
-				}
+				RenderRowActions(row, a_dir);
 			}
 			ImGuiMCP::EndTable();
 		}
@@ -241,10 +333,13 @@ namespace dvb::UI
 				"Replay a captured trajectory against the current build. Replay is "
 				"async; it restores the recorded scene first (force = run anyway on a mismatch).");
 			ImGuiMCP::Spacing();
-			if (ImGuiMCP::Button("Replay last"))
-				ReplayPath("");
+			if (ImGuiMCP::Button("Replay most recent"))
+				ReplayAction("");
+			Tooltip("Replay the most recently recorded trajectory (async).");
 			if (!s_lastError.empty())
-				ImGuiMCP::TextColored(kRed, "action failed: %s", s_lastError.c_str());
+				ImGuiMCP::TextColored(kRed, "%s", s_lastError.c_str());
+			else if (!s_lastStatus.empty())
+				ImGuiMCP::TextColored(kGreen, "%s", s_lastStatus.c_str());
 			ImGuiMCP::Separator();
 
 			const json list = dvb::ListRecordingsCached();
@@ -261,13 +356,13 @@ namespace dvb::UI
 				RenderRecordingsLegacy(list.value("recordings", json::array()), dir);
 		}
 
-		void __stdcall RenderKeybinds()
+		void __stdcall RenderHotkeys()
 		{
 			int  recKey = 0, repKey = 0;
 			bool recShift = false, repShift = false;
 			dvb::GetHotkeys(recKey, recShift, repKey, repShift);
-			ImGuiMCP::Text("recordHotkey : %d%s", recKey, recShift ? " +Shift" : "");
-			ImGuiMCP::Text("replayHotkey : %d%s", repKey, repShift ? " +Shift" : "");
+			ImGuiMCP::Text("Record : %s%s", ui::KeyName(recKey).c_str(), recShift ? " +Shift" : "");
+			ImGuiMCP::Text("Replay : %s%s", ui::KeyName(repKey).c_str(), repShift ? " +Shift" : "");
 			ImGuiMCP::Separator();
 			ImGuiMCP::TextWrapped(
 				"Rebind in the FUCK menu (if installed) or edit Data/SKSE/Plugins/devbench/config.json "
@@ -283,7 +378,7 @@ namespace dvb::UI
 		}
 		SKSEMenuFramework::SetSection("devbench");
 		SKSEMenuFramework::AddSectionItem("Recordings", RenderRecordings);
-		SKSEMenuFramework::AddSectionItem("Keybinds", RenderKeybinds);
+		SKSEMenuFramework::AddSectionItem("Hotkeys", RenderHotkeys);
 		logger::info("devbench: registered SMF pages (framework v{:.1f}).", SKSEMenuFramework::GetMenuFrameworkVersion());
 	}
 }

--- a/src/RecordingsMenu.cpp
+++ b/src/RecordingsMenu.cpp
@@ -16,10 +16,12 @@
 
 #include "SKSEMenuFramework.h"
 
-#include "Json.h"    // dvb::json (nlohmann) — unrelated to imgui, safe in this TU
-#include "Server.h"  // dvb::RunTool
+#include "InputHotkeys.h"    // dvb::GetHotkeys (read-only keybinds display)
+#include "Json.h"            // dvb::json (nlohmann) — unrelated to imgui, safe in this TU
+#include "RecordingsView.h"  // dvb::ui row model
+#include "Server.h"          // dvb::RunTool / OpenRecordingsFolder
 
-#include <fstream>
+#include <set>
 #include <string>
 
 namespace logger = SKSE::log;
@@ -32,6 +34,33 @@ namespace dvb::UI
 		constexpr ImGuiMCP::ImVec4 kGreen{ 0.40f, 0.85f, 0.45f, 1.0f };
 		constexpr ImGuiMCP::ImVec4 kRed{ 1.0f, 0.45f, 0.45f, 1.0f };
 
+		// Menu state (single SMF page → function-local statics are fine).
+		char                  s_filter[128]{};
+		std::set<std::string> s_selected;
+		bool                  s_confirmDelete = false;
+		ui::SortKey           s_sortKey = ui::SortKey::Name;
+		bool                  s_sortAsc = true;
+
+		// The SMF host resolves each ImGuiMCP call via GetProcAddress; the table/sort exports may be
+		// absent on an older host. Probe a fresh module handle (the header's cached one can be NULL
+		// if devbench loaded first) once; fall back to the plain per-row layout if any are missing.
+		bool ProbeTables()
+		{
+			HMODULE smf = ::GetModuleHandleW(L"SKSEMenuFramework");
+			return smf &&
+			       ::GetProcAddress(smf, "igBeginTable") &&
+			       ::GetProcAddress(smf, "igTableSetupColumn") &&
+			       ::GetProcAddress(smf, "igTableHeadersRow") &&
+			       ::GetProcAddress(smf, "igTableGetSortSpecs") &&
+			       ::GetProcAddress(smf, "igCheckbox");
+		}
+
+		bool FilterExportOk()
+		{
+			HMODULE smf = ::GetModuleHandleW(L"SKSEMenuFramework");
+			return smf && ::GetProcAddress(smf, "igInputTextWithHint");
+		}
+
 		// Replay a recording (or, with an empty path, the most recent). ASYNC by default so the
 		// call returns immediately — a blocking replay here would stall the render thread.
 		void ReplayPath(const std::string& a_path)
@@ -40,6 +69,175 @@ namespace dvb::UI
 			if (!a_path.empty())
 				args["path"] = a_path;
 			dvb::RunTool("record", args);
+		}
+
+		void Validate(const std::string& a_file, bool a_value)
+		{
+			dvb::RunTool("recordings", json{ { "action", "validate" }, { "file", a_file }, { "value", a_value } });
+			dvb::InvalidateRecordingsCache();
+		}
+
+		void Delete(const std::string& a_file)
+		{
+			dvb::RunTool("recordings", json{ { "action", "delete" }, { "file", a_file } });
+			dvb::InvalidateRecordingsCache();
+		}
+
+		// Pre-table per-recording block layout, kept as the fallback when the host lacks the table
+		// exports. (Was the whole of RenderRecordings before the table rework.)
+		void RenderRecordingsLegacy(const json& a_recs, const std::string& a_dir)
+		{
+			int idx = 0;
+			for (const auto& r : a_recs) {
+				const std::string file = r.value("file", std::string{});
+				const std::string name = r.value("name", file);
+				const std::string fmt = r.value("format", std::string{ "?" });
+				const bool        validated = r.value("validated", false);
+				const int         samples = r.value("sampleCount", 0);
+				const std::string id = "##rec" + std::to_string(idx++);
+
+				ImGuiMCP::Text("%s", name.c_str());
+				ImGuiMCP::TextColored(kGrey, "  %s | %d samples", fmt.c_str(), samples);
+				ImGuiMCP::SameLine();
+				ImGuiMCP::TextColored(validated ? kGreen : kGrey, validated ? "| validated" : "| unvalidated");
+
+				if (ImGuiMCP::Button((std::string("Replay") + id).c_str()))
+					ReplayPath(a_dir + "/" + file);
+				ImGuiMCP::SameLine();
+				if (ImGuiMCP::Button((std::string(validated ? "Unvalidate" : "Validate") + id).c_str()))
+					Validate(file, !validated);
+				ImGuiMCP::SameLine();
+				if (ImGuiMCP::Button((std::string("Delete") + id).c_str()))
+					Delete(file);
+				ImGuiMCP::Separator();
+			}
+		}
+
+		// Bulk action bar over the current selection; a delete needs a second (confirm) click.
+		void RenderActionBar(const json& a_list)
+		{
+			ImGuiMCP::BeginDisabled(s_selected.empty());
+			if (ImGuiMCP::Button("Validate selected"))
+				for (const auto& f : s_selected)
+					Validate(f, true);
+			ImGuiMCP::SameLine();
+			if (ImGuiMCP::Button("Unvalidate selected"))
+				for (const auto& f : s_selected)
+					Validate(f, false);
+			ImGuiMCP::SameLine();
+			if (ImGuiMCP::Button("Delete selected"))
+				s_confirmDelete = true;
+			ImGuiMCP::EndDisabled();
+			if (s_confirmDelete && !s_selected.empty()) {
+				ImGuiMCP::SameLine();
+				ImGuiMCP::TextColored(kRed, "delete %d?", static_cast<int>(s_selected.size()));
+				ImGuiMCP::SameLine();
+				if (ImGuiMCP::Button("Yes##confdel")) {
+					for (const auto& f : s_selected)
+						Delete(f);
+					s_selected.clear();
+					s_confirmDelete = false;
+				}
+				ImGuiMCP::SameLine();
+				if (ImGuiMCP::Button("No##confdel"))
+					s_confirmDelete = false;
+			}
+			ImGuiMCP::SameLine();
+			if (ImGuiMCP::Button("Open folder"))
+				dvb::OpenRecordingsFolder();
+			(void)a_list;
+		}
+
+		ui::SortKey ColumnToSort(unsigned a_userID)
+		{
+			switch (a_userID) {
+			case 2:
+				return ui::SortKey::Where;
+			case 3:
+				return ui::SortKey::Start;
+			case 4:
+				return ui::SortKey::Time;
+			case 5:
+				return ui::SortKey::Format;
+			case 6:
+				return ui::SortKey::Validated;
+			default:
+				return ui::SortKey::Name;
+			}
+		}
+
+		void RenderRecordingsTable(const json& a_list, const std::string& a_dir)
+		{
+			static const bool s_filterOk = FilterExportOk();
+			if (s_filterOk)
+				ImGuiMCP::InputTextWithHint("##filter", "filter name / where / start", s_filter, sizeof s_filter);
+			else
+				ImGuiMCP::TextColored(kGrey, "(filter unavailable on this menu-framework build)");
+
+			RenderActionBar(a_list);
+
+			constexpr ImGuiMCP::ImGuiTableFlags flags = ImGuiMCP::ImGuiTableFlags_Resizable |
+			                                            ImGuiMCP::ImGuiTableFlags_Sortable |
+			                                            ImGuiMCP::ImGuiTableFlags_RowBg |
+			                                            ImGuiMCP::ImGuiTableFlags_ScrollY |
+			                                            ImGuiMCP::ImGuiTableFlags_BordersInnerH;
+			if (!ImGuiMCP::BeginTable("recs", 8, flags, ImGuiMCP::ImVec2(0.0f, 320.0f)))
+				return;
+			ImGuiMCP::TableSetupColumn("##sel", ImGuiMCP::ImGuiTableColumnFlags_NoSort, 0.0f, 0);
+			ImGuiMCP::TableSetupColumn("Name", ImGuiMCP::ImGuiTableColumnFlags_DefaultSort, 0.0f, 1);
+			ImGuiMCP::TableSetupColumn("Where", 0, 0.0f, 2);
+			ImGuiMCP::TableSetupColumn("Start", 0, 0.0f, 3);
+			ImGuiMCP::TableSetupColumn("Time", 0, 0.0f, 4);
+			ImGuiMCP::TableSetupColumn("Fmt", 0, 0.0f, 5);
+			ImGuiMCP::TableSetupColumn("Val", 0, 0.0f, 6);
+			ImGuiMCP::TableSetupColumn("Actions", ImGuiMCP::ImGuiTableColumnFlags_NoSort, 0.0f, 7);
+			ImGuiMCP::TableSetupScrollFreeze(0, 1);
+			ImGuiMCP::TableHeadersRow();
+
+			if (ImGuiMCP::ImGuiTableSortSpecs* specs = ImGuiMCP::TableGetSortSpecs(); specs && specs->SpecsCount > 0) {
+				s_sortKey = ColumnToSort(specs->Specs[0].ColumnUserID);
+				s_sortAsc = specs->Specs[0].SortDirection != ImGuiMCP::ImGuiSortDirection_Descending;
+			}
+
+			for (const auto& row : ui::BuildRows(a_list, s_filter, s_sortKey, s_sortAsc)) {
+				ImGuiMCP::TableNextRow();
+				ImGuiMCP::TableNextColumn();
+				bool sel = s_selected.count(row.file) > 0;
+				if (ImGuiMCP::Checkbox(("##sel" + row.file).c_str(), &sel)) {
+					if (sel)
+						s_selected.insert(row.file);
+					else
+						s_selected.erase(row.file);
+				}
+				ImGuiMCP::TableNextColumn();
+				ImGuiMCP::Text("%s", row.name.c_str());
+				ImGuiMCP::TableNextColumn();
+				ImGuiMCP::Text("%s", row.where.c_str());
+				ImGuiMCP::TableNextColumn();
+				if (row.restorable)
+					ImGuiMCP::Text("%s", row.startText.c_str());
+				else
+					ImGuiMCP::TextColored(kRed, "%s", row.startText.c_str());
+				ImGuiMCP::TableNextColumn();
+				ImGuiMCP::Text("%s", row.timeText.c_str());
+				ImGuiMCP::TableNextColumn();
+				ImGuiMCP::Text("%s", row.format.c_str());
+				ImGuiMCP::TableNextColumn();
+				ImGuiMCP::TextColored(row.validated ? kGreen : kGrey, row.validated ? "yes" : "no");
+				ImGuiMCP::TableNextColumn();
+				const std::string id = "##" + row.file;
+				if (ImGuiMCP::Button(("Replay" + id).c_str()))
+					ReplayPath(a_dir + "/" + row.file);
+				ImGuiMCP::SameLine();
+				if (ImGuiMCP::Button(((row.validated ? "Unval" : "Val") + id).c_str()))
+					Validate(row.file, !row.validated);
+				ImGuiMCP::SameLine();
+				if (ImGuiMCP::Button(("Del" + id).c_str())) {
+					Delete(row.file);
+					s_selected.erase(row.file);
+				}
+			}
+			ImGuiMCP::EndTable();
 		}
 
 		void __stdcall RenderRecordings()
@@ -58,57 +256,25 @@ namespace dvb::UI
 				return;
 			}
 			const std::string dir = list.value("dir", std::string{});
-			const json        recs = list.value("recordings", json::array());
-			ImGuiMCP::Text("%d recording(s):", static_cast<int>(recs.size()));
-			ImGuiMCP::Spacing();
 
-			int idx = 0;
-			for (const auto& r : recs) {
-				const std::string file = r.value("file", std::string{});
-				const std::string name = r.value("name", file);
-				const std::string fmt = r.value("format", std::string{ "?" });
-				const bool        validated = r.value("validated", false);
-				const int         samples = r.value("sampleCount", 0);
-				const std::string id = "##rec" + std::to_string(idx++);
-
-				ImGuiMCP::Text("%s", name.c_str());
-				ImGuiMCP::TextColored(kGrey, "  %s | %d samples", fmt.c_str(), samples);
-				ImGuiMCP::SameLine();
-				ImGuiMCP::TextColored(validated ? kGreen : kGrey, validated ? "| validated" : "| unvalidated");
-
-				const std::string path = dir + "/" + file;
-				if (ImGuiMCP::Button((std::string("Replay") + id).c_str()))
-					ReplayPath(path);
-				ImGuiMCP::SameLine();
-				if (ImGuiMCP::Button((std::string(validated ? "Unvalidate" : "Validate") + id).c_str())) {
-					dvb::RunTool("recordings", json{ { "action", "validate" }, { "file", file }, { "value", !validated } });
-					dvb::InvalidateRecordingsCache();
-				}
-				ImGuiMCP::SameLine();
-				if (ImGuiMCP::Button((std::string("Delete") + id).c_str())) {
-					dvb::RunTool("recordings", json{ { "action", "delete" }, { "file", file } });
-					dvb::InvalidateRecordingsCache();
-				}
-				ImGuiMCP::Separator();
-			}
+			static const bool s_tablesOk = ProbeTables();
+			if (s_tablesOk)
+				RenderRecordingsTable(list, dir);
+			else
+				RenderRecordingsLegacy(list.value("recordings", json::array()), dir);
 		}
 
 		void __stdcall RenderKeybinds()
 		{
-			ImGuiMCP::TextWrapped(
-				"Record/replay hotkeys are set in Data/SKSE/Plugins/devbench/config.json "
-				"(DXScanCode integers; 0 = disabled). In-menu rebinding is a planned follow-up.");
+			int  recKey = 0, repKey = 0;
+			bool recShift = false, repShift = false;
+			dvb::GetHotkeys(recKey, recShift, repKey, repShift);
+			ImGuiMCP::Text("recordHotkey : %d%s", recKey, recShift ? " +Shift" : "");
+			ImGuiMCP::Text("replayHotkey : %d%s", repKey, repShift ? " +Shift" : "");
 			ImGuiMCP::Separator();
-			json cfg;
-			try {
-				if (std::ifstream in("Data/SKSE/Plugins/devbench/config.json"); in)
-					in >> cfg;
-			} catch (...) {
-			}
-			ImGuiMCP::Text("recordHotkey : %d", cfg.value("recordHotkey", 0));
-			ImGuiMCP::Text("replayHotkey : %d", cfg.value("replayHotkey", 0));
-			const std::string rp = cfg.value("replayPath", std::string{});
-			ImGuiMCP::Text("replayPath   : %s", rp.empty() ? "(most recent)" : rp.c_str());
+			ImGuiMCP::TextWrapped(
+				"Rebind in the FUCK menu (if installed) or edit Data/SKSE/Plugins/devbench/config.json "
+				"(DXScanCode integers; 0 = disabled). SMF has no rebind widget.");
 		}
 	}
 

--- a/src/RecordingsMenu.cpp
+++ b/src/RecordingsMenu.cpp
@@ -52,7 +52,7 @@ namespace dvb::UI
 				ReplayPath("");
 			ImGuiMCP::Separator();
 
-			const json list = dvb::RunTool("recordings", json{ { "action", "list" } });
+			const json list = dvb::ListRecordingsCached();
 			if (list.contains("error")) {
 				ImGuiMCP::TextColored(kRed, "recordings unavailable: %s", list.value("error", std::string{}).c_str());
 				return;
@@ -80,11 +80,15 @@ namespace dvb::UI
 				if (ImGuiMCP::Button((std::string("Replay") + id).c_str()))
 					ReplayPath(path);
 				ImGuiMCP::SameLine();
-				if (ImGuiMCP::Button((std::string(validated ? "Unvalidate" : "Validate") + id).c_str()))
+				if (ImGuiMCP::Button((std::string(validated ? "Unvalidate" : "Validate") + id).c_str())) {
 					dvb::RunTool("recordings", json{ { "action", "validate" }, { "file", file }, { "value", !validated } });
+					dvb::InvalidateRecordingsCache();
+				}
 				ImGuiMCP::SameLine();
-				if (ImGuiMCP::Button((std::string("Delete") + id).c_str()))
+				if (ImGuiMCP::Button((std::string("Delete") + id).c_str())) {
 					dvb::RunTool("recordings", json{ { "action", "delete" }, { "file", file } });
+					dvb::InvalidateRecordingsCache();
+				}
 				ImGuiMCP::Separator();
 			}
 		}

--- a/src/RecordingsMenu.cpp
+++ b/src/RecordingsMenu.cpp
@@ -1,0 +1,122 @@
+// devbench's optional in-game menu, hosted by SKSE Menu Framework 3.
+//
+// This TU is PCH-FREE and must stay that way: the SMF client header exposes cimgui-style typedefs
+// (ImGuiMCP) that cannot coexist with the real imgui.h the main PCH pulls in. All drawing goes
+// through ImGuiMCP (the HOST's ImGui context, resolved via GetProcAddress) — never a local imgui.
+// Because SMF resolves every call at runtime, the whole module is inert when the framework DLL is
+// absent (SKSEMenuFramework::IsInstalled() gates registration).
+
+#define WIN32_LEAN_AND_MEAN
+#define NOMINMAX
+
+#include "RecordingsMenu.h"
+
+#include <RE/Skyrim.h>  // RE::InputEvent — referenced by SMF header callback typedefs
+#include <SKSE/SKSE.h>  // SKSE::log (this TU has no PCH `logs` alias)
+
+#include "SKSEMenuFramework.h"
+
+#include "Json.h"    // dvb::json (nlohmann) — unrelated to imgui, safe in this TU
+#include "Server.h"  // dvb::RunTool
+
+#include <fstream>
+#include <string>
+
+namespace logger = SKSE::log;
+
+namespace dvb::UI
+{
+	namespace
+	{
+		constexpr ImGuiMCP::ImVec4 kGrey{ 0.7f, 0.7f, 0.7f, 1.0f };
+		constexpr ImGuiMCP::ImVec4 kGreen{ 0.40f, 0.85f, 0.45f, 1.0f };
+		constexpr ImGuiMCP::ImVec4 kRed{ 1.0f, 0.45f, 0.45f, 1.0f };
+
+		// Replay a recording (or, with an empty path, the most recent). ASYNC by default so the
+		// call returns immediately — a blocking replay here would stall the render thread.
+		void ReplayPath(const std::string& a_path)
+		{
+			json args{ { "action", "replay" }, { "restoreScene", true }, { "force", true } };
+			if (!a_path.empty())
+				args["path"] = a_path;
+			dvb::RunTool("record", args);
+		}
+
+		void __stdcall RenderRecordings()
+		{
+			ImGuiMCP::TextWrapped(
+				"Replay a captured trajectory against the current build. Replay is "
+				"async; it restores the recorded scene first (force = run anyway on a mismatch).");
+			ImGuiMCP::Spacing();
+			if (ImGuiMCP::Button("Replay last"))
+				ReplayPath("");
+			ImGuiMCP::Separator();
+
+			const json list = dvb::RunTool("recordings", json{ { "action", "list" } });
+			if (list.contains("error")) {
+				ImGuiMCP::TextColored(kRed, "recordings unavailable: %s", list.value("error", std::string{}).c_str());
+				return;
+			}
+			const std::string dir = list.value("dir", std::string{});
+			const json        recs = list.value("recordings", json::array());
+			ImGuiMCP::Text("%d recording(s):", static_cast<int>(recs.size()));
+			ImGuiMCP::Spacing();
+
+			int idx = 0;
+			for (const auto& r : recs) {
+				const std::string file = r.value("file", std::string{});
+				const std::string name = r.value("name", file);
+				const std::string fmt = r.value("format", std::string{ "?" });
+				const bool        validated = r.value("validated", false);
+				const int         samples = r.value("sampleCount", 0);
+				const std::string id = "##rec" + std::to_string(idx++);
+
+				ImGuiMCP::Text("%s", name.c_str());
+				ImGuiMCP::TextColored(kGrey, "  %s | %d samples", fmt.c_str(), samples);
+				ImGuiMCP::SameLine();
+				ImGuiMCP::TextColored(validated ? kGreen : kGrey, validated ? "| validated" : "| unvalidated");
+
+				const std::string path = dir + "/" + file;
+				if (ImGuiMCP::Button((std::string("Replay") + id).c_str()))
+					ReplayPath(path);
+				ImGuiMCP::SameLine();
+				if (ImGuiMCP::Button((std::string(validated ? "Unvalidate" : "Validate") + id).c_str()))
+					dvb::RunTool("recordings", json{ { "action", "validate" }, { "file", file }, { "value", !validated } });
+				ImGuiMCP::SameLine();
+				if (ImGuiMCP::Button((std::string("Delete") + id).c_str()))
+					dvb::RunTool("recordings", json{ { "action", "delete" }, { "file", file } });
+				ImGuiMCP::Separator();
+			}
+		}
+
+		void __stdcall RenderKeybinds()
+		{
+			ImGuiMCP::TextWrapped(
+				"Record/replay hotkeys are set in Data/SKSE/Plugins/devbench/config.json "
+				"(DXScanCode integers; 0 = disabled). In-menu rebinding is a planned follow-up.");
+			ImGuiMCP::Separator();
+			json cfg;
+			try {
+				if (std::ifstream in("Data/SKSE/Plugins/devbench/config.json"); in)
+					in >> cfg;
+			} catch (...) {
+			}
+			ImGuiMCP::Text("recordHotkey : %d", cfg.value("recordHotkey", 0));
+			ImGuiMCP::Text("replayHotkey : %d", cfg.value("replayHotkey", 0));
+			const std::string rp = cfg.value("replayPath", std::string{});
+			ImGuiMCP::Text("replayPath   : %s", rp.empty() ? "(most recent)" : rp.c_str());
+		}
+	}
+
+	void Register()
+	{
+		if (!SKSEMenuFramework::IsInstalled()) {
+			logger::info("SKSE Menu Framework not installed; devbench in-game menu disabled.");
+			return;
+		}
+		SKSEMenuFramework::SetSection("devbench");
+		SKSEMenuFramework::AddSectionItem("Recordings", RenderRecordings);
+		SKSEMenuFramework::AddSectionItem("Keybinds", RenderKeybinds);
+		logger::info("devbench: registered SMF pages (framework v{:.1f}).", SKSEMenuFramework::GetMenuFrameworkVersion());
+	}
+}

--- a/src/RecordingsMenu.cpp
+++ b/src/RecordingsMenu.cpp
@@ -37,6 +37,7 @@ namespace dvb::UI
 		bool                  s_confirmDelete = false;
 		ui::SortKey           s_sortKey = ui::SortKey::Name;
 		bool                  s_sortAsc = true;
+		std::string           s_lastError;  // last failed action, shown red until the next action
 
 		// The SMF host resolves each ImGuiMCP call via GetProcAddress; the table/sort exports may be
 		// absent on an older host. Probe a fresh module handle (the header's cached one can be NULL
@@ -58,29 +59,10 @@ namespace dvb::UI
 			return smf && ::GetProcAddress(smf, "igInputTextWithHint");
 		}
 
-		// Replay a recording (or, with an empty path, the most recent). ASYNC by default so the
-		// call returns immediately — a blocking replay here would stall the render thread.
-		void ReplayPath(const std::string& a_path)
-		{
-			json args{ { "action", "replay" }, { "restoreScene", true }, { "force", true } };
-			if (!a_path.empty())
-				args["path"] = a_path;
-			dvb::RunTool("record", args);
-		}
-
-		void Validate(const std::string& a_file, bool a_value, bool a_invalidate = true)
-		{
-			dvb::RunTool("recordings", json{ { "action", "validate" }, { "file", a_file }, { "value", a_value } });
-			if (a_invalidate)
-				dvb::InvalidateRecordingsCache();
-		}
-
-		void Delete(const std::string& a_file, bool a_invalidate = true)
-		{
-			dvb::RunTool("recordings", json{ { "action", "delete" }, { "file", a_file } });
-			if (a_invalidate)
-				dvb::InvalidateRecordingsCache();
-		}
+		// Thin wrappers over the shared imgui-free helpers that capture any error for the page.
+		void ReplayPath(const std::string& a_path) { s_lastError = ui::Replay(a_path); }
+		void Validate(const std::string& a_file, bool a_value, bool a_invalidate = true) { s_lastError = ui::Validate(a_file, a_value, a_invalidate); }
+		void Delete(const std::string& a_file, bool a_invalidate = true) { s_lastError = ui::Delete(a_file, a_invalidate); }
 
 		// Pre-table per-recording block layout, kept as the fallback when the host lacks the table
 		// exports. (Was the whole of RenderRecordings before the table rework.)
@@ -117,14 +99,18 @@ namespace dvb::UI
 		{
 			ImGuiMCP::BeginDisabled(s_selected.empty());
 			if (ImGuiMCP::Button("Validate selected")) {
+				s_lastError.clear();
 				for (const auto& f : s_selected)
-					Validate(f, true, false);
+					if (const auto e = ui::Validate(f, true, false); s_lastError.empty())
+						s_lastError = e;
 				dvb::InvalidateRecordingsCache();
 			}
 			ImGuiMCP::SameLine();
 			if (ImGuiMCP::Button("Unvalidate selected")) {
+				s_lastError.clear();
 				for (const auto& f : s_selected)
-					Validate(f, false, false);
+					if (const auto e = ui::Validate(f, false, false); s_lastError.empty())
+						s_lastError = e;
 				dvb::InvalidateRecordingsCache();
 			}
 			ImGuiMCP::SameLine();
@@ -136,8 +122,10 @@ namespace dvb::UI
 				ImGuiMCP::TextColored(kRed, "delete %d?", static_cast<int>(s_selected.size()));
 				ImGuiMCP::SameLine();
 				if (ImGuiMCP::Button("Yes##confdel")) {
+					s_lastError.clear();
 					for (const auto& f : s_selected)
-						Delete(f, false);
+						if (const auto e = ui::Delete(f, false); s_lastError.empty())
+							s_lastError = e;
 					dvb::InvalidateRecordingsCache();
 					s_selected.clear();
 					s_confirmDelete = false;
@@ -255,6 +243,8 @@ namespace dvb::UI
 			ImGuiMCP::Spacing();
 			if (ImGuiMCP::Button("Replay last"))
 				ReplayPath("");
+			if (!s_lastError.empty())
+				ImGuiMCP::TextColored(kRed, "action failed: %s", s_lastError.c_str());
 			ImGuiMCP::Separator();
 
 			const json list = dvb::ListRecordingsCached();

--- a/src/RecordingsMenu.cpp
+++ b/src/RecordingsMenu.cpp
@@ -181,7 +181,10 @@ namespace dvb::UI
 			                                            ImGuiMCP::ImGuiTableFlags_RowBg |
 			                                            ImGuiMCP::ImGuiTableFlags_ScrollY |
 			                                            ImGuiMCP::ImGuiTableFlags_BordersInnerH;
-			if (!ImGuiMCP::BeginTable("recs", 8, flags, ImGuiMCP::ImVec2(0.0f, 320.0f)))
+			// Fill the rest of the page rather than a fixed 320px box (ScrollY needs a height).
+			ImGuiMCP::ImVec2 avail{ 0.0f, 0.0f };
+			ImGuiMCP::GetContentRegionAvail(&avail);
+			if (!ImGuiMCP::BeginTable("recs", 8, flags, ImGuiMCP::ImVec2(0.0f, avail.y)))
 				return;
 			ImGuiMCP::TableSetupColumn("##sel", ImGuiMCP::ImGuiTableColumnFlags_NoSort, 0.0f, 0);
 			ImGuiMCP::TableSetupColumn("Name", ImGuiMCP::ImGuiTableColumnFlags_DefaultSort, 0.0f, 1);

--- a/src/RecordingsMenu.h
+++ b/src/RecordingsMenu.h
@@ -7,4 +7,9 @@ namespace dvb::UI
 {
 	// Register devbench's SMF pages. Call at kDataLoaded (SMF is up by then). No-op if SMF absent.
 	void Register();
+
+	// Register devbench's FUCK tool. Call at kDataLoaded. No-op if FUCK is not installed. Lives in
+	// its own PCH-free TU (RecordingsMenuFuck.cpp) — FUCK_API.h pulls in the real imgui.h, which
+	// cannot coexist with SMF's cimgui ImGuiMCP in RecordingsMenu.cpp.
+	void RegisterFuck();
 }

--- a/src/RecordingsMenu.h
+++ b/src/RecordingsMenu.h
@@ -1,0 +1,10 @@
+#pragma once
+
+// Optional in-game SKSE Menu Framework (SMF3) UI for browsing/managing the recording library.
+// Inert unless SMF is installed. Lives in its own PCH-free TU (RecordingsMenu.cpp) because the
+// SMF client header's cimgui typedefs cannot coexist with the real imgui.h the main PCH pulls in.
+namespace dvb::UI
+{
+	// Register devbench's SMF pages. Call at kDataLoaded (SMF is up by then). No-op if SMF absent.
+	void Register();
+}

--- a/src/RecordingsMenuFuck.cpp
+++ b/src/RecordingsMenuFuck.cpp
@@ -18,10 +18,13 @@
 
 #include "FUCK_API.h"  // pulls in <imgui.h> for types; drawing via FUCK:: wrappers
 
-#include "Json.h"    // dvb::json (nlohmann) — unrelated to imgui, safe in this TU
-#include "Server.h"  // dvb::RunTool
+#include "InputHotkeys.h"    // dvb::SetRecordHotkey / GetHotkeys
+#include "Json.h"            // dvb::json (nlohmann) — unrelated to imgui, safe in this TU
+#include "RecordingsView.h"  // dvb::ui row model
+#include "Server.h"          // dvb::RunTool / OpenRecordingsFolder
 
-#include <fstream>
+#include <cstdint>
+#include <set>
 #include <string>
 
 namespace logger = SKSE::log;
@@ -44,12 +47,61 @@ namespace dvb::UI
 			dvb::RunTool("record", args);
 		}
 
-		// A FUCK sidebar tool (grouped under "devbench") that browses/manages the recording library.
+		void Validate(const std::string& a_file, bool a_value)
+		{
+			dvb::RunTool("recordings", json{ { "action", "validate" }, { "file", a_file }, { "value", a_value } });
+			dvb::InvalidateRecordingsCache();
+		}
+
+		void Delete(const std::string& a_file)
+		{
+			dvb::RunTool("recordings", json{ { "action", "delete" }, { "file", a_file } });
+			dvb::InvalidateRecordingsCache();
+		}
+
+		// Apply a completed rebind. FUCK owns the capture (DrawManagedHotkey + OnAsyncInput); once it
+		// finishes (isBinding clears, kKey changed) push the new bind to the sink + config. Only Shift
+		// and keyboard binds are supported, so a Ctrl/Alt or gamepad bind is rejected with a warning.
+		void ApplyBind(FUCK::ManagedHotkey& a_h, std::uint32_t& a_last, bool a_isRecord, std::string& a_warn)
+		{
+			if (a_h.isBinding || a_h.kKey == a_last)
+				return;
+			a_last = a_h.kKey;
+			if (a_h.kKey == 0) {
+				a_warn = "keyboard only — bind ignored";
+				return;
+			}
+			if (a_h.kMod2 != -1 || (a_h.kMod1 != -1 && a_h.kMod1 != static_cast<int>(FUCK::Modifier::kShift))) {
+				a_warn = "only Shift modifier supported";
+				return;
+			}
+			a_warn.clear();
+			const bool shift = a_h.kMod1 == static_cast<int>(FUCK::Modifier::kShift);
+			if (a_isRecord)
+				dvb::SetRecordHotkey(static_cast<int>(a_h.kKey), shift);
+			else
+				dvb::SetReplayHotkey(static_cast<int>(a_h.kKey), shift);
+		}
+
+		// A FUCK sidebar tool (grouped under "devbench") that browses/manages the recording library
+		// and rebinds the record/replay hotkeys.
 		class RecordingsTool : public FUCK::ITool
 		{
 		public:
 			const char* Name() const override { return "Recordings"; }
 			const char* Group() const override { return "devbench"; }
+
+			// Feed input events to a hotkey being rebound. We NEVER call ProcessManagedHotkey, so a
+			// managed hotkey never fires an action — firing stays the raw sink (zero double-fire).
+			bool OnAsyncInput(const void* a_event) override
+			{
+				bool used = false;
+				if (m_recordHK.isBinding)
+					used |= FUCK::UpdateManagedHotkey(a_event, m_recordHK);
+				if (m_replayHK.isBinding)
+					used |= FUCK::UpdateManagedHotkey(a_event, m_replayHK);
+				return used;
+			}
 
 			void Draw() override
 			{
@@ -67,40 +119,166 @@ namespace dvb::UI
 					return;
 				}
 				const std::string dir = list.value("dir", std::string{});
-				const json        recs = list.value("recordings", json::array());
-				FUCK::Text("%d recording(s):", static_cast<int>(recs.size()));
-				FUCK::Spacing();
 
-				int idx = 0;
-				for (const auto& r : recs) {
-					const std::string file = r.value("file", std::string{});
-					const std::string name = r.value("name", file);
-					const std::string fmt = r.value("format", std::string{ "?" });
-					const bool        validated = r.value("validated", false);
-					const int         samples = r.value("sampleCount", 0);
-					const std::string id = "##rec" + std::to_string(idx++);
+				RenderActionBar();
+				RenderTable(list, dir);
+				RenderKeybinds();
+			}
 
-					FUCK::Text("%s", name.c_str());
-					FUCK::TextColored(kGrey, "  %s | %d samples", fmt.c_str(), samples);
+		private:
+			void RenderActionBar()
+			{
+				FUCK::InputText("##filter", m_filter, sizeof m_filter);
+				FUCK::BeginDisabled(m_selected.empty());
+				if (FUCK::Button("Validate selected"))
+					for (const auto& f : m_selected)
+						Validate(f, true);
+				FUCK::SameLine();
+				if (FUCK::Button("Unvalidate selected"))
+					for (const auto& f : m_selected)
+						Validate(f, false);
+				FUCK::SameLine();
+				if (FUCK::Button("Delete selected"))
+					m_confirmDelete = true;
+				FUCK::EndDisabled();
+				if (m_confirmDelete && !m_selected.empty()) {
 					FUCK::SameLine();
-					FUCK::TextColored(validated ? kGreen : kGrey, validated ? "| validated" : "| unvalidated");
-
-					const std::string path = dir + "/" + file;
-					if (FUCK::Button((std::string("Replay") + id).c_str()))
-						ReplayPath(path);
+					FUCK::TextColored(kRed, "delete %d?", static_cast<int>(m_selected.size()));
 					FUCK::SameLine();
-					if (FUCK::Button((std::string(validated ? "Unvalidate" : "Validate") + id).c_str())) {
-						dvb::RunTool("recordings", json{ { "action", "validate" }, { "file", file }, { "value", !validated } });
-						dvb::InvalidateRecordingsCache();
+					if (FUCK::Button("Yes##confdel")) {
+						for (const auto& f : m_selected)
+							Delete(f);
+						m_selected.clear();
+						m_confirmDelete = false;
 					}
 					FUCK::SameLine();
-					if (FUCK::Button((std::string("Delete") + id).c_str())) {
-						dvb::RunTool("recordings", json{ { "action", "delete" }, { "file", file } });
-						dvb::InvalidateRecordingsCache();
+					if (FUCK::Button("No##confdel"))
+						m_confirmDelete = false;
+				}
+				FUCK::SameLine();
+				if (FUCK::Button("Open folder"))
+					dvb::OpenRecordingsFolder();
+			}
+
+			// Manual sortable header — FUCK exposes no TableGetSortSpecs, so a clicked header cell
+			// toggles our own sort state that feeds ui::BuildRows.
+			void HeaderCell(int a_col, const char* a_title, ui::SortKey a_key)
+			{
+				FUCK::TableNextColumn();
+				std::string label = a_title;
+				if (m_sortKey == a_key)
+					label += m_sortAsc ? " ^" : " v";
+				if (FUCK::Selectable((label + "##h" + std::to_string(a_col)).c_str())) {
+					if (m_sortKey == a_key)
+						m_sortAsc = !m_sortAsc;
+					else {
+						m_sortKey = a_key;
+						m_sortAsc = true;
 					}
-					FUCK::Separator();
 				}
 			}
+
+			void RenderTable(const json& a_list, const std::string& a_dir)
+			{
+				const FUCK::TableFlags flags = FUCK::TableFlags::kResizable | FUCK::TableFlags::kRowBg |
+				                               FUCK::TableFlags::kBordersInnerH;
+				if (!FUCK::BeginTable("recs", 8, flags))
+					return;
+				FUCK::TableSetupColumn("##sel");
+				FUCK::TableSetupColumn("Name");
+				FUCK::TableSetupColumn("Where");
+				FUCK::TableSetupColumn("Start");
+				FUCK::TableSetupColumn("Time");
+				FUCK::TableSetupColumn("Fmt");
+				FUCK::TableSetupColumn("Val");
+				FUCK::TableSetupColumn("Actions");
+
+				FUCK::TableNextRow();
+				FUCK::TableNextColumn();  // select column: no sort
+				HeaderCell(1, "Name", ui::SortKey::Name);
+				HeaderCell(2, "Where", ui::SortKey::Where);
+				HeaderCell(3, "Start", ui::SortKey::Start);
+				HeaderCell(4, "Time", ui::SortKey::Time);
+				HeaderCell(5, "Fmt", ui::SortKey::Format);
+				HeaderCell(6, "Val", ui::SortKey::Validated);
+				FUCK::TableNextColumn();  // actions column: no sort
+
+				for (const auto& row : ui::BuildRows(a_list, m_filter, m_sortKey, m_sortAsc)) {
+					FUCK::TableNextRow();
+					FUCK::TableNextColumn();
+					bool sel = m_selected.count(row.file) > 0;
+					if (FUCK::Checkbox(("##sel" + row.file).c_str(), &sel)) {
+						if (sel)
+							m_selected.insert(row.file);
+						else
+							m_selected.erase(row.file);
+					}
+					FUCK::TableNextColumn();
+					FUCK::Text("%s", row.name.c_str());
+					FUCK::TableNextColumn();
+					FUCK::Text("%s", row.where.c_str());
+					FUCK::TableNextColumn();
+					if (row.restorable)
+						FUCK::Text("%s", row.startText.c_str());
+					else
+						FUCK::TextColored(kRed, "%s", row.startText.c_str());
+					FUCK::TableNextColumn();
+					FUCK::Text("%s", row.timeText.c_str());
+					FUCK::TableNextColumn();
+					FUCK::Text("%s", row.format.c_str());
+					FUCK::TableNextColumn();
+					FUCK::TextColored(row.validated ? kGreen : kGrey, row.validated ? "yes" : "no");
+					FUCK::TableNextColumn();
+					const std::string id = "##" + row.file;
+					if (FUCK::Button(("Replay" + id).c_str()))
+						ReplayPath(a_dir + "/" + row.file);
+					FUCK::SameLine();
+					if (FUCK::Button(((row.validated ? "Unval" : "Val") + id).c_str()))
+						Validate(row.file, !row.validated);
+					FUCK::SameLine();
+					if (FUCK::Button(("Del" + id).c_str())) {
+						Delete(row.file);
+						m_selected.erase(row.file);
+					}
+				}
+				FUCK::EndTable();
+			}
+
+			void RenderKeybinds()
+			{
+				if (!FUCK::CollapsingHeader("Keybinds"))
+					return;
+				if (!m_seeded) {
+					int  recKey = 0, repKey = 0;
+					bool recShift = false, repShift = false;
+					dvb::GetHotkeys(recKey, recShift, repKey, repShift);
+					m_recordHK.kKey = static_cast<std::uint32_t>(recKey);
+					m_recordHK.kMod1 = recShift ? static_cast<int>(FUCK::Modifier::kShift) : -1;
+					m_replayHK.kKey = static_cast<std::uint32_t>(repKey);
+					m_replayHK.kMod1 = repShift ? static_cast<int>(FUCK::Modifier::kShift) : -1;
+					m_lastRecordKey = m_recordHK.kKey;
+					m_lastReplayKey = m_replayHK.kKey;
+					m_seeded = true;
+				}
+				FUCK::DrawManagedHotkey("Record", m_recordHK);
+				ApplyBind(m_recordHK, m_lastRecordKey, true, m_recordWarn);
+				if (!m_recordWarn.empty())
+					FUCK::TextColored(kRed, "%s", m_recordWarn.c_str());
+				FUCK::DrawManagedHotkey("Replay", m_replayHK);
+				ApplyBind(m_replayHK, m_lastReplayKey, false, m_replayWarn);
+				if (!m_replayWarn.empty())
+					FUCK::TextColored(kRed, "%s", m_replayWarn.c_str());
+			}
+
+			char                  m_filter[128]{};
+			std::set<std::string> m_selected;
+			bool                  m_confirmDelete = false;
+			ui::SortKey           m_sortKey = ui::SortKey::Name;
+			bool                  m_sortAsc = true;
+			FUCK::ManagedHotkey   m_recordHK, m_replayHK;
+			std::uint32_t         m_lastRecordKey = 0, m_lastReplayKey = 0;
+			bool                  m_seeded = false;
+			std::string           m_recordWarn, m_replayWarn;
 		};
 
 		// Registered by pointer with FUCK; must outlive registration → static storage.

--- a/src/RecordingsMenuFuck.cpp
+++ b/src/RecordingsMenuFuck.cpp
@@ -61,7 +61,7 @@ namespace dvb::UI
 					ReplayPath("");
 				FUCK::Separator();
 
-				const json list = dvb::RunTool("recordings", json{ { "action", "list" } });
+				const json list = dvb::ListRecordingsCached();
 				if (list.contains("error")) {
 					FUCK::TextColored(kRed, "recordings unavailable: %s", list.value("error", std::string{}).c_str());
 					return;
@@ -89,11 +89,15 @@ namespace dvb::UI
 					if (FUCK::Button((std::string("Replay") + id).c_str()))
 						ReplayPath(path);
 					FUCK::SameLine();
-					if (FUCK::Button((std::string(validated ? "Unvalidate" : "Validate") + id).c_str()))
+					if (FUCK::Button((std::string(validated ? "Unvalidate" : "Validate") + id).c_str())) {
 						dvb::RunTool("recordings", json{ { "action", "validate" }, { "file", file }, { "value", !validated } });
+						dvb::InvalidateRecordingsCache();
+					}
 					FUCK::SameLine();
-					if (FUCK::Button((std::string("Delete") + id).c_str()))
+					if (FUCK::Button((std::string("Delete") + id).c_str())) {
 						dvb::RunTool("recordings", json{ { "action", "delete" }, { "file", file } });
+						dvb::InvalidateRecordingsCache();
+					}
 					FUCK::Separator();
 				}
 			}

--- a/src/RecordingsMenuFuck.cpp
+++ b/src/RecordingsMenuFuck.cpp
@@ -1,0 +1,115 @@
+// devbench's optional in-game menu, hosted by FUCK (a keybind + ImGui menu framework).
+//
+// This TU is PCH-FREE and must stay that way: FUCK_API.h pulls in the real imgui.h, which cannot
+// coexist with SMF's cimgui ImGuiMCP in RecordingsMenu.cpp — hence a separate PCH-free target
+// (devbench-UI-fuck). Drawing routes through the FUCK:: wrappers (the HOST's ImGui, via the
+// interface fetched from the FUCK.dll "RequestFUCK" export), so the module is inert when FUCK is
+// not installed (FUCK::Connect returns false and nothing is registered).
+
+#define WIN32_LEAN_AND_MEAN
+#define NOMINMAX
+
+#include "RecordingsMenu.h"
+
+#include <RE/Skyrim.h>  // RE::InputEvent — referenced by FUCK API callback typedefs
+#include <SKSE/SKSE.h>  // SKSE::log (this TU has no PCH `logs` alias)
+
+#include <SimpleIni.h>  // FUCK_API.h references CSimpleIniA in its INI/keybind callbacks — include first
+
+#include "FUCK_API.h"  // pulls in <imgui.h> for types; drawing via FUCK:: wrappers
+
+#include "Json.h"    // dvb::json (nlohmann) — unrelated to imgui, safe in this TU
+#include "Server.h"  // dvb::RunTool
+
+#include <fstream>
+#include <string>
+
+namespace logger = SKSE::log;
+
+namespace dvb::UI
+{
+	namespace
+	{
+		const ImVec4 kGrey{ 0.7f, 0.7f, 0.7f, 1.0f };
+		const ImVec4 kGreen{ 0.40f, 0.85f, 0.45f, 1.0f };
+		const ImVec4 kRed{ 1.0f, 0.45f, 0.45f, 1.0f };
+
+		// Replay a recording (empty path → most recent). ASYNC by default so the call returns
+		// immediately — a blocking replay here would stall the render thread.
+		void ReplayPath(const std::string& a_path)
+		{
+			json args{ { "action", "replay" }, { "restoreScene", true }, { "force", true } };
+			if (!a_path.empty())
+				args["path"] = a_path;
+			dvb::RunTool("record", args);
+		}
+
+		// A FUCK sidebar tool (grouped under "devbench") that browses/manages the recording library.
+		class RecordingsTool : public FUCK::ITool
+		{
+		public:
+			const char* Name() const override { return "Recordings"; }
+			const char* Group() const override { return "devbench"; }
+
+			void Draw() override
+			{
+				FUCK::TextWrapped(
+					"Replay a captured trajectory against the current build. Replay is async; it "
+					"restores the recorded scene first (force = run anyway on a mismatch).");
+				FUCK::Spacing();
+				if (FUCK::Button("Replay last"))
+					ReplayPath("");
+				FUCK::Separator();
+
+				const json list = dvb::RunTool("recordings", json{ { "action", "list" } });
+				if (list.contains("error")) {
+					FUCK::TextColored(kRed, "recordings unavailable: %s", list.value("error", std::string{}).c_str());
+					return;
+				}
+				const std::string dir = list.value("dir", std::string{});
+				const json        recs = list.value("recordings", json::array());
+				FUCK::Text("%d recording(s):", static_cast<int>(recs.size()));
+				FUCK::Spacing();
+
+				int idx = 0;
+				for (const auto& r : recs) {
+					const std::string file = r.value("file", std::string{});
+					const std::string name = r.value("name", file);
+					const std::string fmt = r.value("format", std::string{ "?" });
+					const bool        validated = r.value("validated", false);
+					const int         samples = r.value("sampleCount", 0);
+					const std::string id = "##rec" + std::to_string(idx++);
+
+					FUCK::Text("%s", name.c_str());
+					FUCK::TextColored(kGrey, "  %s | %d samples", fmt.c_str(), samples);
+					FUCK::SameLine();
+					FUCK::TextColored(validated ? kGreen : kGrey, validated ? "| validated" : "| unvalidated");
+
+					const std::string path = dir + "/" + file;
+					if (FUCK::Button((std::string("Replay") + id).c_str()))
+						ReplayPath(path);
+					FUCK::SameLine();
+					if (FUCK::Button((std::string(validated ? "Unvalidate" : "Validate") + id).c_str()))
+						dvb::RunTool("recordings", json{ { "action", "validate" }, { "file", file }, { "value", !validated } });
+					FUCK::SameLine();
+					if (FUCK::Button((std::string("Delete") + id).c_str()))
+						dvb::RunTool("recordings", json{ { "action", "delete" }, { "file", file } });
+					FUCK::Separator();
+				}
+			}
+		};
+
+		// Registered by pointer with FUCK; must outlive registration → static storage.
+		RecordingsTool g_recordingsTool;
+	}
+
+	void RegisterFuck()
+	{
+		if (!FUCK::Connect("devbench")) {
+			logger::info("FUCK not installed; devbench FUCK menu disabled.");
+			return;
+		}
+		FUCK::RegisterTool(&g_recordingsTool);
+		logger::info("devbench: registered FUCK recordings tool.");
+	}
+}

--- a/src/RecordingsMenuFuck.cpp
+++ b/src/RecordingsMenuFuck.cpp
@@ -1,10 +1,7 @@
-// devbench's optional in-game menu, hosted by FUCK (a keybind + ImGui menu framework).
-//
-// This TU is PCH-FREE and must stay that way: FUCK_API.h pulls in the real imgui.h, which cannot
-// coexist with SMF's cimgui ImGuiMCP in RecordingsMenu.cpp — hence a separate PCH-free target
-// (devbench-UI-fuck). Drawing routes through the FUCK:: wrappers (the HOST's ImGui, via the
-// interface fetched from the FUCK.dll "RequestFUCK" export), so the module is inert when FUCK is
-// not installed (FUCK::Connect returns false and nothing is registered).
+// devbench's optional in-game menu, hosted by FUCK. PCH-FREE and must stay so: FUCK_API.h pulls in
+// the real imgui.h, which can't coexist with SMF's cimgui ImGuiMCP — hence a separate PCH-free
+// target (devbench-UI-fuck). Drawing routes through FUCK:: wrappers; inert when FUCK is absent
+// (FUCK::Connect returns false).
 
 #define WIN32_LEAN_AND_MEAN
 #define NOMINMAX

--- a/src/RecordingsMenuFuck.cpp
+++ b/src/RecordingsMenuFuck.cpp
@@ -59,6 +59,11 @@ namespace dvb::UI
 			dvb::InvalidateRecordingsCache();
 		}
 
+		// FUCK stores a bind's modifier in kMod1 as a raw keyboard DXScanCode (its KB_MODS), NOT the
+		// Modifier enum. devbench's sink only honors Shift, so recognize left/right Shift by scancode.
+		constexpr int kLeftShiftDX = 0x2A, kRightShiftDX = 0x36;
+		bool          IsShiftMod(std::int32_t a_mod) { return a_mod == kLeftShiftDX || a_mod == kRightShiftDX; }
+
 		// Apply a completed rebind (called when UpdateManagedHotkey signals a captured key). Only Shift
 		// and keyboard binds are supported, so a Ctrl/Alt or gamepad bind is rejected with a warning.
 		void ApplyBind(FUCK::ManagedHotkey& a_h, bool a_isRecord, std::string& a_warn)
@@ -67,12 +72,12 @@ namespace dvb::UI
 				a_warn = "keyboard only — bind ignored";
 				return;
 			}
-			if (a_h.kMod2 != -1 || (a_h.kMod1 != -1 && a_h.kMod1 != static_cast<int>(FUCK::Modifier::kShift))) {
+			if (a_h.kMod2 != -1 || (a_h.kMod1 != -1 && !IsShiftMod(a_h.kMod1))) {
 				a_warn = "only Shift modifier supported";
 				return;
 			}
 			a_warn.clear();
-			const bool shift = a_h.kMod1 == static_cast<int>(FUCK::Modifier::kShift);
+			const bool shift = IsShiftMod(a_h.kMod1);
 			if (a_isRecord)
 				dvb::SetRecordHotkey(static_cast<int>(a_h.kKey), shift);
 			else
@@ -264,9 +269,9 @@ namespace dvb::UI
 					bool recShift = false, repShift = false;
 					dvb::GetHotkeys(recKey, recShift, repKey, repShift);
 					m_recordHK.kKey = static_cast<std::uint32_t>(recKey);
-					m_recordHK.kMod1 = recShift ? static_cast<int>(FUCK::Modifier::kShift) : -1;
+					m_recordHK.kMod1 = recShift ? kLeftShiftDX : -1;
 					m_replayHK.kKey = static_cast<std::uint32_t>(repKey);
-					m_replayHK.kMod1 = repShift ? static_cast<int>(FUCK::Modifier::kShift) : -1;
+					m_replayHK.kMod1 = repShift ? kLeftShiftDX : -1;
 					m_seeded = true;
 				}
 				// Click a widget to rebind; capture + apply happen in OnAsyncInput.

--- a/src/RecordingsMenuFuck.cpp
+++ b/src/RecordingsMenuFuck.cpp
@@ -59,14 +59,10 @@ namespace dvb::UI
 			dvb::InvalidateRecordingsCache();
 		}
 
-		// Apply a completed rebind. FUCK owns the capture (DrawManagedHotkey + OnAsyncInput); once it
-		// finishes (isBinding clears, kKey changed) push the new bind to the sink + config. Only Shift
+		// Apply a completed rebind (called when UpdateManagedHotkey signals a captured key). Only Shift
 		// and keyboard binds are supported, so a Ctrl/Alt or gamepad bind is rejected with a warning.
-		void ApplyBind(FUCK::ManagedHotkey& a_h, std::uint32_t& a_last, bool a_isRecord, std::string& a_warn)
+		void ApplyBind(FUCK::ManagedHotkey& a_h, bool a_isRecord, std::string& a_warn)
 		{
-			if (a_h.isBinding || a_h.kKey == a_last)
-				return;
-			a_last = a_h.kKey;
 			if (a_h.kKey == 0) {
 				a_warn = "keyboard only — bind ignored";
 				return;
@@ -81,6 +77,7 @@ namespace dvb::UI
 				dvb::SetRecordHotkey(static_cast<int>(a_h.kKey), shift);
 			else
 				dvb::SetReplayHotkey(static_cast<int>(a_h.kKey), shift);
+			logger::info("devbench: rebound {} hotkey to key {} (shift={})", a_isRecord ? "record" : "replay", a_h.kKey, shift);
 		}
 
 		// A FUCK sidebar tool (grouped under "devbench") that browses/manages the recording library
@@ -91,16 +88,29 @@ namespace dvb::UI
 			const char* Name() const override { return "Recordings"; }
 			const char* Group() const override { return "devbench"; }
 
-			// Feed input events to a hotkey being rebound. We NEVER call ProcessManagedHotkey, so a
-			// managed hotkey never fires an action — firing stays the raw sink (zero double-fire).
+			// Feed every input event to the managed hotkeys (unconditional, mirroring FUCK's own
+			// SettingsTool): UpdateManagedHotkey captures only while one is binding and returns true when
+			// a bind completes — then apply it. We NEVER call ProcessManagedHotkey, so nothing fires here
+			// (firing stays the raw sink; zero double-fire).
 			bool OnAsyncInput(const void* a_event) override
 			{
-				bool used = false;
-				if (m_recordHK.isBinding)
-					used |= FUCK::UpdateManagedHotkey(a_event, m_recordHK);
-				if (m_replayHK.isBinding)
-					used |= FUCK::UpdateManagedHotkey(a_event, m_replayHK);
-				return used;
+				bool consumed = false;
+				if (FUCK::UpdateManagedHotkey(a_event, m_recordHK)) {
+					ApplyBind(m_recordHK, true, m_recordWarn);
+					consumed = true;
+				}
+				if (FUCK::UpdateManagedHotkey(a_event, m_replayHK)) {
+					ApplyBind(m_replayHK, false, m_replayWarn);
+					consumed = true;
+				}
+				return consumed;
+			}
+
+			// Abort any in-progress rebind when the menu closes, so a hotkey isn't left stuck binding.
+			void OnClose() override
+			{
+				FUCK::AbortManagedHotkey(m_recordHK);
+				FUCK::AbortManagedHotkey(m_replayHK);
 			}
 
 			void Draw() override
@@ -207,7 +217,8 @@ namespace dvb::UI
 					FUCK::TableNextRow();
 					FUCK::TableNextColumn();
 					bool sel = m_selected.count(row.file) > 0;
-					if (FUCK::Checkbox(("##sel" + row.file).c_str(), &sel)) {
+					// alignFar/labelLeft = false: draw the box at the cell's left, not pushed off-column.
+					if (FUCK::Checkbox(("##sel" + row.file).c_str(), &sel, false, false)) {
 						if (sel)
 							m_selected.insert(row.file);
 						else
@@ -256,16 +267,13 @@ namespace dvb::UI
 					m_recordHK.kMod1 = recShift ? static_cast<int>(FUCK::Modifier::kShift) : -1;
 					m_replayHK.kKey = static_cast<std::uint32_t>(repKey);
 					m_replayHK.kMod1 = repShift ? static_cast<int>(FUCK::Modifier::kShift) : -1;
-					m_lastRecordKey = m_recordHK.kKey;
-					m_lastReplayKey = m_replayHK.kKey;
 					m_seeded = true;
 				}
+				// Click a widget to rebind; capture + apply happen in OnAsyncInput.
 				FUCK::DrawManagedHotkey("Record", m_recordHK);
-				ApplyBind(m_recordHK, m_lastRecordKey, true, m_recordWarn);
 				if (!m_recordWarn.empty())
 					FUCK::TextColored(kRed, "%s", m_recordWarn.c_str());
 				FUCK::DrawManagedHotkey("Replay", m_replayHK);
-				ApplyBind(m_replayHK, m_lastReplayKey, false, m_replayWarn);
 				if (!m_replayWarn.empty())
 					FUCK::TextColored(kRed, "%s", m_replayWarn.c_str());
 			}
@@ -276,7 +284,6 @@ namespace dvb::UI
 			ui::SortKey           m_sortKey = ui::SortKey::Name;
 			bool                  m_sortAsc = true;
 			FUCK::ManagedHotkey   m_recordHK, m_replayHK;
-			std::uint32_t         m_lastRecordKey = 0, m_lastReplayKey = 0;
 			bool                  m_seeded = false;
 			std::string           m_recordWarn, m_replayWarn;
 		};

--- a/src/RecordingsMenuFuck.cpp
+++ b/src/RecordingsMenuFuck.cpp
@@ -34,30 +34,6 @@ namespace dvb::UI
 		const ImVec4 kGreen{ 0.40f, 0.85f, 0.45f, 1.0f };
 		const ImVec4 kRed{ 1.0f, 0.45f, 0.45f, 1.0f };
 
-		// Replay a recording (empty path → most recent). ASYNC by default so the call returns
-		// immediately — a blocking replay here would stall the render thread.
-		void ReplayPath(const std::string& a_path)
-		{
-			json args{ { "action", "replay" }, { "restoreScene", true }, { "force", true } };
-			if (!a_path.empty())
-				args["path"] = a_path;
-			dvb::RunTool("record", args);
-		}
-
-		void Validate(const std::string& a_file, bool a_value, bool a_invalidate = true)
-		{
-			dvb::RunTool("recordings", json{ { "action", "validate" }, { "file", a_file }, { "value", a_value } });
-			if (a_invalidate)
-				dvb::InvalidateRecordingsCache();
-		}
-
-		void Delete(const std::string& a_file, bool a_invalidate = true)
-		{
-			dvb::RunTool("recordings", json{ { "action", "delete" }, { "file", a_file } });
-			if (a_invalidate)
-				dvb::InvalidateRecordingsCache();
-		}
-
 		// FUCK stores a bind's modifier in kMod1 as a raw keyboard DXScanCode (its KB_MODS), NOT the
 		// Modifier enum. devbench's sink only honors Shift, so recognize left/right Shift by scancode.
 		constexpr int kLeftShiftDX = 0x2A, kRightShiftDX = 0x36;
@@ -125,6 +101,8 @@ namespace dvb::UI
 				FUCK::Spacing();
 				if (FUCK::Button("Replay last"))
 					ReplayPath("");
+				if (!m_lastError.empty())
+					FUCK::TextColored(kRed, "action failed: %s", m_lastError.c_str());
 				FUCK::Separator();
 
 				const json list = dvb::ListRecordingsCached();
@@ -140,19 +118,28 @@ namespace dvb::UI
 			}
 
 		private:
+			// Thin wrappers over the shared imgui-free helpers that capture any error for the page.
+			void ReplayPath(const std::string& a_path) { m_lastError = ui::Replay(a_path); }
+			void Validate(const std::string& a_file, bool a_value, bool a_invalidate = true) { m_lastError = ui::Validate(a_file, a_value, a_invalidate); }
+			void Delete(const std::string& a_file, bool a_invalidate = true) { m_lastError = ui::Delete(a_file, a_invalidate); }
+
 			void RenderActionBar()
 			{
 				FUCK::InputText("##filter", m_filter, sizeof m_filter);
 				FUCK::BeginDisabled(m_selected.empty());
 				if (FUCK::Button("Validate selected")) {
+					m_lastError.clear();
 					for (const auto& f : m_selected)
-						Validate(f, true, false);
+						if (const auto e = ui::Validate(f, true, false); m_lastError.empty())
+							m_lastError = e;
 					dvb::InvalidateRecordingsCache();
 				}
 				FUCK::SameLine();
 				if (FUCK::Button("Unvalidate selected")) {
+					m_lastError.clear();
 					for (const auto& f : m_selected)
-						Validate(f, false, false);
+						if (const auto e = ui::Validate(f, false, false); m_lastError.empty())
+							m_lastError = e;
 					dvb::InvalidateRecordingsCache();
 				}
 				FUCK::SameLine();
@@ -164,8 +151,10 @@ namespace dvb::UI
 					FUCK::TextColored(kRed, "delete %d?", static_cast<int>(m_selected.size()));
 					FUCK::SameLine();
 					if (FUCK::Button("Yes##confdel")) {
+						m_lastError.clear();
 						for (const auto& f : m_selected)
-							Delete(f, false);
+							if (const auto e = ui::Delete(f, false); m_lastError.empty())
+								m_lastError = e;
 						dvb::InvalidateRecordingsCache();
 						m_selected.clear();
 						m_confirmDelete = false;
@@ -295,6 +284,7 @@ namespace dvb::UI
 			FUCK::ManagedHotkey   m_recordHK, m_replayHK;
 			bool                  m_seeded = false;
 			std::string           m_recordWarn, m_replayWarn;
+			std::string           m_lastError;  // last failed action, shown red until the next action
 		};
 
 		// Registered by pointer with FUCK; must outlive registration → static storage.

--- a/src/RecordingsMenuFuck.cpp
+++ b/src/RecordingsMenuFuck.cpp
@@ -44,16 +44,18 @@ namespace dvb::UI
 			dvb::RunTool("record", args);
 		}
 
-		void Validate(const std::string& a_file, bool a_value)
+		void Validate(const std::string& a_file, bool a_value, bool a_invalidate = true)
 		{
 			dvb::RunTool("recordings", json{ { "action", "validate" }, { "file", a_file }, { "value", a_value } });
-			dvb::InvalidateRecordingsCache();
+			if (a_invalidate)
+				dvb::InvalidateRecordingsCache();
 		}
 
-		void Delete(const std::string& a_file)
+		void Delete(const std::string& a_file, bool a_invalidate = true)
 		{
 			dvb::RunTool("recordings", json{ { "action", "delete" }, { "file", a_file } });
-			dvb::InvalidateRecordingsCache();
+			if (a_invalidate)
+				dvb::InvalidateRecordingsCache();
 		}
 
 		// FUCK stores a bind's modifier in kMod1 as a raw keyboard DXScanCode (its KB_MODS), NOT the
@@ -142,13 +144,17 @@ namespace dvb::UI
 			{
 				FUCK::InputText("##filter", m_filter, sizeof m_filter);
 				FUCK::BeginDisabled(m_selected.empty());
-				if (FUCK::Button("Validate selected"))
+				if (FUCK::Button("Validate selected")) {
 					for (const auto& f : m_selected)
-						Validate(f, true);
+						Validate(f, true, false);
+					dvb::InvalidateRecordingsCache();
+				}
 				FUCK::SameLine();
-				if (FUCK::Button("Unvalidate selected"))
+				if (FUCK::Button("Unvalidate selected")) {
 					for (const auto& f : m_selected)
-						Validate(f, false);
+						Validate(f, false, false);
+					dvb::InvalidateRecordingsCache();
+				}
 				FUCK::SameLine();
 				if (FUCK::Button("Delete selected"))
 					m_confirmDelete = true;
@@ -159,7 +165,8 @@ namespace dvb::UI
 					FUCK::SameLine();
 					if (FUCK::Button("Yes##confdel")) {
 						for (const auto& f : m_selected)
-							Delete(f);
+							Delete(f, false);
+						dvb::InvalidateRecordingsCache();
 						m_selected.clear();
 						m_confirmDelete = false;
 					}

--- a/src/RecordingsMenuFuck.cpp
+++ b/src/RecordingsMenuFuck.cpp
@@ -23,6 +23,7 @@
 #include <cstdint>
 #include <set>
 #include <string>
+#include <vector>
 
 namespace logger = SKSE::log;
 
@@ -38,6 +39,12 @@ namespace dvb::UI
 		// Modifier enum. devbench's sink only honors Shift, so recognize left/right Shift by scancode.
 		constexpr int kLeftShiftDX = 0x2A, kRightShiftDX = 0x36;
 		bool          IsShiftMod(std::int32_t a_mod) { return a_mod == kLeftShiftDX || a_mod == kRightShiftDX; }
+
+		void Tooltip(const char* a_text)
+		{
+			if (FUCK::IsItemHovered(0))
+				FUCK::SetTooltip(a_text);
+		}
 
 		// Apply a completed rebind (called when UpdateManagedHotkey signals a captured key). Only Shift
 		// and keyboard binds are supported, so a Ctrl/Alt or gamepad bind is rejected with a warning.
@@ -95,14 +102,13 @@ namespace dvb::UI
 
 			void Draw() override
 			{
-				FUCK::TextWrapped(
-					"Replay a captured trajectory against the current build. Replay is async; it "
-					"restores the recorded scene first (force = run anyway on a mismatch).");
-				FUCK::Spacing();
-				if (FUCK::Button("Replay last"))
-					ReplayPath("");
-				if (!m_lastError.empty())
-					FUCK::TextColored(kRed, "action failed: %s", m_lastError.c_str());
+				RenderHotkeys();  // always visible at the top — rebinding is the least discoverable feature
+				FUCK::Separator();
+
+				if (FUCK::Button("Replay most recent"))
+					ReplayAction("");
+				Tooltip("Replay the most recently recorded trajectory against the current build (async).");
+				RenderStatus();
 				FUCK::Separator();
 
 				const json list = dvb::ListRecordingsCached();
@@ -112,151 +118,63 @@ namespace dvb::UI
 				}
 				const std::string dir = list.value("dir", std::string{});
 
-				RenderActionBar();
-				RenderTable(list, dir);
-				RenderKeybinds();
+				FUCK::Text("Filter");
+				FUCK::SameLine();
+				FUCK::InputText("##filter", m_filter, sizeof m_filter);
+
+				const auto rows = ui::BuildRows(list, m_filter, m_sortKey, m_sortAsc);
+				RenderBulkBar(rows);
+
+				if (rows.empty()) {
+					RenderEmptyState();
+					return;
+				}
+				RenderTable(rows, dir);
 			}
 
 		private:
-			// Thin wrappers over the shared imgui-free helpers that capture any error for the page.
-			void ReplayPath(const std::string& a_path) { m_lastError = ui::Replay(a_path); }
-			void Validate(const std::string& a_file, bool a_value, bool a_invalidate = true) { m_lastError = ui::Validate(a_file, a_value, a_invalidate); }
-			void Delete(const std::string& a_file, bool a_invalidate = true) { m_lastError = ui::Delete(a_file, a_invalidate); }
-
-			void RenderActionBar()
+			// --- action wrappers: drive the shared helper, then set the status/error line ---
+			void ReplayAction(const std::string& a_path)
 			{
-				FUCK::InputText("##filter", m_filter, sizeof m_filter);
-				FUCK::BeginDisabled(m_selected.empty());
-				if (FUCK::Button("Validate selected")) {
-					m_lastError.clear();
-					for (const auto& f : m_selected)
-						if (const auto e = ui::Validate(f, true, false); m_lastError.empty())
-							m_lastError = e;
-					dvb::InvalidateRecordingsCache();
-				}
-				FUCK::SameLine();
-				if (FUCK::Button("Unvalidate selected")) {
-					m_lastError.clear();
-					for (const auto& f : m_selected)
-						if (const auto e = ui::Validate(f, false, false); m_lastError.empty())
-							m_lastError = e;
-					dvb::InvalidateRecordingsCache();
-				}
-				FUCK::SameLine();
-				if (FUCK::Button("Delete selected"))
-					m_confirmDelete = true;
-				FUCK::EndDisabled();
-				if (m_confirmDelete && !m_selected.empty()) {
-					FUCK::SameLine();
-					FUCK::TextColored(kRed, "delete %d?", static_cast<int>(m_selected.size()));
-					FUCK::SameLine();
-					if (FUCK::Button("Yes##confdel")) {
-						m_lastError.clear();
-						for (const auto& f : m_selected)
-							if (const auto e = ui::Delete(f, false); m_lastError.empty())
-								m_lastError = e;
-						dvb::InvalidateRecordingsCache();
-						m_selected.clear();
-						m_confirmDelete = false;
-					}
-					FUCK::SameLine();
-					if (FUCK::Button("No##confdel"))
-						m_confirmDelete = false;
-				}
-				FUCK::SameLine();
-				if (FUCK::Button("Open folder"))
-					dvb::OpenRecordingsFolder();
+				if (const std::string e = ui::Replay(a_path); e.empty())
+					SetStatus("Replay started");
+				else
+					SetError("Replay failed: " + e);
+			}
+			void ValidateAction(const std::string& a_file, bool a_value)
+			{
+				if (const std::string e = ui::Validate(a_file, a_value); e.empty())
+					SetStatus((a_value ? "Validated " : "Unvalidated ") + a_file);
+				else
+					SetError("Validate failed: " + e);
+			}
+			void DeleteAction(const std::string& a_file)
+			{
+				if (const std::string e = ui::Delete(a_file); e.empty())
+					SetStatus("Deleted " + a_file);
+				else
+					SetError("Delete failed: " + e);
+			}
+			void SetStatus(const std::string& a_s)
+			{
+				m_lastStatus = a_s;
+				m_lastError.clear();
+			}
+			void SetError(const std::string& a_e)
+			{
+				m_lastError = a_e;
+				m_lastStatus.clear();
+			}
+			void RenderStatus()
+			{
+				if (!m_lastError.empty())
+					FUCK::TextColored(kRed, "%s", m_lastError.c_str());
+				else if (!m_lastStatus.empty())
+					FUCK::TextColored(kGreen, "%s", m_lastStatus.c_str());
 			}
 
-			// Manual sortable header — FUCK exposes no TableGetSortSpecs, so a clicked header cell
-			// toggles our own sort state that feeds ui::BuildRows.
-			void HeaderCell(int a_col, const char* a_title, ui::SortKey a_key)
+			void RenderHotkeys()
 			{
-				FUCK::TableNextColumn();
-				std::string label = a_title;
-				if (m_sortKey == a_key)
-					label += m_sortAsc ? " ^" : " v";
-				if (FUCK::Selectable((label + "##h" + std::to_string(a_col)).c_str())) {
-					if (m_sortKey == a_key)
-						m_sortAsc = !m_sortAsc;
-					else {
-						m_sortKey = a_key;
-						m_sortAsc = true;
-					}
-				}
-			}
-
-			void RenderTable(const json& a_list, const std::string& a_dir)
-			{
-				const FUCK::TableFlags flags = FUCK::TableFlags::kResizable | FUCK::TableFlags::kRowBg |
-				                               FUCK::TableFlags::kBordersInnerH;
-				if (!FUCK::BeginTable("recs", 8, flags))
-					return;
-				FUCK::TableSetupColumn("##sel");
-				FUCK::TableSetupColumn("Name");
-				FUCK::TableSetupColumn("Where");
-				FUCK::TableSetupColumn("Start");
-				FUCK::TableSetupColumn("Time");
-				FUCK::TableSetupColumn("Fmt");
-				FUCK::TableSetupColumn("Val");
-				FUCK::TableSetupColumn("Actions");
-
-				FUCK::TableNextRow();
-				FUCK::TableNextColumn();  // select column: no sort
-				HeaderCell(1, "Name", ui::SortKey::Name);
-				HeaderCell(2, "Where", ui::SortKey::Where);
-				HeaderCell(3, "Start", ui::SortKey::Start);
-				HeaderCell(4, "Time", ui::SortKey::Time);
-				HeaderCell(5, "Fmt", ui::SortKey::Format);
-				HeaderCell(6, "Val", ui::SortKey::Validated);
-				FUCK::TableNextColumn();  // actions column: no sort
-
-				for (const auto& row : ui::BuildRows(a_list, m_filter, m_sortKey, m_sortAsc)) {
-					FUCK::TableNextRow();
-					FUCK::TableNextColumn();
-					bool sel = m_selected.count(row.file) > 0;
-					// alignFar/labelLeft = false: draw the box at the cell's left, not pushed off-column.
-					if (FUCK::Checkbox(("##sel" + row.file).c_str(), &sel, false, false)) {
-						if (sel)
-							m_selected.insert(row.file);
-						else
-							m_selected.erase(row.file);
-					}
-					FUCK::TableNextColumn();
-					FUCK::Text("%s", row.name.c_str());
-					FUCK::TableNextColumn();
-					FUCK::Text("%s", row.where.c_str());
-					FUCK::TableNextColumn();
-					if (row.restorable)
-						FUCK::Text("%s", row.startText.c_str());
-					else
-						FUCK::TextColored(kRed, "%s", row.startText.c_str());
-					FUCK::TableNextColumn();
-					FUCK::Text("%s", row.timeText.c_str());
-					FUCK::TableNextColumn();
-					FUCK::Text("%s", row.format.c_str());
-					FUCK::TableNextColumn();
-					FUCK::TextColored(row.validated ? kGreen : kGrey, row.validated ? "yes" : "no");
-					FUCK::TableNextColumn();
-					const std::string id = "##" + row.file;
-					if (FUCK::Button(("Replay" + id).c_str()))
-						ReplayPath(a_dir + "/" + row.file);
-					FUCK::SameLine();
-					if (FUCK::Button(((row.validated ? "Unval" : "Val") + id).c_str()))
-						Validate(row.file, !row.validated);
-					FUCK::SameLine();
-					if (FUCK::Button(("Del" + id).c_str())) {
-						Delete(row.file);
-						m_selected.erase(row.file);
-					}
-				}
-				FUCK::EndTable();
-			}
-
-			void RenderKeybinds()
-			{
-				if (!FUCK::CollapsingHeader("Keybinds"))
-					return;
 				if (!m_seeded) {
 					int  recKey = 0, repKey = 0;
 					bool recShift = false, repShift = false;
@@ -267,7 +185,8 @@ namespace dvb::UI
 					m_replayHK.kMod1 = repShift ? kLeftShiftDX : -1;
 					m_seeded = true;
 				}
-				// Click a widget to rebind; capture + apply happen in OnAsyncInput.
+				// Click a widget then press a key to rebind; capture + apply happen in OnAsyncInput.
+				FUCK::Text("Hotkeys (click, then press a key to rebind):");
 				FUCK::DrawManagedHotkey("Record", m_recordHK);
 				if (!m_recordWarn.empty())
 					FUCK::TextColored(kRed, "%s", m_recordWarn.c_str());
@@ -276,15 +195,205 @@ namespace dvb::UI
 					FUCK::TextColored(kRed, "%s", m_replayWarn.c_str());
 			}
 
+			void RenderEmptyState()
+			{
+				if (m_filter[0]) {
+					FUCK::TextColored(kGrey, "No matches for \"%s\"", m_filter);
+					return;
+				}
+				int  recKey = 0, repKey = 0;
+				bool recShift = false, repShift = false;
+				dvb::GetHotkeys(recKey, recShift, repKey, repShift);
+				FUCK::TextColored(kGrey, "No recordings yet — press %s to record.", ui::KeyName(recKey).c_str());
+			}
+
+			// Select-all + bulk actions over the currently-filtered rows.
+			void RenderBulkBar(const std::vector<ui::Row>& a_rows)
+			{
+				if (FUCK::Button("All"))
+					for (const auto& r : a_rows)
+						m_selected.insert(r.file);
+				FUCK::SameLine();
+				if (FUCK::Button("None"))
+					m_selected.clear();
+				FUCK::SameLine();
+				FUCK::Text("(%d selected)", static_cast<int>(m_selected.size()));
+
+				FUCK::BeginDisabled(m_selected.empty());
+				FUCK::SameLine();
+				if (FUCK::Button("Validate selected"))
+					BulkValidate(true);
+				FUCK::SameLine();
+				if (FUCK::Button("Unvalidate selected"))
+					BulkValidate(false);
+				FUCK::SameLine();
+				if (FUCK::Button("Delete selected"))
+					m_confirmBulkDelete = true;
+				FUCK::EndDisabled();
+				if (m_confirmBulkDelete && !m_selected.empty()) {
+					FUCK::SameLine();
+					FUCK::TextColored(kRed, "delete %d?", static_cast<int>(m_selected.size()));
+					FUCK::SameLine();
+					if (FUCK::Button("Yes##confdel")) {
+						BulkDelete();
+						m_confirmBulkDelete = false;
+					}
+					FUCK::SameLine();
+					if (FUCK::Button("No##confdel"))
+						m_confirmBulkDelete = false;
+				}
+				FUCK::SameLine();
+				if (FUCK::Button("Open folder"))
+					dvb::OpenRecordingsFolder();
+			}
+
+			void BulkValidate(bool a_value)
+			{
+				int         fail = 0;
+				std::string first;
+				for (const auto& f : m_selected)
+					if (const std::string e = ui::Validate(f, a_value, false); !e.empty()) {
+						++fail;
+						if (first.empty())
+							first = e;
+					}
+				dvb::InvalidateRecordingsCache();
+				ReportBulk(fail, static_cast<int>(m_selected.size()), a_value ? "validated" : "unvalidated", first);
+			}
+			void BulkDelete()
+			{
+				int         fail = 0;
+				std::string first;
+				for (const auto& f : m_selected)
+					if (const std::string e = ui::Delete(f, false); !e.empty()) {
+						++fail;
+						if (first.empty())
+							first = e;
+					}
+				dvb::InvalidateRecordingsCache();
+				ReportBulk(fail, static_cast<int>(m_selected.size()), "deleted", first);
+				m_selected.clear();
+			}
+			void ReportBulk(int a_fail, int a_total, const char* a_verb, const std::string& a_first)
+			{
+				if (a_fail == 0)
+					SetStatus(std::to_string(a_total) + " " + a_verb);
+				else
+					SetError(std::to_string(a_fail) + " of " + std::to_string(a_total) + " " + a_verb + " failed: " + a_first);
+			}
+
+			// Manual sortable header — FUCK exposes no TableGetSortSpecs. A trailing marker shows the
+			// active sort (^/v) and that the others are clickable (-).
+			void HeaderCell(int a_col, const char* a_title, ui::SortKey a_key)
+			{
+				FUCK::TableNextColumn();
+				std::string label = a_title;
+				label += m_sortKey == a_key ? (m_sortAsc ? " ^" : " v") : " -";
+				if (FUCK::Selectable((label + "##h" + std::to_string(a_col)).c_str())) {
+					if (m_sortKey == a_key)
+						m_sortAsc = !m_sortAsc;
+					else {
+						m_sortKey = a_key;
+						m_sortAsc = true;
+					}
+				}
+			}
+
+			void RenderTable(const std::vector<ui::Row>& a_rows, const std::string& a_dir)
+			{
+				FUCK::TextColored(kGrey, "click a column header to sort");
+				const FUCK::TableFlags flags = FUCK::TableFlags::kResizable | FUCK::TableFlags::kRowBg |
+				                               FUCK::TableFlags::kBordersInnerH;
+				if (!FUCK::BeginTable("recs", 7, flags))
+					return;
+				FUCK::TableSetupColumn("Sel");
+				FUCK::TableSetupColumn("Name");
+				FUCK::TableSetupColumn("Where");
+				FUCK::TableSetupColumn("Start");
+				FUCK::TableSetupColumn("Time");
+				FUCK::TableSetupColumn("Valid");
+				FUCK::TableSetupColumn("Actions");
+
+				FUCK::TableNextRow();
+				FUCK::TableNextColumn();  // select column: no sort
+				FUCK::Text("Sel");
+				HeaderCell(1, "Name", ui::SortKey::Name);
+				HeaderCell(2, "Where", ui::SortKey::Where);
+				HeaderCell(3, "Start", ui::SortKey::Start);
+				HeaderCell(4, "Time", ui::SortKey::Time);
+				HeaderCell(6, "Valid", ui::SortKey::Validated);
+				FUCK::TableNextColumn();  // actions column: no sort
+
+				for (const auto& row : a_rows) {
+					FUCK::TableNextRow();
+					FUCK::TableNextColumn();
+					bool sel = m_selected.count(row.file) > 0;
+					if (FUCK::Checkbox(("##sel" + row.file).c_str(), &sel, false, false)) {
+						if (sel)
+							m_selected.insert(row.file);
+						else
+							m_selected.erase(row.file);
+					}
+					FUCK::TableNextColumn();
+					FUCK::Text("%s", row.name.c_str());
+					Tooltip(("format: " + row.format).c_str());
+					FUCK::TableNextColumn();
+					FUCK::Text("%s", row.where.c_str());
+					FUCK::TableNextColumn();
+					if (row.restorable)
+						FUCK::Text("%s", row.startText.c_str());
+					else {
+						FUCK::TextColored(kRed, "%s", row.startText.c_str());
+						Tooltip("No save/coc entry captured — replay can't restore the starting scene; comparisons may be unreliable.");
+					}
+					FUCK::TableNextColumn();
+					FUCK::Text("%s", row.timeText.c_str());
+					FUCK::TableNextColumn();
+					FUCK::TextColored(row.validated ? kGreen : kGrey, row.validated ? "yes" : "no");
+					FUCK::TableNextColumn();
+					RenderRowActions(row, a_dir);
+				}
+				FUCK::EndTable();
+			}
+
+			void RenderRowActions(const ui::Row& a_row, const std::string& a_dir)
+			{
+				const std::string id = "##" + a_row.file;
+				if (FUCK::Button(("Replay" + id).c_str()))
+					ReplayAction(a_dir + "/" + a_row.file);
+				Tooltip("Replay this recording.");
+				FUCK::SameLine();
+				if (FUCK::Button(((a_row.validated ? "Unvalidate" : "Validate") + id).c_str()))
+					ValidateAction(a_row.file, !a_row.validated);
+				Tooltip("Mark this recording validated / not.");
+				FUCK::SameLine();
+				// Per-row delete needs a confirm too (bulk delete already does).
+				if (m_confirmDeleteFile == a_row.file) {
+					if (FUCK::Button(("Yes" + id).c_str())) {
+						DeleteAction(a_row.file);
+						m_selected.erase(a_row.file);
+						m_confirmDeleteFile.clear();
+					}
+					FUCK::SameLine();
+					if (FUCK::Button(("No" + id).c_str()))
+						m_confirmDeleteFile.clear();
+				} else {
+					if (FUCK::Button(("Delete" + id).c_str()))
+						m_confirmDeleteFile = a_row.file;
+					Tooltip("Delete this recording (asks to confirm).");
+				}
+			}
+
 			char                  m_filter[128]{};
 			std::set<std::string> m_selected;
-			bool                  m_confirmDelete = false;
+			bool                  m_confirmBulkDelete = false;
+			std::string           m_confirmDeleteFile;  // the row awaiting a delete confirm
 			ui::SortKey           m_sortKey = ui::SortKey::Name;
 			bool                  m_sortAsc = true;
 			FUCK::ManagedHotkey   m_recordHK, m_replayHK;
 			bool                  m_seeded = false;
 			std::string           m_recordWarn, m_replayWarn;
-			std::string           m_lastError;  // last failed action, shown red until the next action
+			std::string           m_lastError, m_lastStatus;  // last action outcome (red / green)
 		};
 
 		// Registered by pointer with FUCK; must outlive registration → static storage.

--- a/src/RecordingsView.cpp
+++ b/src/RecordingsView.cpp
@@ -4,6 +4,7 @@
 
 #include <algorithm>
 #include <cctype>
+#include <utility>
 
 namespace dvb::ui
 {
@@ -120,5 +121,79 @@ namespace dvb::ui
 		if (a_invalidate)
 			dvb::InvalidateRecordingsCache();
 		return r.value("error", std::string{});
+	}
+
+	std::string KeyName(int a_code)
+	{
+		if (a_code == 0)
+			return "(unset)";
+		switch (a_code) {
+		case 1:
+			return "Esc";
+		case 14:
+			return "Backspace";
+		case 15:
+			return "Tab";
+		case 28:
+			return "Enter";
+		case 29:
+			return "LCtrl";
+		case 42:
+			return "LShift";
+		case 54:
+			return "RShift";
+		case 56:
+			return "LAlt";
+		case 57:
+			return "Space";
+		case 58:
+			return "CapsLock";
+		case 157:
+			return "RCtrl";
+		case 184:
+			return "RAlt";
+		case 199:
+			return "Home";
+		case 200:
+			return "Up";
+		case 201:
+			return "PageUp";
+		case 203:
+			return "Left";
+		case 205:
+			return "Right";
+		case 207:
+			return "End";
+		case 208:
+			return "Down";
+		case 209:
+			return "PageDown";
+		case 210:
+			return "Insert";
+		case 211:
+			return "Delete";
+		default:
+			break;
+		}
+		if (a_code >= 2 && a_code <= 10)  // top-row 1..9
+			return std::string(1, static_cast<char>('1' + (a_code - 2)));
+		if (a_code == 11)
+			return "0";
+		if (a_code >= 59 && a_code <= 68)  // F1..F10
+			return "F" + std::to_string(a_code - 58);
+		if (a_code == 87)
+			return "F11";
+		if (a_code == 88)
+			return "F12";
+		// Letters, in DirectInput scancode layout order (not alphabetical).
+		static const std::pair<int, const char*> letters[] = {
+			{ 16, "Q" }, { 17, "W" }, { 18, "E" }, { 19, "R" }, { 20, "T" }, { 21, "Y" }, { 22, "U" }, { 23, "I" }, { 24, "O" }, { 25, "P" },
+			{ 30, "A" }, { 31, "S" }, { 32, "D" }, { 33, "F" }, { 34, "G" }, { 35, "H" }, { 36, "J" }, { 37, "K" }, { 38, "L" },
+			{ 44, "Z" }, { 45, "X" }, { 46, "C" }, { 47, "V" }, { 48, "B" }, { 49, "N" }, { 50, "M" }
+		};
+		for (const auto& [code, name] : letters)
+			if (code == a_code)
+				return name;
+		return "key " + std::to_string(a_code);
 	}
 }

--- a/src/RecordingsView.cpp
+++ b/src/RecordingsView.cpp
@@ -1,0 +1,92 @@
+#include "RecordingsView.h"
+
+#include <algorithm>
+#include <cctype>
+
+namespace dvb::ui
+{
+	namespace
+	{
+		std::string Lower(std::string a_s)
+		{
+			std::transform(a_s.begin(), a_s.end(), a_s.begin(),
+				[](unsigned char c) { return static_cast<char>(std::tolower(c)); });
+			return a_s;
+		}
+	}
+
+	std::string FormatDuration(long long a_ms)
+	{
+		const long long s = a_ms / 1000;
+		if (s <= 0)
+			return "0s";
+		const long long m = s / 60;
+		return m > 0 ? std::to_string(m) + "m" + std::to_string(s % 60) + "s" : std::to_string(s) + "s";
+	}
+
+	std::string FormatStart(const json& a_entry)
+	{
+		const std::string kind = a_entry.value("kind", std::string{});
+		if (kind == "save" || kind == "coc")
+			return kind + ": " + a_entry.value("value", std::string{});
+		return "no restore point";
+	}
+
+	std::string FormatWhere(const json& a_rec)
+	{
+		std::string where = a_rec.value("worldspace", std::string{});
+		if (where.empty())
+			where = a_rec.value("cell", std::string{});
+		if (a_rec.value("interior", false))
+			where += " (interior)";
+		return where;
+	}
+
+	std::vector<Row> BuildRows(const json& a_list, const std::string& a_filter, SortKey a_key, bool a_ascending)
+	{
+		std::vector<Row>  rows;
+		const std::string needle = Lower(a_filter);
+		if (a_list.contains("recordings") && a_list["recordings"].is_array()) {
+			for (const auto& r : a_list["recordings"]) {
+				if (r.contains("error"))
+					continue;
+				Row row;
+				row.file = r.value("file", std::string{});
+				row.name = r.value("name", row.file);
+				row.format = r.value("format", std::string{ "?" });
+				row.validated = r.value("validated", false);
+				row.recordedMs = r.value("recordedMs", 0LL);
+				row.timeText = FormatDuration(row.recordedMs);
+				row.where = FormatWhere(r);
+				const json entry = r.value("entry", json::object());
+				row.startText = FormatStart(entry);
+				row.restorable = entry.value("kind", std::string{}) != "unknown";
+				if (!needle.empty() &&
+					Lower(row.name + "\n" + row.where + "\n" + row.startText).find(needle) == std::string::npos)
+					continue;
+				rows.push_back(std::move(row));
+			}
+		}
+
+		const auto less = [a_key](const Row& x, const Row& y) {
+			switch (a_key) {
+			case SortKey::Where:
+				return x.where < y.where;
+			case SortKey::Start:
+				return x.startText < y.startText;
+			case SortKey::Time:
+				return x.recordedMs < y.recordedMs;
+			case SortKey::Format:
+				return x.format < y.format;
+			case SortKey::Validated:
+				return x.validated < y.validated;
+			case SortKey::Name:
+			default:
+				return x.name < y.name;
+			}
+		};
+		std::stable_sort(rows.begin(), rows.end(),
+			[&](const Row& x, const Row& y) { return a_ascending ? less(x, y) : less(y, x); });
+		return rows;
+	}
+}

--- a/src/RecordingsView.cpp
+++ b/src/RecordingsView.cpp
@@ -1,5 +1,7 @@
 #include "RecordingsView.h"
 
+#include "Server.h"  // dvb::RunTool / InvalidateRecordingsCache (imgui-free)
+
 #include <algorithm>
 #include <cctype>
 
@@ -50,21 +52,27 @@ namespace dvb::ui
 			for (const auto& r : a_list["recordings"]) {
 				if (r.contains("error"))
 					continue;
-				Row row;
-				row.file = r.value("file", std::string{});
-				row.name = r.value("name", row.file);
-				row.format = r.value("format", std::string{ "?" });
-				row.validated = r.value("validated", false);
-				row.recordedMs = r.value("recordedMs", 0LL);
-				row.timeText = FormatDuration(row.recordedMs);
-				row.where = FormatWhere(r);
-				const json entry = r.value("entry", json::object());
-				row.startText = FormatStart(entry);
-				row.restorable = entry.value("kind", std::string{}) != "unknown";
-				if (!needle.empty() &&
-					Lower(row.name + "\n" + row.where + "\n" + row.startText).find(needle) == std::string::npos)
+				try {
+					// A hand-edited recording with a wrong-type meta field would make .value() throw
+					// on the render thread — skip the bad entry rather than crash the menu.
+					Row row;
+					row.file = r.value("file", std::string{});
+					row.name = r.value("name", row.file);
+					row.format = r.value("format", std::string{ "?" });
+					row.validated = r.value("validated", false);
+					row.recordedMs = r.value("recordedMs", 0LL);
+					row.timeText = FormatDuration(row.recordedMs);
+					row.where = FormatWhere(r);
+					const json entry = r.value("entry", json::object());
+					row.startText = FormatStart(entry);
+					row.restorable = entry.value("kind", std::string{}) != "unknown";
+					if (!needle.empty() &&
+						Lower(row.name + "\n" + row.where + "\n" + row.startText).find(needle) == std::string::npos)
+						continue;
+					rows.push_back(std::move(row));
+				} catch (const std::exception&) {
 					continue;
-				rows.push_back(std::move(row));
+				}
 			}
 		}
 
@@ -88,5 +96,29 @@ namespace dvb::ui
 		std::stable_sort(rows.begin(), rows.end(),
 			[&](const Row& x, const Row& y) { return a_ascending ? less(x, y) : less(y, x); });
 		return rows;
+	}
+
+	std::string Replay(const std::string& a_path)
+	{
+		json args{ { "action", "replay" }, { "restoreScene", true }, { "force", true } };
+		if (!a_path.empty())
+			args["path"] = a_path;
+		return dvb::RunTool("record", args).value("error", std::string{});
+	}
+
+	std::string Validate(const std::string& a_file, bool a_value, bool a_invalidate)
+	{
+		const json r = dvb::RunTool("recordings", json{ { "action", "validate" }, { "file", a_file }, { "value", a_value } });
+		if (a_invalidate)
+			dvb::InvalidateRecordingsCache();
+		return r.value("error", std::string{});
+	}
+
+	std::string Delete(const std::string& a_file, bool a_invalidate)
+	{
+		const json r = dvb::RunTool("recordings", json{ { "action", "delete" }, { "file", a_file } });
+		if (a_invalidate)
+			dvb::InvalidateRecordingsCache();
+		return r.value("error", std::string{});
 	}
 }

--- a/src/RecordingsView.h
+++ b/src/RecordingsView.h
@@ -35,4 +35,10 @@ namespace dvb::ui
 	std::string FormatDuration(long long a_ms);    // 91000 -> "1m31s"; < 1s -> "0s"
 	std::string FormatStart(const json& a_entry);  // "save: X" / "coc: X" / "no restore point"
 	std::string FormatWhere(const json& a_rec);    // worldspace else cell; " (interior)" suffix
+
+	// Menu action helpers (imgui-free — shared by both menu TUs). Each drives a devbench tool and
+	// returns the tool's "error" message, or "" on success, so the caller can surface a failure.
+	std::string Replay(const std::string& a_path);  // async record replay (empty path = most recent)
+	std::string Validate(const std::string& a_file, bool a_value, bool a_invalidate = true);
+	std::string Delete(const std::string& a_file, bool a_invalidate = true);
 }

--- a/src/RecordingsView.h
+++ b/src/RecordingsView.h
@@ -1,0 +1,38 @@
+#pragma once
+
+#include <cstdint>
+#include <string>
+#include <vector>
+
+#include "Json.h"
+
+// Imgui-free projection of the `recordings` list into display rows, shared by both PCH-free menu
+// TUs (SMF cimgui + FUCK real-imgui can't share a TU, but both link this from the main target).
+namespace dvb::ui
+{
+	struct Row
+	{
+		std::string file, name, where, startText, timeText, format;
+		long long   recordedMs = 0;  // numeric key for the Time column (timeText is display-only)
+		bool        validated = false;
+		bool        restorable = true;  // entry.kind != "unknown"
+	};
+
+	enum class SortKey
+	{
+		Name,
+		Where,
+		Start,
+		Time,
+		Format,
+		Validated
+	};
+
+	// Project list["recordings"] into filtered + sorted rows. `filter` is a case-insensitive
+	// substring over name/where/start (empty = all). Entries carrying an "error" are skipped.
+	std::vector<Row> BuildRows(const json& a_list, const std::string& a_filter, SortKey a_key, bool a_ascending);
+
+	std::string FormatDuration(long long a_ms);    // 91000 -> "1m31s"; < 1s -> "0s"
+	std::string FormatStart(const json& a_entry);  // "save: X" / "coc: X" / "no restore point"
+	std::string FormatWhere(const json& a_rec);    // worldspace else cell; " (interior)" suffix
+}

--- a/src/RecordingsView.h
+++ b/src/RecordingsView.h
@@ -35,6 +35,7 @@ namespace dvb::ui
 	std::string FormatDuration(long long a_ms);    // 91000 -> "1m31s"; < 1s -> "0s"
 	std::string FormatStart(const json& a_entry);  // "save: X" / "coc: X" / "no restore point"
 	std::string FormatWhere(const json& a_rec);    // worldspace else cell; " (interior)" suffix
+	std::string KeyName(int a_dxScanCode);         // DXScanCode -> "F1"/"A"/… ; 0 -> "(unset)"
 
 	// Menu action helpers (imgui-free — shared by both menu TUs). Each drives a devbench tool and
 	// returns the tool's "error" message, or "" on success, so the caller can surface a failure.

--- a/src/Server.cpp
+++ b/src/Server.cpp
@@ -12,16 +12,26 @@
 #include <ws2tcpip.h>
 
 #include <atomic>
+#include <chrono>
 #include <filesystem>
 #include <fstream>
+#include <mutex>
 
 namespace
 {
 	std::atomic<int> g_boundPort{ 0 };
 
 	// Process-wide registry pointer so dvb::RunTool can invoke tools from the in-game menu (a
-	// separate render-thread TU) without a Server reference. Set/cleared by Server::Start/Stop.
-	dvb::ToolRegistry* g_registry = nullptr;
+	// separate render-thread TU) without a Server reference. Atomic: written on the SKSE thread
+	// (Start/Stop), read on the render thread (RunTool). Set/cleared by Server::Start/Stop.
+	std::atomic<dvb::ToolRegistry*> g_registry{ nullptr };
+
+	// Throttle for ListRecordingsCached: a menu redraws every frame, and listing fully parses every
+	// recording file, so cache the result and refresh at most ~once/second (or on invalidation).
+	std::mutex                            g_recCacheMtx;
+	dvb::json                             g_recCache;
+	std::chrono::steady_clock::time_point g_recCacheAt{};
+	bool                                  g_recCacheValid = false;
 
 	// True if 127.0.0.1:port can be bound (i.e. it's free). WSAStartup is ref-counted,
 	// so pairing it with WSACleanup here is safe whether or not winsock is already up.
@@ -119,7 +129,7 @@ namespace dvb
 		// Publish the chosen port before start() spawns the listener, so a health/inspect
 		// hit racing startup reads the right port rather than 0.
 		g_boundPort.store(chosen);
-		g_registry = &m_registry;             // reachable by dvb::RunTool (the in-game menu) while up
+		g_registry.store(&m_registry);        // reachable by dvb::RunTool (the in-game menu) while up
 		const bool ok = m_mcp->start(false);  // non-blocking; spawns the listener thread
 		if (ok) {
 			WriteRuntimeInfo(chosen);
@@ -131,7 +141,7 @@ namespace dvb
 			// make a later Start() return true without a live listener. Reset the port too, or
 			// it would advertise a live bridge for a server that never came up.
 			g_boundPort.store(0);
-			g_registry = nullptr;
+			g_registry.store(nullptr);
 			m_restAdapter.reset();
 			m_mcpAdapter.reset();
 			m_mcp.reset();
@@ -149,7 +159,7 @@ namespace dvb
 		m_restAdapter.reset();
 		m_mcpAdapter.reset();
 		g_boundPort.store(0);
-		g_registry = nullptr;
+		g_registry.store(nullptr);
 	}
 
 	bool Server::Running() const
@@ -164,17 +174,37 @@ namespace dvb
 
 	void SetProcessRegistry(ToolRegistry* a_registry)
 	{
-		g_registry = a_registry;
+		g_registry.store(a_registry);
 	}
 
 	json RunTool(const std::string& a_name, const json& a_args)
 	{
-		if (!g_registry)
+		// Load once: a concurrent Stop() must not null the pointer between the check and the call.
+		ToolRegistry* registry = g_registry.load();
+		if (!registry)
 			return json{ { "error", "devbench server not running" }, { "code", 503 } };
 		ToolContext ctx{ "ui" };
 		ctx.internal = true;  // menu-driven; don't log each call
-		const ToolResult r = g_registry->Invoke(a_name, a_args, ctx);
+		const ToolResult r = registry->Invoke(a_name, a_args, ctx);
 		return r.ok ? r.value : json{ { "error", r.errorMessage }, { "code", r.errorCode } };
+	}
+
+	json ListRecordingsCached()
+	{
+		using namespace std::chrono;
+		std::lock_guard lock(g_recCacheMtx);
+		if (const auto now = steady_clock::now(); !g_recCacheValid || now - g_recCacheAt > seconds(1)) {
+			g_recCache = RunTool("recordings", json{ { "action", "list" } });
+			g_recCacheAt = now;
+			g_recCacheValid = true;
+		}
+		return g_recCache;
+	}
+
+	void InvalidateRecordingsCache()
+	{
+		std::lock_guard lock(g_recCacheMtx);
+		g_recCacheValid = false;  // next ListRecordingsCached() re-parses
 	}
 
 	std::string ExecutableName()

--- a/src/Server.cpp
+++ b/src/Server.cpp
@@ -19,6 +19,10 @@ namespace
 {
 	std::atomic<int> g_boundPort{ 0 };
 
+	// Process-wide registry pointer so dvb::RunTool can invoke tools from the in-game menu (a
+	// separate render-thread TU) without a Server reference. Set/cleared by Server::Start/Stop.
+	dvb::ToolRegistry* g_registry = nullptr;
+
 	// True if 127.0.0.1:port can be bound (i.e. it's free). WSAStartup is ref-counted,
 	// so pairing it with WSACleanup here is safe whether or not winsock is already up.
 	bool PortAvailable(const std::string& a_host, int a_port)
@@ -115,6 +119,7 @@ namespace dvb
 		// Publish the chosen port before start() spawns the listener, so a health/inspect
 		// hit racing startup reads the right port rather than 0.
 		g_boundPort.store(chosen);
+		g_registry = &m_registry;             // reachable by dvb::RunTool (the in-game menu) while up
 		const bool ok = m_mcp->start(false);  // non-blocking; spawns the listener thread
 		if (ok) {
 			WriteRuntimeInfo(chosen);
@@ -126,6 +131,7 @@ namespace dvb
 			// make a later Start() return true without a live listener. Reset the port too, or
 			// it would advertise a live bridge for a server that never came up.
 			g_boundPort.store(0);
+			g_registry = nullptr;
 			m_restAdapter.reset();
 			m_mcpAdapter.reset();
 			m_mcp.reset();
@@ -143,6 +149,7 @@ namespace dvb
 		m_restAdapter.reset();
 		m_mcpAdapter.reset();
 		g_boundPort.store(0);
+		g_registry = nullptr;
 	}
 
 	bool Server::Running() const
@@ -153,6 +160,21 @@ namespace dvb
 	int BoundPort()
 	{
 		return g_boundPort.load();
+	}
+
+	void SetProcessRegistry(ToolRegistry* a_registry)
+	{
+		g_registry = a_registry;
+	}
+
+	json RunTool(const std::string& a_name, const json& a_args)
+	{
+		if (!g_registry)
+			return json{ { "error", "devbench server not running" }, { "code", 503 } };
+		ToolContext ctx{ "ui" };
+		ctx.internal = true;  // menu-driven; don't log each call
+		const ToolResult r = g_registry->Invoke(a_name, a_args, ctx);
+		return r.ok ? r.value : json{ { "error", r.errorMessage }, { "code", r.errorCode } };
 	}
 
 	std::string ExecutableName()

--- a/src/Server.cpp
+++ b/src/Server.cpp
@@ -11,6 +11,8 @@
 #include <winsock2.h>
 #include <ws2tcpip.h>
 
+#include <shellapi.h>
+
 #include <atomic>
 #include <chrono>
 #include <filesystem>
@@ -205,6 +207,27 @@ namespace dvb
 	{
 		std::lock_guard lock(g_recCacheMtx);
 		g_recCacheValid = false;  // next ListRecordingsCached() re-parses
+	}
+
+	void OpenRecordingsFolder()
+	{
+		const std::string dir = ListRecordingsCached().value("dir", std::string{});
+		if (dir.empty())
+			return;
+		std::error_code             ec;
+		const std::filesystem::path abs = std::filesystem::absolute(dir, ec);
+		::ShellExecuteW(nullptr, L"open", abs.wstring().c_str(), nullptr, nullptr, SW_SHOWNORMAL);
+	}
+
+	void OpenRecordingFile(const std::string& a_file)
+	{
+		const std::string dir = ListRecordingsCached().value("dir", std::string{});
+		if (dir.empty() || a_file.empty())
+			return;
+		std::error_code             ec;
+		const std::filesystem::path abs = std::filesystem::absolute(std::filesystem::path(dir) / a_file, ec);
+		const std::wstring          args = L"/select,\"" + abs.wstring() + L"\"";
+		::ShellExecuteW(nullptr, nullptr, L"explorer.exe", args.c_str(), nullptr, SW_SHOWNORMAL);
 	}
 
 	std::string ExecutableName()

--- a/src/Server.h
+++ b/src/Server.h
@@ -61,4 +61,14 @@ namespace dvb
 	/// thread (pid/exe/vr cached once, port read live) so /api/health and inspect{kind:"state"}
 	/// share one identity source and a caller can tell which game instance replied (devbench#16).
 	json InstanceIdentity();
+
+	/// Point RunTool at the process registry while a Server is up (set by Start, cleared by Stop),
+	/// so the in-game menu — a separate render-thread TU with no Server reference — can invoke tools.
+	void SetProcessRegistry(ToolRegistry* a_registry);
+
+	/// Invoke a devbench tool by name from anywhere (e.g. the SMF menu). Returns the tool's value,
+	/// or { error, code } on failure / when no Server is up. Only call fast, non-blocking tools from
+	/// the render thread (recordings; record replay is async by default) — a RunAndWait-backed tool
+	/// would stall the caller.
+	json RunTool(const std::string& a_name, const json& a_args);
 }

--- a/src/Server.h
+++ b/src/Server.h
@@ -71,4 +71,10 @@ namespace dvb
 	/// the render thread (recordings; record replay is async by default) — a RunAndWait-backed tool
 	/// would stall the caller.
 	json RunTool(const std::string& a_name, const json& a_args);
+
+	/// The `recordings` list, cached and refreshed at most ~once/second. A menu redraws every frame,
+	/// and the underlying list fully parses every recording file — calling it per frame would stall
+	/// the render thread. Call InvalidateRecordingsCache() after a validate/delete to force a refresh.
+	json ListRecordingsCached();
+	void InvalidateRecordingsCache();
 }

--- a/src/Server.h
+++ b/src/Server.h
@@ -77,4 +77,9 @@ namespace dvb
 	/// the render thread. Call InvalidateRecordingsCache() after a validate/delete to force a refresh.
 	json ListRecordingsCached();
 	void InvalidateRecordingsCache();
+
+	/// Open the recordings directory in Explorer (menu "Open folder"); OpenRecordingFile selects one
+	/// file. No-op if the directory is unknown. Not an ImGui call, so it lives in the main TU.
+	void OpenRecordingsFolder();
+	void OpenRecordingFile(const std::string& a_file);
 }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -6,6 +6,7 @@
 #include "HostApi.h"
 #include "InputHotkeys.h"
 #include "Recording.h"
+#include "RecordingsMenu.h"
 #include "Server.h"
 #include "Tools.h"
 #include "Version.h"
@@ -97,6 +98,11 @@ namespace
 		// so registering then silently no-ops. kInputLoaded fires once the input subsystem is up.
 		if (a_msg->type == SKSE::MessagingInterface::kInputLoaded && g_server)
 			dvb::InstallInputHotkeys(g_server->Tools(), g_config);
+
+		// Register the optional in-game menu at kDataLoaded (SMF is up by then). Inert if SMF is
+		// not installed; it drives devbench via dvb::RunTool, so it needs the server (g_server).
+		if (a_msg->type == SKSE::MessagingInterface::kDataLoaded && g_server)
+			dvb::UI::Register();
 
 		if (g_server) {
 			// Publish lifecycle events (dataLoaded and later load/save/new-game).

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -99,10 +99,13 @@ namespace
 		if (a_msg->type == SKSE::MessagingInterface::kInputLoaded && g_server)
 			dvb::InstallInputHotkeys(g_server->Tools(), g_config);
 
-		// Register the optional in-game menu at kDataLoaded (SMF is up by then). Inert if SMF is
-		// not installed; it drives devbench via dvb::RunTool, so it needs the server (g_server).
-		if (a_msg->type == SKSE::MessagingInterface::kDataLoaded && g_server)
+		// Register the optional in-game menus at kDataLoaded (the frameworks are up by then). Each
+		// is inert if its framework isn't installed; both drive devbench via dvb::RunTool, so they
+		// need the server (g_server). SMF and FUCK are independent — host either, both, or neither.
+		if (a_msg->type == SKSE::MessagingInterface::kDataLoaded && g_server) {
 			dvb::UI::Register();
+			dvb::UI::RegisterFuck();
+		}
 
 		if (g_server) {
 			// Publish lifecycle events (dataLoaded and later load/save/new-game).

--- a/xmake-pkgs/packages/f/fuck-api/xmake.lua
+++ b/xmake-pkgs/packages/f/fuck-api/xmake.lua
@@ -1,0 +1,16 @@
+-- FUCK client API header (single file, MIT). Runtime GetProcAddress on the "RequestFUCK" export —
+-- inert when FUCK.dll is not installed (FUCK::Connect returns false). Includes <imgui.h> for TYPES;
+-- all drawing routes through the host's ImGui via FUCK:: wrappers, so this header must NOT share a
+-- TU with SMF's cimgui ImGuiMCP (see the devbench-UI-fuck target).
+package("fuck-api")
+set_kind("library", { headeronly = true })
+set_homepage("https://github.com/alandtse/FUCK")
+set_description("Client API header for FUCK (in-game ImGui menu + keybind framework)")
+set_license("MIT")
+
+add_urls("https://github.com/alandtse/FUCK.git", { submodules = false })
+add_versions("1.0.0", "2522eccf1d2096a794f283782a5c78a16ab83f74")
+
+on_install(function(package)
+    os.cp("src/FUCK_API.h", package:installdir("include"))
+end)

--- a/xmake-pkgs/packages/s/skse-menu-framework-api/xmake.lua
+++ b/xmake-pkgs/packages/s/skse-menu-framework-api/xmake.lua
@@ -1,0 +1,16 @@
+-- SPDX-License-Identifier: GPL-3.0-or-later WITH LicenseRef-Modding-Exception
+-- SMF3 client SDK header (single file, LGPL-2.1). Runtime GetProcAddress
+-- linkage; namespace is ImGuiMCP in this fork. Must NOT share a TU with the
+-- real imgui.h (see the devbench-UI target).
+package("skse-menu-framework-api")
+set_kind("library", { headeronly = true })
+set_homepage("https://github.com/alandtse/SKSE-Menu-Framework-3")
+set_description("Client SDK header for SKSE Menu Framework 3 (in-game ImGui config menus)")
+set_license("LGPL-2.1")
+
+add_urls("https://github.com/alandtse/SKSE-Menu-Framework-3.git", { submodules = false })
+add_versions("3.7.0", "24c40c925650c033b42fea2f61bd5a0382e03e74")
+
+on_install(function(package)
+    os.cp("resources/SKSEMenuFramework.h", package:installdir("include"))
+end)

--- a/xmake-pkgs/packages/s/skse-menu-framework-api/xmake.lua
+++ b/xmake-pkgs/packages/s/skse-menu-framework-api/xmake.lua
@@ -1,7 +1,8 @@
 -- SPDX-License-Identifier: GPL-3.0-or-later WITH LicenseRef-Modding-Exception
--- SMF3 client SDK header (single file, LGPL-2.1). Runtime GetProcAddress
--- linkage; namespace is ImGuiMCP in this fork. Must NOT share a TU with the
--- real imgui.h (see the devbench-UI target).
+-- (this package script). The vendored SMF3 client SDK header is LGPL-2.1
+-- upstream (see set_license). Single file, runtime GetProcAddress linkage;
+-- namespace is ImGuiMCP in this fork. Must NOT share a TU with the real
+-- imgui.h (see the devbench-UI target).
 package("skse-menu-framework-api")
 set_kind("library", { headeronly = true })
 set_homepage("https://github.com/alandtse/SKSE-Menu-Framework-3")

--- a/xmake-requires.lock
+++ b/xmake-requires.lock
@@ -61,6 +61,12 @@
             },
             version = "v4.25"
         },
+        ["skse-menu-framework-api 3.7.0#31fecfc4"] = {
+            repo = {
+                url = "xmake-pkgs"
+            },
+            version = "3.7.0"
+        },
         ["spdlog v1.16.0#9c36f0a9"] = {
             branch = "v1.16.0",
             repo = {

--- a/xmake-requires.lock
+++ b/xmake-requires.lock
@@ -27,6 +27,20 @@
             },
             version = "24.2.0"
         },
+        ["fuck-api 1.0.0#31fecfc4"] = {
+            repo = {
+                url = "xmake-pkgs"
+            },
+            version = "1.0.0"
+        },
+        ["imgui#31fecfc4"] = {
+            repo = {
+                branch = "master",
+                commit = "b0b316eb13e79e5ea7e7a56b80117a3526dedeeb",
+                url = "https://gitlab.com/tboox/xmake-repo.git"
+            },
+            version = "v1.92.0"
+        },
         ["ninja#31fecfc4"] = {
             repo = {
                 branch = "master",
@@ -60,6 +74,14 @@
                 url = "https://gitlab.com/tboox/xmake-repo.git"
             },
             version = "v4.25"
+        },
+        ["simpleini#31fecfc4"] = {
+            repo = {
+                branch = "master",
+                commit = "b0b316eb13e79e5ea7e7a56b80117a3526dedeeb",
+                url = "https://gitlab.com/tboox/xmake-repo.git"
+            },
+            version = "v4.22"
         },
         ["skse-menu-framework-api 3.7.0#31fecfc4"] = {
             repo = {

--- a/xmake.lua
+++ b/xmake.lua
@@ -34,9 +34,27 @@ add_rules("plugin.vsxmake.autoupdate")
 -- packages
 add_requires("nlohmann_json")
 
+-- Local package repo: pins the optional SMF3 client API header (single header, pulled at build
+-- time, runtime GetProcAddress — inert when SMF is not installed). See xmake-pkgs/.
+add_repositories("devbench-pkgs xmake-pkgs")
+add_requires("skse-menu-framework-api 3.7.0")
+
+-- The SMF-hosted in-game menu lives in its own PCH-free static lib: the SMF client header's
+-- cimgui-style typedefs cannot coexist with the real imgui.h the main target's PCH pulls in.
+target("devbench-UI")
+set_kind("static")
+set_warnings("all")
+add_deps("commonlibsse-ng")
+add_packages("skse-menu-framework-api", "nlohmann_json")
+add_defines("_SILENCE_CXX17_CODECVT_HEADER_DEPRECATION_WARNING") -- SMF header uses std::wstring_convert
+add_defines("UNICODE", "_UNICODE", "_WINSOCKAPI_")
+add_files("src/RecordingsMenu.cpp")
+add_includedirs("src")
+target_end()
+
 -- target
 target("devbench")
-add_deps("commonlibsse-ng", "cpp-mcp")
+add_deps("commonlibsse-ng", "cpp-mcp", "devbench-UI")
 add_packages("nlohmann_json")
 
 -- DLL output name
@@ -64,6 +82,9 @@ add_rules("commonlibsse-ng.plugin", {
 
 -- sources
 add_files("src/**.cpp")
+-- RecordingsMenu.cpp is SMF/cimgui and PCH-free — it belongs only to devbench-UI. The glob above
+-- would otherwise also compile it here with the real-imgui PCH, which conflicts.
+remove_files("src/RecordingsMenu.cpp")
 add_headerfiles("src/**.h")
 add_includedirs("src")
 -- Public C-ABI consumer header (DevBenchAPI.h). The companion DevBenchAPI.cpp is

--- a/xmake.lua
+++ b/xmake.lua
@@ -38,6 +38,12 @@ add_requires("nlohmann_json")
 -- time, runtime GetProcAddress — inert when SMF is not installed). See xmake-pkgs/.
 add_repositories("devbench-pkgs xmake-pkgs")
 add_requires("skse-menu-framework-api 3.7.0")
+-- FUCK: an alternative in-game menu + keybind framework. Header-only client API (runtime
+-- GetProcAddress on FUCK.dll — inert when absent). Its header pulls in the real imgui.h for
+-- types and references CSimpleIniA, so its UI target needs imgui + simpleini.
+add_requires("fuck-api 1.0.0")
+add_requires("imgui")
+add_requires("simpleini")
 
 -- The SMF-hosted in-game menu lives in its own PCH-free static lib: the SMF client header's
 -- cimgui-style typedefs cannot coexist with the real imgui.h the main target's PCH pulls in.
@@ -52,9 +58,21 @@ add_files("src/RecordingsMenu.cpp")
 add_includedirs("src")
 target_end()
 
+-- The FUCK-hosted in-game menu also lives in its own PCH-free static lib: FUCK_API.h pulls in the
+-- real imgui.h, which cannot coexist with SMF's cimgui ImGuiMCP (devbench-UI) or the main PCH.
+target("devbench-UI-fuck")
+set_kind("static")
+set_warnings("all")
+add_deps("commonlibsse-ng")
+add_packages("fuck-api", "imgui", "simpleini", "nlohmann_json")
+add_defines("UNICODE", "_UNICODE", "_WINSOCKAPI_")
+add_files("src/RecordingsMenuFuck.cpp")
+add_includedirs("src")
+target_end()
+
 -- target
 target("devbench")
-add_deps("commonlibsse-ng", "cpp-mcp", "devbench-UI")
+add_deps("commonlibsse-ng", "cpp-mcp", "devbench-UI", "devbench-UI-fuck")
 add_packages("nlohmann_json")
 
 -- DLL output name
@@ -85,6 +103,8 @@ add_files("src/**.cpp")
 -- RecordingsMenu.cpp is SMF/cimgui and PCH-free — it belongs only to devbench-UI. The glob above
 -- would otherwise also compile it here with the real-imgui PCH, which conflicts.
 remove_files("src/RecordingsMenu.cpp")
+-- RecordingsMenuFuck.cpp is FUCK/real-imgui and PCH-free — it belongs only to devbench-UI-fuck.
+remove_files("src/RecordingsMenuFuck.cpp")
 add_headerfiles("src/**.h")
 add_includedirs("src")
 -- Public C-ABI consumer header (DevBenchAPI.h). The companion DevBenchAPI.cpp is


### PR DESCRIPTION
Optional in-game menus to manage the recording library, hosted by **SKSE Menu Framework (SMF)** and/or **FUCK** — each auto-detected and **inert when its framework isn't installed**, so devbench can host SMF, FUCK, both, or neither (headless otherwise, as today).

> Stacked on #58 (the v2 recording format + `recordings` tool it sits on). Retarget to `main` once #58 merges; review the two menu commits here.

## What's here (2 commits)
- **SMF menu** (`f7b271e`): a "devbench" SMF section with a **Recordings** page (list every recording + format/samples/validated, per-row Replay/Validate/Delete, Replay-last) and a **Keybinds** page. Drawn via `ImGuiMCP::` in a separate PCH-free `devbench-UI` target (SMF's cimgui typedefs can't share the imgui PCH). Adds `dvb::RunTool` so the render-thread menu can invoke devbench tools.
- **FUCK menu** (`c22f651`): the twin, via `FUCK_API` (fetched from the `FUCK.dll` `RequestFUCK` export) in its own PCH-free `devbench-UI-fuck` target (FUCK_API pulls real `imgui.h`). Same recordings actions + a **rebindable `ManagedHotkey`** to toggle the menu — FUCK's edge over SMF.

## Design
- Both draw the same library over the shared `dvb::RunTool` → the `recordings`/`record` tools (render-thread-safe: only fast/async tools, no `RunAndWait`).
- Graceful detection: SMF via `IsInstalled()`, FUCK via its interface export; no hard dependency on either.
- Vendored client headers as header-only xmake packages (`skse-menu-framework-api`, `fuck-api`).

## Validation
Both build green (xmake releasedbg, prebuilt CommonLib; `devbench.dll` links both UI targets, 0 errors). **Not yet visually tested in-game** — the button *actions* are the already-live-validated `recordings`/`record` tools, so risk is confined to the ImGui draw calls; needs one in-game pass with SMF/FUCK installed to confirm rendering.

## Follow-ups (not here)
- In-menu keybind *rebinding* on the SMF side (SMF has no keybind framework; FUCK already does it).
- **VR** rendering via imgui-vr-helper (both draw flat-only now).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added in-game Recordings and Keybinds menus.
  * Replay, validate, delete, filter, sort, and bulk-manage recordings.
  * Open the recordings folder or individual recording files.
  * Rebind record and replay hotkeys at runtime, including Shift modifiers.
  * Hotkey settings are saved automatically and restored between sessions.
  * Added confirmation prompts for bulk deletion and clearer recording details.
* **Bug Fixes**
  * Improved handling of missing, corrupted, or unavailable recording and configuration data.
  * Prevented duplicate actions while menu hotkeys are being edited.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->