### PR TITLE
fix(record): bound stop latency + double-stop race

### DIFF
--- a/src/MainThread.cpp
+++ b/src/MainThread.cpp
@@ -3,6 +3,7 @@
 #include "GameState.h"     // dvb::game::CurrentFrame
 #include "ToolRegistry.h"  // dvb::ToolError
 
+#include <algorithm>
 #include <atomic>
 #include <future>
 #include <memory>
@@ -19,7 +20,7 @@ namespace
 
 namespace dvb::MainThread
 {
-	json RunAndWait(std::function<json()> a_fn, std::chrono::milliseconds a_timeout)
+	json RunAndWait(std::function<json()> a_fn, std::chrono::milliseconds a_timeout, const std::atomic<bool>* a_keepWaiting)
 	{
 		auto* task = SKSE::GetTaskInterface();
 		if (!task)
@@ -53,11 +54,26 @@ namespace dvb::MainThread
 			}
 		});
 
-		// The engine's frame counter discriminates the two 504 causes: still
-		// advancing = main thread busy (retry can succeed); frozen = hung OR
-		// fully paused (the counter also freezes in pause menus).
-		const int frameAtStart = game::CurrentFrame();
-		if (future.wait_for(a_timeout) != std::future_status::ready) {
+		// Slice the wait so a caller that withdraws interest (a_keepWaiting clears) doesn't
+		// block the full timeout — e.g. the recorder stopping while the main thread is stalled
+		// mid-load. The abandoned task sets its shared promise safely once the main thread runs.
+		const int      frameAtStart = game::CurrentFrame();
+		constexpr auto kSlice = std::chrono::milliseconds(100);
+		auto           remaining = a_timeout;
+		auto           status = std::future_status::timeout;
+		while (remaining.count() > 0) {
+			if (a_keepWaiting && !a_keepWaiting->load(std::memory_order_relaxed))
+				return json(nullptr);
+			const auto slice = std::min(remaining, kSlice);
+			status = future.wait_for(slice);
+			if (status == std::future_status::ready)
+				break;
+			remaining -= slice;
+		}
+		if (status != std::future_status::ready) {
+			// The engine's frame counter discriminates the two 504 causes: still
+			// advancing = main thread busy (retry can succeed); frozen = hung OR
+			// fully paused (the counter also freezes in pause menus).
 			const int frameNow = game::CurrentFrame();
 			if (frameAtStart < 0 || frameNow < 0)
 				throw ToolError(504, std::format("main-thread task did not run within {}ms", a_timeout.count()));

--- a/src/MainThread.h
+++ b/src/MainThread.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <atomic>
 #include <chrono>
 #include <functional>
 
@@ -18,8 +19,13 @@ namespace dvb::MainThread
 	///
 	/// MUST be called from a non-main thread (the server listener). Calling it on the
 	/// main thread would deadlock — the task can never run while this blocks.
+	///
+	/// a_keepWaiting: optional liveness flag. If it clears mid-wait, RunAndWait returns
+	/// json(nullptr) at once (the caller stopped waiting, e.g. the recorder shutting down)
+	/// instead of blocking the full timeout; the queued task is abandoned safely.
 	json RunAndWait(std::function<json()> a_fn,
-		std::chrono::milliseconds         a_timeout = std::chrono::milliseconds(5000));
+		std::chrono::milliseconds         a_timeout = std::chrono::milliseconds(5000),
+		const std::atomic<bool>*          a_keepWaiting = nullptr);
 
 	/// Engine frame at which the most recently queued main-thread task finished (success or
 	/// throw), or -1 if none has run yet. Lock-free; safe to call from the listener thread.

--- a/src/Recording.cpp
+++ b/src/Recording.cpp
@@ -183,12 +183,14 @@ namespace dvb::Recording
 						break;
 					json pose;
 					try {
-						pose = MainThread::RunAndWait(&ReadPose, milliseconds(2000));
+						// Pass &running so a stop() aborts the in-flight wait within one slice
+						// instead of blocking join() for the full 2s during a load screen.
+						pose = MainThread::RunAndWait(&ReadPose, milliseconds(2000), &running);
 					} catch (const std::exception&) {
 						continue;  // main thread stalled mid-load — skip this tick
 					}
 					if (pose.is_null())
-						continue;  // player not loaded
+						continue;  // player not loaded (or the wait was aborted by stop)
 					if (g_replaying.load(std::memory_order_relaxed))
 						continue;  // devbench is teleporting; the replay's setpos commands (captured
 								   // via the console hook) are the trajectory — don't re-sample it
@@ -339,9 +341,10 @@ namespace dvb::Recording
 		}
 
 		if (action == "stop") {
-			if (!rec.running.load())
+			// exchange, not load-then-store: two concurrent stops must not both reach join()
+			// (the second join on an already-joined thread throws std::system_error).
+			if (!rec.running.exchange(false))
 				return json{ { "error", "not recording" } };
-			rec.running.store(false);
 			if (rec.worker.joinable())
 				rec.worker.join();  // sampler done → samples are stable, no lock needed below
 


### PR DESCRIPTION
Fixes the two pre-existing recorder-thread concerns from #60, designed via the supervisor + adversarial (Gemini) pipeline.

## Changes
- **`record stop` ~2s stall (during a load screen):** the sampler's in-flight `MainThread::RunAndWait(2000ms)` was joined on the HTTP listener thread, so a stop landing while the main thread was stalled blocked the API up to ~2s. `RunAndWait` gains an optional `keepWaiting` flag and slices its wait into 100ms chunks; the sampler passes `&running`, so stop aborts the wait within ~100ms. On cancel it returns `json(nullptr)` — `Sample()` already treats a null pose as "skip this tick" — so there's **no exception-as-control-flow**. Other ~dozen `RunAndWait` callers are unaffected (defaulted `nullptr`).
- **Double-`stop` race:** `stop` used a non-atomic `load()`-then-`store(false)`, so two concurrent stops could both reach `worker.join()` (second join → `std::system_error`). Now `running.exchange(false)`.

## Deliberately not changed
- `g_userCocPending`'s `relaxed` ordering is correct — both callers (console hook, cell sink) run on the **main thread only**, so no cross-thread happens-before is needed.
- The `sleep_for(intervalMs)` before the wait stays uninterruptible (≤ one interval extra join latency, 10ms default) — a CV wouldn't fix the load-screen stall (that lives entirely in `RunAndWait`) and adds churn.

## Testing
Builds green. The normal record→stop path is behavior-preserving (single-stop `exchange` ≡ old load+store; the sliced wait returns identically when not cancelled). The load-screen-timing stall isn't deterministically reproducible via automation.

Closes #60.

🤖 Generated with [Claude Code](https://claude.com/claude-code)