### PR TITLE
ci(release): debounce merges into one release

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,10 +1,28 @@
-# Release pipeline. Every push to main runs semantic-release: it reads the
-# Conventional Commit history (squash-merge makes each PR title the commit subject),
+# Release pipeline. Every push to main, after a short debounce, runs semantic-release: it
+# reads the Conventional Commit history (squash-merge makes each PR title the commit subject),
 # picks the next version, bumps `local version` in xmake.lua, commits it back to main
 # (with [skip ci] so it doesn't re-trigger), creates the vX.Y.Z tag, and publishes a
 # GitHub Release whose body is the curated changelog. Downstream jobs then build the
 # plugin, attach the .7z mod archive to that release, and — on the source repo —
 # upload to Nexus with the same changelog.
+#
+# Debounce: a leading `debounce` job makes each push wait out a short quiet window before
+# releasing, so several PRs merged in close succession collapse into ONE semantic-release run
+# (and one Nexus upload) instead of one release per push. Each new push starts a fresh debounce
+# that cancels the still-waiting one (cancel-in-progress) and restarts the timer; once main is
+# quiet for the window the surviving run proceeds and semantic-release batches every accumulated
+# commit into a single version bump. workflow_dispatch skips the wait and releases immediately.
+# The version-bump commit carries [skip ci], so it neither starts a debounce nor cuts a release.
+#
+# Concurrency is per-job (one top-level group can't hold both cancel-in-progress semantics):
+#   - debounce         -> group semantic-release-debounce, cancel-in-progress: true  (a newer
+#                         merge cancels only the still-sleeping wait, never a live release job)
+#   - semantic-release -> group semantic-release-publish, cancel-in-progress: false (a live
+#                         bump commit + tag + Release is never aborted; concurrent runs queue)
+#   - nexus            -> its own group, cancel-in-progress: false, so two releases that both
+#                         escape the debounce window can't upload to the same mod page at once
+#                         (the reusable uploader reads the file list then writes — not
+#                         concurrency-safe; the session-cookie secret it still takes is inert).
 #
 # Single workflow on purpose (mirrors CrashLoggerSSE): because build/package/nexus
 # run in the same run as semantic-release, they read its outputs directly and nothing
@@ -21,21 +39,42 @@ on:
     branches: [main]
   workflow_dispatch:
 
-concurrency:
-  group: release-${{ github.ref }}
-  cancel-in-progress: false
-
 # Default to read-only; the two jobs that push commits/tags or publish assets
 # opt into contents: write individually.
 permissions:
   contents: read
 
 jobs:
+  debounce:
+    name: Debounce merges
+    runs-on: ubuntu-latest
+    # Source repo only. Skip semantic-release's own [skip ci] bump commit — but ONLY for push
+    # events, so a manual dispatch right after a "chore(release): X.Y.Z [skip ci]" bump is never
+    # blocked (GitHub also skips [skip ci] pushes natively; belt-and-braces).
+    if: >-
+      github.repository_owner == 'alandtse' &&
+      (github.event_name != 'push' ||
+       !contains(github.event.head_commit.message, '[skip ci]'))
+    concurrency:
+      group: semantic-release-debounce
+      cancel-in-progress: true
+    steps:
+      - name: Wait for the merge burst to settle
+        # Only debounce real pushes; workflow_dispatch releases immediately.
+        if: github.event_name == 'push'
+        run: sleep 300 # 5 min; a newer merge cancels + restarts this wait
+
   semantic-release:
     name: Semantic Release
+    needs: debounce
     runs-on: ubuntu-latest
     # Source repo only: forks have no release/Nexus credentials.
     if: github.repository_owner == 'alandtse'
+    # Own group, cancel-in-progress: false — a live bump commit + tag + Release is never aborted
+    # by a newer push; concurrent runs queue behind it.
+    concurrency:
+      group: semantic-release-publish
+      cancel-in-progress: false
     permissions:
       contents: write # push the bump commit + tag, create the GitHub Release
     outputs:
@@ -142,6 +181,14 @@ jobs:
     name: Nexus upload
     needs: [semantic-release, build, package]
     if: needs.semantic-release.outputs.new_release_published == 'true'
+    # Serialize Nexus uploads across runs: the reusable uploader reads the mod's file list
+    # (check_existing + previous_file:auto) then writes, which isn't concurrency-safe against one
+    # mod page. cancel-in-progress:false so an in-flight upload finishes and a second run queues.
+    # (Queue depth is 1: a third release piling on while one uploads and one waits evicts the
+    # waiter — its GitHub release/tag survive and re-upload via nexus-upload.yaml. Accepted.)
+    concurrency:
+      group: nexus-upload-${{ github.repository }}
+      cancel-in-progress: false
     uses: ./.github/workflows/nexus-upload.yaml
     with:
       tag: ${{ needs.semantic-release.outputs.new_release_git_tag }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -6,23 +6,13 @@
 # plugin, attach the .7z mod archive to that release, and — on the source repo —
 # upload to Nexus with the same changelog.
 #
-# Debounce: a leading `debounce` job makes each push wait out a short quiet window before
-# releasing, so several PRs merged in close succession collapse into ONE semantic-release run
-# (and one Nexus upload) instead of one release per push. Each new push starts a fresh debounce
-# that cancels the still-waiting one (cancel-in-progress) and restarts the timer; once main is
-# quiet for the window the surviving run proceeds and semantic-release batches every accumulated
-# commit into a single version bump. workflow_dispatch skips the wait and releases immediately.
-# The version-bump commit carries [skip ci], so it neither starts a debounce nor cuts a release.
-#
-# Concurrency is per-job (one top-level group can't hold both cancel-in-progress semantics):
-#   - debounce         -> group semantic-release-debounce, cancel-in-progress: true  (a newer
-#                         merge cancels only the still-sleeping wait, never a live release job)
-#   - semantic-release -> group semantic-release-publish, cancel-in-progress: false (a live
-#                         bump commit + tag + Release is never aborted; concurrent runs queue)
-#   - nexus            -> its own group, cancel-in-progress: false, so two releases that both
-#                         escape the debounce window can't upload to the same mod page at once
-#                         (the reusable uploader reads the file list then writes — not
-#                         concurrency-safe; the session-cookie secret it still takes is inert).
+# Debounce: a leading `debounce` job waits out a short quiet window; each new push cancels the
+# still-sleeping wait and restarts it, so a burst of merges collapses into ONE release instead of
+# one per push. workflow_dispatch skips the wait; the [skip ci] bump commit triggers neither.
+# Concurrency is per-job (a top-level group can't hold both semantics): `debounce` is
+# cancel-in-progress (only ever a sleeping wait); `semantic-release` and `nexus` are
+# cancel-in-progress:false so a live publish/upload is never aborted, and the `nexus` group also
+# serializes uploads across runs (the reusable uploader reads-then-writes the mod file list).
 #
 # Single workflow on purpose (mirrors CrashLoggerSSE): because build/package/nexus
 # run in the same run as semantic-release, they read its outputs directly and nothing


### PR DESCRIPTION
Adds a release **debounce** so several PRs merged in close succession collapse into **one** semantic-release run + one Nexus upload automatically — removing the manual disable/re-enable/dispatch dance we just used to batch the last stack. Mirrors alandtse/CommonLibVR's proven pattern; designed via the supervisor + adversarial review pipeline.

## How it works
- New `debounce` job sleeps a **300s** quiet window before releasing. Each new push starts a fresh debounce that **cancels the still-sleeping** one and restarts the timer, so once `main` is quiet the surviving run lets semantic-release batch every accumulated commit into a single version bump. `workflow_dispatch` skips the wait (releases immediately).
- **Per-job concurrency** (a top-level group can't hold both semantics):
  - `debounce` → `semantic-release-debounce`, `cancel-in-progress: true` — a newer merge can only ever cancel a **sleeping** wait, never a live release job. A cancelled debounce → `semantic-release` **skips** → the older run shows **cancelled (grey), not failed**.
  - `semantic-release` → `semantic-release-publish`, `cancel-in-progress: false` — a live bump-commit + tag + Release is never aborted; concurrent runs queue.
  - `nexus` → own `nexus-upload-${{ github.repository }}` group, `cancel-in-progress: false` — serializes uploads so two releases that both escape the window can't hit the same mod page concurrently (the reusable uploader does a read-then-write of the file list).
- The `[skip ci]` guard is **event-aware** (`github.event_name != 'push' || !contains(...)`) so a manual dispatch right after a `chore(release): … [skip ci]` bump is never blocked.

## Adversarial review notes (resolved)
- The "shared session-cookie CSRF race" was **refuted** — the uploader dropped session-cookie auth in BUTR.NexusUploader 4.0 (secret is inert); the real, weaker concern is a TOCTOU on the mod file-list, which the `nexus` group fixes.
- Billing is moot (public repo → free runner minutes); sleep tuned to 300s for latency over CommonLibVR's 600s (change the one `sleep` literal for fleet parity).

## Must-verify once merged (behavior only fully observable on main)
1. Two pushes <5 min apart → first run **cancelled**, only the second releases with both commits.
2. Lone push waits ~5 min → one release. 3. `workflow_dispatch` releases immediately (sleep step skipped). 4. The `[skip ci]` bump spawns no second run. 5. GHA honors `concurrency:` on the `uses:`-based `nexus` job (documented, verify in first overlap).

This `release.yaml` is the template rolled to the sibling SKSE repos, so it's kept as a clean drop-in.

🤖 Generated with [Claude Code](https://claude.com/claude-code)