### PR TITLE
feat(devbench): add capture-checkpoint replay

### DIFF
--- a/docs/plans/replay-checkpoint-capture.md
+++ b/docs/plans/replay-checkpoint-capture.md
@@ -2,7 +2,7 @@
 
 **Scope:** devbench (host, `E:\Documents\source\repos\devbench`) + Open Shaders (reference capture provider, `E:\Documents\source\repos\open-shaders`).
 **Goal:** capture a frame at deterministic checkpoints during a recording replay, signal reliably when the file is on disk, and return the path plus correlation metadata. All comparison (SSIM, thresholds, goldens, pass/fail) lives in Python.
-**Status:** final — produced via supervisor plan (Opus) → adversarial review (Gemini/agy-bridge) → rebuttal/reconciliation → consolidation. Self-contained; supersedes all earlier drafts.
+**Status:** historical — the "all comparison lives in Python" decision below was reconsidered after live testing surfaced two real gaps (checkpoint authoring required hand-editing JSON; the Python harness wasn't actually usable by a third-party mod author). A second bounded debate (cross-model, independent judge) reversed the comparison-location call: devbench now ALSO computes a native, single-checkpoint SSIM verdict in-process (`capture`'s `golden`/`threshold`/`regions` args, normally reached via `record{action:"replay", goldens:{...}}`) — see `Capture.cpp`'s "image comparison (SSIM)" section for the current design and reasoning. `tests/http/visual.py` remains for the batch/corpus-scoring job it was always suited to; it is no longer positioned as the primary consumer interface. `record{action:"checkpoint"}` (live checkpoint marking, closing the authoring gap this doc's Part 2 left open) also postdates this document. Kept as-is below for the historical record of the original decision, not as current documentation.
 
 ---
 

--- a/docs/plans/replay-checkpoint-capture.md
+++ b/docs/plans/replay-checkpoint-capture.md
@@ -1,0 +1,785 @@
+# Implementation Plan — Replay-Checkpoint Frame Capture
+
+**Scope:** devbench (host, `E:\Documents\source\repos\devbench`) + Open Shaders (reference capture provider, `E:\Documents\source\repos\open-shaders`).
+**Goal:** capture a frame at deterministic checkpoints during a recording replay, signal reliably when the file is on disk, and return the path plus correlation metadata. All comparison (SSIM, thresholds, goldens, pass/fail) lives in Python.
+**Status:** final — produced via supervisor plan (Opus) → adversarial review (Gemini/agy-bridge) → rebuttal/reconciliation → consolidation. Self-contained; supersedes all earlier drafts.
+
+---
+
+## 0. Verified ground truth
+
+Everything below was read in the actual source, not assumed. Anchors are `file:line`.
+
+| Fact                                                                                                          | Anchor                                                                                  |
+| ------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------- |
+| `RegisterToolExtension` mechanism; base tools keyed case-insensitively                                        | `devbench/src/ToolExtensions.cpp:36-54`                                                 |
+| Extension dispatch precedent (`inspect kind=<registered>`)                                                    | `devbench/src/Tools.cpp:1112-1114`                                                      |
+| Base-tool descriptor rebuild on registration                                                                  | `devbench/src/Tools.cpp:2001-2016`                                                      |
+| Scenario step dispatch; step kinds `pose/wait/waitFor/waitUntil/tool/assert`                                  | `devbench/src/Tools.cpp:1566, 1611, 1616, 1649, 1669, 1687`; unknown-step throw `:1772` |
+| Per-step exception containment (a throwing step fails that step, not the run)                                 | `devbench/src/Tools.cpp:1774-1791`                                                      |
+| `repeat` loop                                                                                                 | `devbench/src/Tools.cpp:1534`                                                           |
+| `sceneMismatch` produced as a **step-local** result field only                                                | `devbench/src/Tools.cpp:1738-1767`                                                      |
+| `waitFor` poll loop idiom (`HeadSeq` → `Since` → sleep → deadline)                                            | `devbench/src/Tools.cpp:1626-1643`                                                      |
+| `EventBus::Publish` is mutex-guarded, returns immediately, delivers off-thread                                | `devbench/src/EventBus.h:97-113, 136-160`; ring bound `kMaxRecent = 256` at `:133`      |
+| `BuildReplaySteps`: compat gate, restore prologue, scene assert, trajectory copy + `coc/cow` settle injection | `devbench/src/Recording.cpp:581-592, 602-663, 669-683, 690-701`                         |
+| `BuildScenario` emits `{"pose":…,"wait":Δ}` where Δ is the recorder's inter-sample `tMs` delta                | `devbench/src/Recording.cpp:203-205, 237-268`                                           |
+| `directory_iterator` precedent                                                                                | `devbench/src/Recording.cpp:503, 770`; `Tools.cpp:185`                                  |
+| INI read precedent                                                                                            | `devbench/src/Tools.cpp:165-170`                                                        |
+| `RE::MenuControls::QueueScreenshot()` — null-checks the handler, returns `false` if already queued            | `devbench/lib/commonlibsse-ng/src/RE/M/MenuControls.cpp:57-64`                          |
+| devbench version 1.13.0 → build 11300                                                                         | `devbench/xmake.lua:18`                                                                 |
+| OS `openshaders.capture kind=screenshot` is fire-and-forget, no path, no completion                           | `open-shaders/src/Features/RemoteControl/DevBenchBridge.cpp:751-761`                    |
+| OS screenshot filename generated internally; save on a background worker; HUD toast on save                   | `open-shaders/src/Features/ScreenshotFeature.cpp:435-447, 865-925, 1016`                |
+| `ResolveToAbsoluteGamePath` = `GetModuleFileNameW` parent (game root)                                         | `open-shaders/src/Features/ScreenshotFeature.cpp:203-216`                               |
+
+**Two corrections to premises that were handed to the design pass, both verified against source:**
+
+1. **`waitUntil noMenu` is unusable during gameplay.** `CheckState("noMenu")` is `GetOpenMenus().empty()` (`Tools.cpp:1397`), and `HUD Menu` is permanently in the tracked set — it is explicitly filtered out at `Tools.cpp:1332`. A `waitUntil noMenu` step before a capture would burn its entire timeout every time. **Use `waitUntil noBlockingMenu`.**
+2. **`menu action=close` requires a `name`** (`Tools.cpp:485-487`). A blind "close whatever is open" step is not expressible; the macro uses `assert noBlockingMenu` + `waitUntil noBlockingMenu` instead.
+
+---
+
+## Part 0 — Prerequisite: registrant list (`inspect kind=registrants`)
+
+Closes `ROADMAP.md:298-306`. Ships standalone.
+
+**Files:** `src/HostApi.h`, `src/HostApi.cpp`, `src/Tools.cpp`.
+
+`OnInterfaceRequest` (`HostApi.cpp:157-163`) already receives `a_message->sender`. Add a mutex-guarded ledger:
+
+```cpp
+// HostApi.h
+namespace dvb::HostApi
+{
+    struct Consumer {
+        std::string   name;        ///< a_message->sender, or "<?>"
+        unsigned int  revision;    ///< a_revisionNumber passed to GetApi
+        long long     atEpoch;
+        std::uint32_t atFrame;
+    };
+    struct Registration {
+        std::string   kind;        ///< "tool" | "extension"
+        std::string   name;        ///< tool name, or "<baseTool>:<key>"
+        long long     atEpoch;
+        std::uint32_t atFrame;
+        bool          replaced;    ///< Register returned false
+    };
+    std::vector<Consumer>     Consumers();
+    std::vector<Registration> Registrations();
+}
+```
+
+- `OnInterfaceRequest` appends a `Consumer` before setting `GetApiFunction`.
+- `Interface::RegisterTool` (`HostApi.cpp:47`) and `Interface::RegisterToolExtension` (`HostApi.cpp:76`) each append a `Registration`.
+- Both lists guarded by one `std::mutex`; accessors return copies.
+
+**No cross-attribution.** The interface is a shared singleton with no caller identity (`ROADMAP.md:302-306`); "the last requester owns this registration" would be a confident lie. The two lists are returned side by side.
+
+New built-in inspect kind, inserted in `InspectHandler` immediately before the `extensions` branch at `Tools.cpp:1100`:
+
+```jsonc
+// inspect kind=registrants →
+{
+  "consumers": [
+    {
+      "name": "CommunityShaders",
+      "revision": 1,
+      "atEpoch": 1765412300,
+      "atFrame": 41,
+    },
+  ],
+  "registrations": [
+    {
+      "kind": "tool",
+      "name": "openshaders.capture",
+      "atEpoch": 1765412301,
+      "atFrame": 42,
+      "replaced": false,
+    },
+    {
+      "kind": "extension",
+      "name": "capture:openshaders",
+      "atEpoch": 1765412301,
+      "atFrame": 42,
+      "replaced": false,
+    },
+  ],
+  "capabilities": {
+    "capture": ["openshaders"],
+    "inspect": ["openshaders", "profiler", "shadercache", "llfshadows"],
+    "menu": ["CommunityShaders"],
+  },
+}
+```
+
+`capabilities` is built from `ToolExtensions::Keys(base)` for `capture|inspect|menu`. This is the exact data the Part 2b capability gate consumes; `consumers`/`registrations` exist for humans and error text.
+
+Also: add `"registrants"` to the kinds enum at `Tools.cpp:1870`, to the description at `:1867`, and to the unknown-kind message at `:1116`.
+
+---
+
+## Part 1 — devbench: `capture`, a third extension-enabled base tool
+
+**Files:** new `src/Capture.h`, `src/Capture.cpp`; edits to `src/Tools.cpp`, `src/Config.h`, `src/Config.cpp`, `src/main.cpp`, `include/DevBenchAPI.h` (documentation only).
+
+### 1a. Registration and dispatch
+
+`capture` is a top-level tool, kind-dispatched exactly like `inspect`, opted into `ToolExtensions`. Registered next to `Tools.cpp:2002-2003`:
+
+```cpp
+a_registry.Register(BuildCaptureDescriptor(), &Capture::Handle);
+```
+
+The change-listener at `Tools.cpp:2009-2016` gains a third arm:
+
+```cpp
+else if (base == "capture")
+    reg->Register(BuildCaptureDescriptor(), &Capture::Handle);
+```
+
+Built-in kinds: `native`, `providers`, `extensions`. Any other kind routes through `ToolExtensions::Find("capture", kind)`, mirroring `Tools.cpp:1113`.
+
+### 1b. Kind resolution — `auto` never resolves to native
+
+This is a hard rule, applied at **every** entry point (checkpoint macro, bare tool call, MCP/REST client):
+
+| `kind`     | `allowNative` | Outcome                                                                                            |
+| ---------- | ------------- | -------------------------------------------------------------------------------------------------- |
+| `"auto"`   | absent/false  | exactly one registered provider ⇒ that provider; **zero ⇒ 404**; **two or more ⇒ 400** naming them |
+| `"auto"`   | `true`        | as above, but zero providers ⇒ native                                                              |
+| `"native"` | —             | native, always                                                                                     |
+| `"<key>"`  | —             | that provider; unregistered ⇒ 404                                                                  |
+
+404 message: `"no capture provider registered; install one (see inspect kind=registrants), or pass kind='native' / allowNative:true for the low-fidelity vanilla fallback (NOT comparable against provider-authored goldens)"`.
+
+`allowNative` is supplied by the checkpoint macro **only** from a recording's declared `meta.capabilities[].allowNative` (Part 2a), and defaults to `false` everywhere. Rationale: a recording with no `capabilities` block — i.e. every recording that exists today — must not silently produce an INI-format vanilla BMP that a scorer then SSIMs against a provider-authored PNG. A missing provider is a loud, fixable 404.
+
+### 1c. Tool input schema
+
+```jsonc
+{
+  "kind": "auto (default) | native | providers | extensions | <registered provider key>",
+  "checkpointId": "string, REQUIRED — stable file stem and correlation key",
+  "recording": "string — recording file stem (correlation)",
+  "variant": "string — variant under test, default \"default\" (correlation)",
+  "allowNative": "boolean, default false — permit kind=auto to fall back to the vanilla path",
+  "excludeUi": "boolean, default true — request a pre-UI source; native cannot honor it",
+  "outDir": "string — override the capture bundle dir (absolute, or relative to game root)",
+  "timeoutMs": "integer, default config.captureTimeoutMs (8000)",
+  "pollMs": "integer, default 100",
+  "subrect": "object {x,y,w,h} in 0..1 UV — OPTIONAL, provider-only; native ignores it",
+  "cleanup": "boolean, default false — native only: delete the game's source file after copying",
+  "runId": "integer — injected by ScenarioHandler (correlation)",
+  "repeat": "integer — injected by ScenarioHandler when repeat > 1 (filename suffix)",
+  "atMs": "integer — injected by the checkpoint macro (authored anchor)",
+  "resolvedAtMs": "integer — injected by the checkpoint macro (actual anchor)",
+  "resolvedIndex": "integer — injected by the checkpoint macro (index in the assembled step list)",
+}
+```
+
+### 1d. Tool output — identical shape for every provider
+
+```jsonc
+{
+  "ok": true,
+  "provider": "openshaders", // or "native"
+  "kind": "screenshot",
+  "path": "E:/…/Data/SKSE/Plugins/devbench/captures/GuardianStonesToWhiterun/variantA/01_stones_north.png",
+  "file": "01_stones_north.png",
+  "bytes": 8123456,
+  "width": 2560,
+  "height": 1440,
+
+  "checkpointId": "01_stones_north",
+  "recording": "GuardianStonesToWhiterun",
+  "variant": "variantA",
+  "runId": 42,
+  "repeat": null,
+  "atMs": 12000,
+  "resolvedAtMs": 12003,
+  "resolvedIndex": 1207,
+
+  "frame": 918273,
+  "epoch": 1765412345,
+  "worldspaceFormID": 60,
+  "cellFormID": 39825,
+  "gameHour": 14.36,
+  "weatherFormID": 2074,
+
+  "sceneMismatch": false,
+  "uiExcluded": true,
+  "readyBy": "event", // "event" | "poll"
+  "elapsedMs": 412,
+  "requestId": "01_stones_north#42#17",
+  "degraded": [], // e.g. ["nativeFallback","formatFromIni","hudNotSuppressed",
+  //       "sceneMismatch","uiIncluded","cleanupFailed"]
+  "sourcePath": "E:/…/ScreenShot42.bmp", // native only
+}
+```
+
+devbench additionally:
+
+- writes a sidecar `<stem>.json` next to the image containing this exact object — so the Python scorer can walk the captures tree standalone (golden refresh, CI artifact upload) without replaying the HTTP transcript;
+- publishes `capture.saved` with the same object on the EventBus;
+- publishes `capture.abandoned` `{requestId, path, checkpointId, runId, reason}` on timeout, so the harness can distinguish "provider never finished" from "provider wrote a bad image".
+
+**Output paths.** `<captureDir>/<recording>/<variant>/<checkpointId>[__r<rep>].<ext>`, overwritten each run (deterministic ⇒ trivially scriptable). The `__r<rep>` suffix is appended **only** when the injected `repeat` field is present, so a `repeat`-ed replay produces N distinct artifacts per checkpoint instead of one silently overwritten file. Golden/candidate versioning is entirely a Python concern.
+
+### 1e. Header
+
+```cpp
+// src/Capture.h
+namespace dvb::Capture
+{
+    json Handle(const json& a_args, const ToolContext& a_ctx);   ///< the `capture` tool handler
+    json Native(const json& a_args);                             ///< vanilla fallback (1g)
+    json ListScreenshots(const json& a_args);                    ///< inspect kind=screenshots (1h)
+
+    std::filesystem::path GameRoot();                            ///< GetModuleFileNameW parent
+    std::filesystem::path CaptureDir(const json& a_args);        ///< <captureDir>/<recording>/<variant>
+
+    /// Wait for a provider artifact. Satisfied by a `capture.ready` event whose requestId
+    /// matches EXACTLY, or by the file existing, being writer-released, and size-stable.
+    struct Ready { bool ok; std::string readyBy; std::string error; std::uintmax_t bytes; };
+    Ready AwaitArtifact(EventBus& a_events, std::uint64_t a_sinceSeq,
+                        const std::string& a_requestId, const std::filesystem::path& a_path,
+                        long a_timeoutMs, long a_pollMs);
+
+    void SetEvents(EventBus* a_events);        ///< wired from RegisterCoreTools
+    void SetDefaults(const Config& a_cfg);     ///< wired from main.cpp at kPostLoad
+}
+```
+
+`AwaitArtifact` reuses the exact loop shape of `Tools.cpp:1626-1643` (`Since(since)` → advance `since` → sleep `pollMs` → deadline).
+
+### 1f. Provider contract
+
+Documented in the `capture` descriptor and above `RegisterToolExtension` in `include/DevBenchAPI.h:76-88`.
+
+A provider registered under base tool `capture` receives the full args object, which devbench guarantees additionally contains:
+
+- `outputPath` — absolute, forward-slash; **devbench has already created the parent directory**;
+- `requestId` — opaque, globally unique, format `<checkpointId>#<runId>#<atomic seq>` where the counter is a process-wide `std::atomic<uint64_t>`. Uniqueness is load-bearing: a late event from a timed-out checkpoint must never match a later wait.
+
+The provider must:
+
+1. return synchronously `{"queued":true,"requestId":…,"path":outputPath}` (or `{"ok":true,"path":…}` if it completed inline);
+2. write **exactly** that path, PNG, lossless;
+3. honor `excludeUi` if it can, and report `uiExcluded` in its return;
+4. emit `capture.ready` `{"requestId","path","ok","error"?,"uiExcluded"?,"width"?,"height"?}` once the bytes are on disk.
+
+Returning `{"error":…}` fails the call immediately with **502**.
+
+**Ordering requirement, load-bearing:** `sinceSeq = a_events.HeadSeq()` is snapshotted **immediately before** invoking the provider handler, never after. Inverted, a fast provider could publish before the snapshot and the wait would miss the event and burn its full timeout (a false 504).
+
+If a provider never emits, the file-readiness poll still resolves it and the result is stamped `readyBy:"poll"` — a working-but-degraded provider is visible, not silent. The ring is bounded at 256 events (`EventBus.h:133`); during a dense replay `scenario.step` is published only every 100th step (`Tools.cpp:1551`), so eviction inside an 8s window is unlikely, and the poll covers it if it happens. Documented, not further defended.
+
+### 1g. Native fallback (`kind:"native"`)
+
+Rock-bottom smoke-test path. No D3D11, no image codec — a main-thread flag flip plus a directory poll, the same complexity class as the existing main-thread work in `Tools.cpp`.
+
+**Step 1 — preflight (main thread, `MainThread::RunAndWait`, ≤1000ms, idiom per `Tools.cpp:1310`).** Read `RE::INISettingCollection::GetSingleton()->GetSetting("bAllowScreenShot:Display")` (INI precedent `Tools.cpp:165-170`). Present and false ⇒ **409** `"vanilla screenshots disabled (bAllowScreenShot:Display=0)"`. Absent ⇒ proceed.
+
+**Step 2 — snapshot the scan dirs.** `directory_iterator` over `config.captureScanDirs` (default `["", "Screenshots"]`, resolved against `GameRoot()`), non-recursive, extensions `{.bmp,.png,.jpg,.jpeg,.dds}`. Record **per file**: path, size, `last_write_time`.
+
+**Step 3 — queue (main thread).** `RE::MenuControls::GetSingleton()->QueueScreenshot()`. Returns `false` ⇒ **409** `"no ScreenshotHandler, or a shot is already queued"`.
+
+**Step 4 — poll for a completed candidate**, every `pollMs` (default 100) until `timeoutMs` (default 8000).
+
+Three-way candidate rule — mtime is compared **per file against its own snapshot value**, never against a wall-clock `t0` (that would be a clock-domain error):
+
+> candidate ⇔ `path ∉ snapshot` **OR** `size(path) != snapshot[path].size` **OR** `mtime(path) > snapshot[path].mtime`
+
+The set-difference branch is the primary path and is completely independent of NTFS timestamp granularity or caching — the engine writes a **new** auto-incremented filename every time and never overwrites in place. The other two branches are defence in depth.
+
+Completeness is decided by an exclusive-open probe, not by a size heuristic. Magic-byte checks do not prove completeness (the header is written first):
+
+```cpp
+// src/Capture.cpp — file-local. True only when no other handle is open on the file.
+bool IsWriterDone(const std::filesystem::path& a_p)
+{
+    HANDLE h = CreateFileW(a_p.c_str(), GENERIC_READ, 0 /*no sharing*/, nullptr,
+                           OPEN_EXISTING, FILE_ATTRIBUTE_NORMAL, nullptr);
+    if (h == INVALID_HANDLE_VALUE)
+        return false;                    // ERROR_SHARING_VIOLATION → the writer still holds it
+    CloseHandle(h);
+    return true;
+}
+```
+
+A candidate is accepted only when `size > 0 && IsWriterDone(p) && size unchanged since the previous poll`. Timeout ⇒ **504** naming every directory scanned.
+
+**Step 5 — copy into the bundle,** with bounded retry against AV / search-indexer / cloud-sync locks. The `std::error_code` overloads are mandatory (they do not throw; and `ScenarioHandler:1774-1791` would contain a throw anyway, but silent non-throwing failure is the wrong outcome here):
+
+```cpp
+bool CopyWithRetry(const std::filesystem::path& a_from, const std::filesystem::path& a_to,
+                   std::string& a_err)
+{
+    for (int i = 0; i < 5; ++i) {
+        std::error_code ec;
+        std::filesystem::copy_file(a_from, a_to,
+            std::filesystem::copy_options::overwrite_existing, ec);
+        if (!ec)
+            return true;
+        a_err = ec.message();
+        std::this_thread::sleep_for(std::chrono::milliseconds(50 * (1 << i)));  // 50…800ms
+    }
+    return false;
+}
+```
+
+`cleanup:true` runs `fs::remove` through the same retry shape; a failure there is downgraded to `degraded:["cleanupFailed"]`, never a step failure — a leftover source file is cosmetic. `cleanup` defaults to **false**: non-destructive, and safe because step 2 snapshots per call, so leftovers can never be mistaken for a later capture.
+
+**Step 6 — report.** Always `uiExcluded:false`; `degraded` always contains `["nativeFallback","formatFromIni","hudNotSuppressed"]`. Write the sidecar, publish `capture.saved`.
+
+**Assumptions, explicitly labelled (none verified against a running game in this pass):**
+
+- **A1** — vanilla SE writes into the game root (`GetModuleFileNameW` parent). Supported by convention plus Open Shaders' own `ResolveToAbsoluteGamePath` (`ScreenshotFeature.cpp:203-216`). Mitigated by the configurable dir list and by Part 1h letting a human discover the real dir in one call.
+- **A2** — ENB/ReShade hook the screenshot _key_, not the engine's queued-screenshot path, so `QueueScreenshot()` reaches the engine writer. If false, the poll 504s cleanly rather than misbehaving.
+- **A3** — the vanilla index counter is in-memory, so `cleanup:true` cannot cause a filename collision. This is why `cleanup` defaults to `false`.
+- **A4** — `bAllowScreenShot` lives under `Display` with that exact key. Guarded: absent ⇒ proceed.
+
+### 1h. `inspect kind=screenshots`
+
+Same snapshot helper as 1g step 2, exposed independently. Added to `InspectHandler` before `Tools.cpp:1100`, to the enum at `:1870`, to the description at `:1867`.
+
+```jsonc
+// inspect kind=screenshots [dir?] [limit? default 50] →
+{
+  "dirs": [
+    "E:/…/Skyrim Special Edition",
+    "E:/…/Skyrim Special Edition/Screenshots",
+  ],
+  "count": 12,
+  "returned": 12,
+  "truncated": false,
+  "screenshots": [
+    {
+      "file": "ScreenShot42.bmp",
+      "path": "E:/…/ScreenShot42.bmp",
+      "bytes": 12441654,
+      "mtimeEpoch": 1765412345,
+    },
+  ],
+}
+```
+
+Newest first (matches `EnumerateSaves`, `Tools.cpp:189`); `{count, returned, truncated}` per the convention at `Tools.cpp:347`.
+
+### 1i. Config additions
+
+```cpp
+// src/Config.h
+std::string              captureDir      = "Data/SKSE/Plugins/devbench/captures";
+std::vector<std::string> captureScanDirs = { "", "Screenshots" };   // relative to game root
+int                      captureTimeoutMs = 8000;
+int                      captureSettleMs  = 500;   // default settle before each checkpoint
+```
+
+Wired in `main.cpp` alongside `Recording::SetLoadSettleMs(cfg.loadSettleMs)` via `Capture::SetDefaults(cfg)` and `Recording::SetCaptureDefaults(cfg.captureSettleMs)`.
+
+### 1j. Run-scoped injection in `ScenarioHandler`
+
+`sceneMismatch` is a step-local result field (`Tools.cpp:1753`); nothing carries it forward. The only place run-scoped state can be injected is the tool branch. Three surgical edits:
+
+```cpp
+// Tools.cpp:1534 — declare INSIDE the repeat loop: rep N's scene verdict is rep N's alone.
+for (int rep = 0; rep < repeat && !aborted; ++rep) {
+    bool runSceneMismatch = false;
+    for (size_t i = 0; i < steps.size() && !aborted; ++i) {
+        …
+```
+
+```cpp
+// Tools.cpp:1669-1678 — `args` becomes NON-CONST so run-scoped context can be injected.
+} else if (step.contains("tool")) {
+    const std::string tool = step["tool"].get<std::string>();
+    json              args = step.value("args", json::object());   // was: const json args
+    r["kind"] = "tool";
+    r["tool"] = tool;
+    if (step.contains("label"))
+        r["label"] = step["label"];
+    if (tool == "capture") {                       // context the static step list cannot carry
+        args["runId"] = runId;
+        if (repeat > 1)      args["repeat"] = rep;         // → "__r<rep>" filename suffix
+        if (runSceneMismatch) args["sceneMismatch"] = true;
+    }
+    ToolContext stepCtx = a_ctx;
+    stepCtx.internal = true;
+    const ToolResult tr = a_registry.Invoke(tool, args, stepCtx);
+    …
+```
+
+```cpp
+// Tools.cpp:1738-1746 (assert scene, !ready) AND :1747-1762 (assert scene, mismatch):
+runSceneMismatch = true;
+```
+
+An unconfirmed scene is set too, not just a mismatched one — a shot taken while the scene never finished loading is equally unusable as a golden reference.
+
+The injected fields reach the transcript **via the result**, not via the args: `Capture::Handle` echoes `runId`, `repeat`, `checkpointId`, `recording`, `variant`, `sceneMismatch`, `atMs`, `resolvedAtMs`, `resolvedIndex` into its output, and `ScenarioHandler` stores that at `r["result"] = tr.value` (`Tools.cpp:1681`). That is the right place — the result also records what the tool actually _resolved_ (`provider`, `readyBy`, `uiExcluded`, `degraded`), which args could never show. The on-disk sidecar is a second, independent copy.
+
+When `sceneMismatch` is true the capture **still runs** (a mismatched shot is diagnostic evidence) but is stamped `degraded:["sceneMismatch"]` so the Python scorer marks it inconclusive rather than reporting a false regression.
+
+---
+
+## Part 2 — devbench: checkpoints in the recording manifest
+
+**Files:** `src/Recording.cpp` (`BuildReplaySteps`, 491-714), `src/Recording.h` (doc comment), `src/Tools.cpp` (`record` schema at 2164-2177).
+
+### 2a. Manifest schema (purely additive; every existing recording stays valid)
+
+```jsonc
+"meta": {
+  "capabilities": [
+    { "capability": "capture", "provider": "openshaders", "required": true, "allowNative": false }
+  ],
+  "checkpoints": [
+    { "id": "01_stones_north", "atMs": 12000, "pov": "first", "settleMs": 750,
+      "excludeUi": true,
+      "subrect": {"x":0.25,"y":0.25,"w":0.5,"h":0.5},
+      "note": "guardian stones, sun behind camera" }
+  ]
+}
+```
+
+- `capabilities[].provider` omitted ⇒ any registered `capture` provider satisfies the gate.
+- `capabilities[].allowNative` defaults to `false` — the **only** source of `allowNative` anywhere in the system.
+- Unknown `capability` values are ignored by the gate (forward-compatible).
+- `subrect` is optional and provider-only; ROI is a Python concern by default (Part 4).
+
+**`atMs` is the only anchor.** Justification, derived from source rather than asserted:
+
+1. `BuildScenario` (`Recording.cpp:237-268`) emits one `{"pose":…,"wait":Δ}` or `{"wait":Δ}` per sample, where `Δ = tMs[k] − tMs[k−1]` and `tMs` is the recorder's wall-clock offset stamped at sample time (`Recording.cpp:203-205, 259-260`). Therefore the sum of `wait` over the first _k_ trajectory steps **is** the recorder's `tMs` at sample _k_ — the same numbers, only clamped to `max(1, Δ)`.
+2. The insertion loop accumulates `cumMs` **at plan time**, inside `BuildReplaySteps`, as pure arithmetic over a static JSON array. No clock is read.
+3. Therefore `atMs → index` is resolved deterministically _before the run starts_. Nothing at execution time — a slow cell load, a 40s `waitFor postLoadGame`, frame-rate variance, `RunAndWait` latency inflating real step duration above `wait` — can move it. Variable-duration steps shift the checkpoint's _wall-clock_ firing time only; its position relative to the surrounding pose steps is invariant, and that is the property that matters: the shot must follow the correct `player.setpos`/`setangle`, not a stopwatch reading.
+
+A step index would be _less_ robust: it breaks the moment anyone hand-edits or re-serializes a recording, which the format explicitly invites (`Recording.cpp:285-287`: "one compact step per line … hand-editable and git-diffable"). `atMs` is stable under insertion/deletion of neighbouring samples.
+
+### 2b. Capability gate
+
+Inserted immediately after the runtime/compat gate at `Recording.cpp:581-592` — same shape, same `force` downgrade, same 409, deliberately not a second failure idiom:
+
+```cpp
+const json captureCap = FindCaptureCapability(meta);          // the meta.capabilities entry, or {}
+if (!captureCap.empty() && captureCap.value("required", true)) {
+    const std::string want = captureCap.value("provider", std::string{});
+    const auto        keys = ToolExtensions::Keys("capture");
+    bool ok = want.empty() ? !keys.empty()
+                           : ToolExtensions::Find("capture", want).has_value();
+    if (!ok && captureCap.value("allowNative", false))
+        ok = true;                                            // native is always available
+    if (!ok && !force)
+        throw ToolError(409, std::format(
+            "recording requires capture provider '{}' but none is registered (registered: [{}]) — "
+            "install the provider mod (see inspect kind=registrants), set "
+            "meta.capabilities[].allowNative, or pass force",
+            want.empty() ? "<any>" : want, JoinNames(keys)));
+}
+```
+
+### 2c. Checkpoint expansion — a macro, not a new step kind
+
+`ROADMAP.md:311-318` forbids growing `scenario` into a DSL. A checkpoint is therefore expanded by `BuildReplaySteps` into existing primitives; `ScenarioHandler` gains **no** new step type (only the run-scoped injection of 1j).
+
+Rewrite the trajectory copy loop (`Recording.cpp:690-701`):
+
+```cpp
+long   cumMs = 0;
+size_t cpIdx = 0;
+const json checkpoints = SortedCheckpoints(meta);   // validates, sorts by atMs
+
+for (const auto& s : rec["steps"]) {
+    steps.push_back(s);
+    // LOAD-BEARING: accumulate ONLY over rec["steps"] — the recorder's own clock.
+    // The coc/cow settle steps injected below, and the restore-prologue waits at
+    // Recording.cpp:602-663, are NOT part of that clock and must never be summed.
+    if (s.contains("wait"))
+        cumMs += s["wait"].get<long>();
+
+    /* existing coc/cow settle injection, Recording.cpp:692-700 — unchanged, NOT summed */
+
+    while (cpIdx < checkpoints.size() && checkpoints[cpIdx].value("atMs", 0L) <= cumMs)
+        AppendCheckpointSteps(steps, checkpoints[cpIdx++], meta, captureCap, a_args, cumMs);
+}
+// Checkpoints anchored past the end of the trajectory still fire.
+while (cpIdx < checkpoints.size())
+    AppendCheckpointSteps(steps, checkpoints[cpIdx++], meta, captureCap, a_args, cumMs);
+```
+
+```cpp
+// Recording.cpp, file-local
+json SortedCheckpoints(const json& a_meta);   // ToolError(400) on duplicate id, missing id,
+                                              // or negative atMs; warns when atMs exceeds the
+                                              // total trajectory duration (still fires, end-flush)
+void AppendCheckpointSteps(json& a_steps, const json& a_cp, const json& a_meta,
+                           const json& a_cap, const json& a_args, long a_cumMs);
+```
+
+`AppendCheckpointSteps` emits exactly:
+
+```jsonc
+{"assert":"noBlockingMenu"}                                       // reuses Tools.cpp:1691
+{"waitUntil":"noBlockingMenu","timeoutMs":5000,"pollMs":100}      // NOT noMenu — HUD Menu is always open
+{"tool":"camera","args":{"action":"setPov","pov":"first"}}        // only when cp.pov present
+{"wait": <cp.settleMs | config.captureSettleMs>}
+{"tool":"capture","args":{ …see below… }}
+```
+
+```cpp
+json capArgs{
+    { "kind",          a_cap.value("provider", std::string("auto")) },  // NAMED provider, not "auto"
+    { "allowNative",   a_cap.value("allowNative", false) },
+    { "checkpointId",  a_cp.at("id") },
+    { "recording",     recordingStem },
+    { "variant",       a_args.value("variant", std::string("default")) },
+    { "excludeUi",     a_cp.value("excludeUi", true) },
+    { "atMs",          a_cp.value("atMs", 0L) },
+    { "resolvedAtMs",  a_cumMs },
+    { "resolvedIndex", static_cast<long>(a_steps.size()) },
+};
+if (a_cp.contains("settleMs")) capArgs["timeoutMs"] = /* config.captureTimeoutMs */;
+if (a_cp.contains("subrect"))  capArgs["subrect"]   = a_cp["subrect"];
+a_steps.push_back(json{ { "tool", "capture" }, { "args", std::move(capArgs) } });
+```
+
+Design notes, each traced to code:
+
+- **`kind` is the resolved provider, never `"auto"`.** The macro and the 2b gate read the _same_ `captureCap` object, so they cannot disagree by construction. Emitting `"auto"` while the gate validated a named provider would 400 mid-replay whenever a second provider happened to be installed — exactly the silent-late-failure the design exists to prevent.
+- **`waitUntil noBlockingMenu`**, not `noMenu`. `BlockingMenus()` (`Tools.cpp:1307-1338`) already excludes HUD/Cursor/Console and already survives a paused-frame `RunAndWait` 504.
+- **No pose step is emitted.** The trajectory's own `pose` step immediately preceding the checkpoint already set x/y/z/yaw/pitch (`Tools.cpp:1566-1610`); re-issuing it is a no-op costing five console round-trips. Only `pov` is re-asserted, because Skyrim's idle-vanity timer can flip it — the exact hazard called out at `Tools.cpp:1197`.
+- **No `tm`.** HUD suppression is _not_ attempted from the step list. `tm` is a blind toggle: it un-hides an already-hidden HUD, and the balanced un-hide leaks whenever a step fails (`aborted` is set at `Tools.cpp:1799` and the loop exits before the trailing step runs). UI exclusion moves into the capture contract as `excludeUi`, where the provider — which actually owns the render surface — decides. Native reports `uiExcluded:false` and `degraded:["hudNotSuppressed"]`, which is honest and consistent with native already being excluded from golden comparison by 1b.
+- `resolvedAtMs`/`resolvedIndex` make the anchoring falsifiable at runtime rather than arguable. `resolvedAtMs ≥ atMs` by at most one sample interval.
+
+**Test to write alongside this:** a unit/integration test asserting that a recording whose trajectory contains a captured `coc` produces the _same_ `resolvedIndex`-relative pose neighbour as the same recording without one — i.e. that the injected settle wait was not summed into `cumMs`.
+
+### 2d. `record` tool
+
+New arg `variant` (string, default `"default"`), threaded into the emitted capture steps; added to the input schema at `Tools.cpp:2164-2177` and to the description at `:2137-2163`.
+
+---
+
+## Part 3 — Open Shaders: reference capture provider
+
+**Files:** `src/Features/ScreenshotFeature.h`, `src/Features/ScreenshotFeature.cpp`, `src/Features/RemoteControl/DevBenchBridge.cpp`.
+
+### 3a. `ScreenshotFeature` — targeted capture with a completion signal
+
+Today `Capture()` computes its own timestamped name (`:1016` → `BuildScreenshotPath`, `:435-447`) and the worker (`:865-925`) signals nothing.
+
+```cpp
+// ScreenshotFeature.h — public
+struct CaptureRequest
+{
+    std::filesystem::path outputPath;    ///< empty ⇒ legacy BuildScreenshotPath behaviour
+    std::string           requestId;     ///< empty ⇒ no completion callback
+    bool                  forcePng   = true;   ///< override sdrUsePng for this shot only
+    bool                  useSubrect = false;  ///< override applyCropToScreenshot for this shot only
+    bool                  excludeUi  = true;   ///< prefer a pre-UI source
+    bool                  quiet      = false;  ///< suppress the in-game "saved" toast
+    std::optional<Util::Subrect::Rect> subrect;
+};
+
+/// THE single entry point for every capture — hotkey, ImGui button, and devbench provider
+/// calls all funnel through here, so the queue is the one source of truth. Thread-safe.
+void RequestCapture(CaptureRequest a_req);
+
+using CompletionFn = void (*)(const char* a_requestId, const char* a_path,
+                              bool a_ok, bool a_uiExcluded, const char* a_error);
+static void SetCompletionCallback(CompletionFn a_fn);   ///< atomic; nullptr disables
+```
+
+Private additions: `std::mutex requestMutex; std::deque<CaptureRequest> pendingRequests;`, and `std::string requestId; bool quiet; bool uiExcluded;` on `PendingScreenshot` (`ScreenshotFeature.h:54-65`).
+
+```cpp
+void ScreenshotFeature::RequestCapture(CaptureRequest a_req)
+{
+    {
+        std::lock_guard<std::mutex> lock(requestMutex);
+        pendingRequests.push_back(std::move(a_req));
+    }
+    captureRequested.store(true, std::memory_order_release);
+}
+
+// Replaces ScreenshotFeature.cpp:826-831.
+void ScreenshotFeature::ProcessCaptureRequest()
+{
+    if (!captureRequested.exchange(false))
+        return;
+    Capture();                       // services at most ONE request — one backbuffer per frame
+    {
+        std::lock_guard<std::mutex> lock(requestMutex);
+        if (!pendingRequests.empty())
+            captureRequested.store(true, std::memory_order_release);   // re-arm for next frame
+    }
+}
+```
+
+Deliberately **not** looping `Capture()` within one frame: two captures of the same frame would copy an identical backbuffer and emit two byte-identical PNGs under different checkpoint ids — worse than a one-frame delay.
+
+Existing callers change to funnel through the queue:
+
+```cpp
+// ScreenshotFeature.cpp:703 (ImGui button) and the hotkey path:
+RequestCapture({});      // empty outputPath/requestId ⇒ legacy behaviour, FIFO with devbench requests
+```
+
+Without this, a hotkey press setting the bare flag while a devbench request sits in the queue makes `Capture()` service the devbench request and silently consume the hotkey's intent. With the queue as sole source of truth, N requests ⇒ N shots on N successive frames, FIFO, none dropped or misattributed; `captureRequested` degenerates into a cheap "queue non-empty" hint readable without taking the mutex every frame.
+
+`Capture()` (`:935-1017`) changes:
+
+- pop one `CaptureRequest` under `requestMutex` at entry; empty queue ⇒ default-constructed request ⇒ legacy path preserved exactly;
+- crop block `:961-966` honors `req.useSubrect` / `req.subrect` instead of the member `applyCropToScreenshot`;
+- `:1008` becomes `saveAsSdrPng = !saveAsHdrPng && (req.forcePng || sdrUsePng)`;
+- `:1016` becomes `screenshot.outputPath = req.outputPath.empty() ? BuildScreenshotPath(...) : req.outputPath`;
+- carry `req.requestId`, `req.quiet`, and the actual UI-exclusion outcome of `SelectCaptureSource` into `PendingScreenshot`.
+
+`ScreenshotWorkerLoop()` (`:865-925`):
+
+- after `SaveScreenshotToDisk`, if `requestId` is non-empty, load the completion callback into a local `CompletionFn`, null-check, and invoke `(requestId, outputPath, saveOk, uiExcluded, error)`;
+- **also invoke it with `ok=false` on the early-`continue` map failure at `:889-893`** — otherwise a mapping failure hangs devbench for the full timeout instead of failing in about one frame;
+- **suppress the HUD toast** (`:920-921`) when `quiet` is set: a "Screenshot saved" message lands in the _next_ checkpoint's frame and is itself a visual diff.
+
+```cpp
+// ScreenshotFeature.cpp — clear the callback BEFORE joining, so nothing can be emitted
+// once teardown has begun.
+void ScreenshotFeature::StopWorkerThread()
+{
+    SetCompletionCallback(nullptr);
+    /* existing: screenshotWorkerRunning = false; notify_all; join */
+}
+```
+
+`~ScreenshotFeature` already calls `StopWorkerThread` (`ScreenshotFeature.h:16`). SKSE never unloads plugins mid-session and devbench's `g_server` (`main.cpp:21`) is never reset, so the only remaining hazard is cross-DLL static-destruction order at process exit; clearing the callback first closes the common case, and devbench never treats a missing event as fatal (the poll resolves it). Residual process-exit risk: accepted and documented.
+
+### 3b. `DevBenchBridge` — register the contract
+
+At `DevBenchBridge.cpp:1056` (beside the existing `GetBuildNumber() >= 10500` block), add:
+
+```cpp
+if (dvb->GetBuildNumber() >= 11400) {
+    g_dvb.store(dvb, std::memory_order_release);            // namespace-scope std::atomic<…*>
+    ScreenshotFeature::SetCompletionCallback(&OnCaptureComplete);
+    dvb->RegisterToolExtension("capture", "openshaders", captureProviderDesc,
+                               &CaptureProviderHandler, nullptr);
+} else {
+    logger::info("DevBenchBridge: devbench build {} < 11400; capture provider needs 1.14.0",
+                 dvb->GetBuildNumber());
+}
+```
+
+```cpp
+// anonymous namespace — captureless free function, runs on the ENCODE WORKER thread.
+// Safe: HostApi::Interface::EmitEvent (HostApi.cpp:93-105) only reaches EventBus::Publish,
+// which is mutex-guarded and delivers off-thread (EventBus.h:97-113).
+void OnCaptureComplete(const char* a_requestId, const char* a_path, bool a_ok,
+                       bool a_uiExcluded, const char* a_error)
+{
+    auto* dvb = g_dvb.load(std::memory_order_acquire);
+    if (!dvb || !a_requestId || !*a_requestId)
+        return;
+    json p{ { "requestId", a_requestId }, { "path", a_path ? a_path : "" },
+            { "ok", a_ok }, { "uiExcluded", a_uiExcluded } };
+    if (!a_ok && a_error && *a_error)
+        p["error"] = a_error;
+    dvb->EmitEvent("capture.ready", p.dump().c_str());
+}
+
+json BuildCaptureProviderResult(const json& a_args)
+{
+    const std::string out = a_args.value("outputPath", std::string{});
+    const std::string rid = a_args.value("requestId",  std::string{});
+    if (out.empty() || rid.empty())
+        return json{ { "error", "capture provider contract requires outputPath and requestId" } };
+
+    return RunOnMainThread([out, rid,
+                            sub = a_args.value("subrect", json::object()),
+                            excludeUi = a_args.value("excludeUi", true)]() -> json {
+        auto* shot = &globals::features::screenshotFeature;
+        if (!shot->loaded)
+            return json{ { "error", "Screenshot feature is not loaded" } };
+        ScreenshotFeature::CaptureRequest req;
+        req.outputPath = std::filesystem::path(out);
+        req.requestId  = rid;
+        req.forcePng   = true;
+        req.excludeUi  = excludeUi;
+        req.quiet      = true;
+        if (!sub.empty()) { req.useSubrect = true; req.subrect = ParseSubrect(sub); }
+        shot->RequestCapture(std::move(req));
+        return json{ { "queued", true }, { "requestId", rid }, { "path", out },
+                     { "enqueued_at_frame", EnqueuedFrame() } };
+    });
+}
+
+void CaptureProviderHandler(void*, const char* a_argsJson, void* a_sink, DevBenchAPI::WriteFn a_write)
+{
+    RunHandler(&BuildCaptureProviderResult, a_argsJson, a_sink, a_write);
+}
+```
+
+`RunOnMainThread` is required for the same reason `DevBenchBridge.cpp:752-760` uses it (`loaded` is mutated by queued toggle tasks).
+
+The existing top-level `openshaders.capture` tool (`:1043`) is left untouched for `renderdoc` / `shadowmaps` / interactive use; its `kind=screenshot` description gains one sentence pointing at the `capture` extension for path-controlled captures.
+
+**Assumption A5:** `SelectCaptureSource` (`ScreenshotFeature.cpp:944`) yields a post-tonemap, pre-ImGui surface, so the CS settings window is not composited into a provider capture. Unverified in this pass. If false, the provider reports `uiExcluded:false` (devbench then stamps `degraded:["uiIncluded"]`) and the checkpoint macro gains a `{"tool":"menu","args":{"action":"invoke","name":"CommunityShaders","op":"close"}}` step.
+
+---
+
+## Part 4 — Python scoring (all comparison lives here)
+
+**Files:** new `tests/http/test_visual_regression.py`, `tests/http/visual.py`; `tests/http/requirements.txt` (+`pillow`, `scikit-image`, `numpy`); goldens at `tests/http/goldens/<recording>/<variant>/<checkpointId>.png`; thresholds at `tests/http/goldens/<recording>/thresholds.json`.
+
+Follows the existing skip-safe conventions in `tests/http/conftest.py` (session skip when no server reachable; `require_tool` / `require_enum` gating against the live schema).
+
+**Skip conditions:** `capture` absent from the live tool schema; or `inspect kind=registrants → capabilities.capture` empty while the recording forbids native.
+
+**Flow:**
+
+1. `record {action:"replay", path, restoreScene:true, variant:"<variant>"}` → `{runId}`.
+2. Poll `record {action:"status", runId}` until `done`.
+3. Walk `result.results[]` for `kind=="tool" && tool=="capture"`; each carries the full output object of 1d at `.result`.
+4. For each, load `.result.path` (or read the sidecar directly when scanning the tree offline).
+5. SSIM via `skimage.metrics.structural_similarity` against the golden; ROI crops/masks applied **in Python** (multiple independent regions, independent thresholds, no plugin change); per-checkpoint thresholds from `thresholds.json`.
+
+**Inconclusive — never a failure — when any of:** `sceneMismatch:true`; non-empty `degraded[]`; `provider=="native"`; `uiExcluded` differs from the golden's recorded flag; a matching `capture.abandoned` event on `GET /api/events`.
+
+**Golden refresh** is a separate opt-in mode (`--visual-update`) that copies capture paths over the goldens. Goldens are versioned in git alongside the recording.
+
+---
+
+## Sequencing
+
+1. **Part 0** — registrant ledger + `inspect kind=registrants`. Self-contained; ships alone; closes a ROADMAP item.
+2. **Part 1h** — `inspect kind=screenshots`. Shares the snapshot helper the native path needs, is independently useful, and validates assumption **A1** against a real install _before_ anything depends on it.
+3. **Part 1a–1i** — `capture` tool, base-tool extension wiring, kind-resolution rule, native fallback, config. Testable standalone: `capture {kind:"native", checkpointId:"smoke"}` with no recording and no provider.
+4. **Part 1j** — run-scoped injection in `ScenarioHandler` (non-const `args`, per-rep `runSceneMismatch`, `runId`/`repeat`/`sceneMismatch`). Trivial once `capture` exists; required before checkpoints mean anything.
+5. **Part 2** — manifest `checkpoints` + `capabilities`, gate, macro expansion, `variant` arg, the `cumMs` accumulation test. Depends on 3 (gate reads `ToolExtensions::Keys("capture")`; macro emits `tool:"capture"`) and 4.
+6. **Part 3** — Open Shaders provider. Depends only on the 1f contract being frozen and the build number bumped; can proceed in parallel with 5.
+7. **Part 4** — pytest scoring. Needs 5 for end-to-end, but `visual.py` (SSIM, ROI, thresholds) can be written and unit-tested against static PNGs from day one.
+
+**Version / ABI.** Bump `xmake.lua:18` to **1.14.0** (build 11400). **No new vtable slot** is added to `IDevBenchInterface001` — `capture` reuses the existing `RegisterToolExtension` slot — so the ABI is unchanged and only the _documented_ base-tool set grows. Update the doc comment at `include/DevBenchAPI.h:76-88`: "Opted-in base tools: `menu`, `inspect`, `capture`", plus the full provider contract from 1f.
+
+---
+
+## Deliberate non-goals
+
+- No SSIM, pixel diffing, thresholds, pass/fail, or golden versioning in C++.
+- No D3D11, staging textures, or image codecs in devbench.
+- No new `scenario` step kind — checkpoints are a macro over existing primitives (`ROADMAP.md:311-318`).
+- No capture-side ROI cropping by default; `subrect` is provider-only and opt-in.
+- No HUD state manipulation from the step list; UI exclusion belongs to whoever owns the render surface.
+- No per-tool→mod attribution in the registrant list (blocked on the per-plugin-interface ROADMAP item).
+- No changes to the existing `openshaders.capture` top-level tool's behaviour.
+
+---
+
+## Review process note
+
+This plan was produced via the standing three-stage process: a supervisor design pass (Opus) reading the actual current source, an adversarial review by a different model family (Gemini, via agy-bridge), and a rebuttal/reconciliation pass by the same supervisor agent addressing every finding individually. The orchestrator independently re-verified the highest-stakes disagreement (checkpoint anchoring via `atMs` vs. the reviewer's claim of wall-clock drift) against `Recording.cpp:236-268` and `685-701` before accepting the supervisor's rejection of that finding. Accepted fixes: request-queue re-arm and shutdown-safe callback clearing (Q1); exclusive-open readiness probe, copy retry, and a granularity-independent candidate rule (Q2); per-repetition scene-mismatch reset and per-repetition filename suffixing (Q4); capability-gate/macro consistency (Q5); a stricter "auto never silently resolves to native" rule (Q6); removal of the `tm` HUD toggle in favor of a provider-side `excludeUi` contract field (Q7); and a single capture-request queue as the sole entry point for hotkey, UI, and provider-triggered captures (Q8). Rejected: step-index checkpoint anchoring (Q3) — the `atMs` mechanism is resolved statically at plan time, not against a replay-time wall clock, so it does not have the drift failure mode the reviewer described.
+
+### Critical files for implementation
+
+- `E:\Documents\source\repos\devbench\src\Tools.cpp` — scenario dispatch 1500-1811; repeat loop 1534; tool branch 1669-1686; assert-scene 1738-1767; `InspectHandler` 624-1117; descriptor rebuild 2001-2016; `record` schema 2164-2177
+- `E:\Documents\source\repos\devbench\src\Recording.cpp` — `BuildReplaySteps` 491-714; compat gate 581-592; trajectory copy + settle injection 690-701; `BuildScenario` wait derivation 237-268
+- `E:\Documents\source\repos\devbench\src\HostApi.cpp` — interface impl 40-106; `OnInterfaceRequest` 157-163
+- `E:\Documents\source\repos\open-shaders\src\Features\ScreenshotFeature.cpp` — ImGui trigger 703; `ProcessCaptureRequest` 826; `StopWorkerThread` 843; worker 865-925; `Capture` 935-1017
+- `E:\Documents\source\repos\open-shaders\src\Features\RemoteControl\DevBenchBridge.cpp` — capture handler 721-787; `Install` 1013-1084

--- a/src/Capture.cpp
+++ b/src/Capture.cpp
@@ -6,12 +6,24 @@
 #include "MainThread.h"
 #include "ToolExtensions.h"
 
+// Decode-only: two already-captured images -> pixel buffers, for the native SSIM comparison
+// below. STBI_ONLY_* keeps the codec surface to exactly the formats devbench's own captures can
+// actually be (provider captures are PNG per the provider contract; the native fallback can also
+// land BMP depending on the user's vanilla screenshot .ini setting) -- not a general-purpose
+// image loader.
+#define STB_IMAGE_IMPLEMENTATION
+#define STBI_ONLY_PNG
+#define STBI_ONLY_BMP
+#include <stb_image.h>
+
 #include <algorithm>
 #include <atomic>
 #include <chrono>
+#include <cmath>
 #include <cstdio>
 #include <ctime>
 #include <fstream>
+#include <optional>
 #include <thread>
 
 namespace dvb::Capture
@@ -110,6 +122,262 @@ namespace dvb::Capture
 				return j;
 			},
 				milliseconds(1000));
+		}
+
+		// ---- image comparison (SSIM) ----
+		//
+		// The ONLY comparison logic devbench itself owns — a fast, single-checkpoint pass/fail
+		// verdict inline in the capture response ("replayed -> matched" in one call). This does
+		// NOT replace tests/http/visual.py, which stays devbench's own batch/corpus-scoring tool
+		// (many recordings, per-checkpoint config files, --visual-update across a whole tree) —
+		// that job needs an ecosystem (report generation, golden management across many files)
+		// that has no business being native code. This one only answers "did THIS capture match
+		// THIS golden," using the same threshold/regions JSON shape visual.py already defined, so
+		// a region written for one is copy-pasteable to the other.
+		//
+		// Decided via a real bounded debate (cross-model, independent judge): the principled line
+		// for what belongs in-process is NOT "small code stays in, big code stays out" — it's
+		// "provider-shaped external-ecosystem concerns stay out (why D3D11 capture is a provider
+		// extension); closed-form deterministic math on data devbench already holds stays in."
+		// SSIM has one universal definition and runs on two buffers devbench already has (one
+		// just came out of the capture call this same request made) — there's no competing
+		// "SSIM provider" ecosystem to be agnostic about the way there is for rendering backends.
+
+		struct GrayImage
+		{
+			std::vector<float> px;  // row-major, 0..255 range as float (SSIM math needs float)
+			int                width = 0;
+			int                height = 0;
+		};
+
+		std::optional<GrayImage> DecodeGray(const fs::path& a_path)
+		{
+			int            w = 0, h = 0, channels = 0;
+			const auto     pathStr = a_path.string();
+			unsigned char* data = stbi_load(pathStr.c_str(), &w, &h, &channels, 1);  // force 1-channel grayscale
+			if (!data)
+				return std::nullopt;
+			GrayImage img;
+			img.width = w;
+			img.height = h;
+			img.px.resize(static_cast<size_t>(w) * h);
+			for (size_t i = 0; i < img.px.size(); ++i)
+				img.px[i] = static_cast<float>(data[i]);
+			stbi_image_free(data);
+			return img;
+		}
+
+		// Crop a 0..1 UV rect {x,y,w,h} — the SAME convention the capture tool's own `subrect`
+		// arg and visual.py's regions both use, so one rect definition works everywhere.
+		GrayImage CropUv(const GrayImage& a_img, const json& a_uv)
+		{
+			const double x0d = a_uv.value("x", 0.0), y0d = a_uv.value("y", 0.0);
+			const double wd = a_uv.value("w", 1.0), hd = a_uv.value("h", 1.0);
+			const int    x0 = std::clamp(static_cast<int>(std::lround(x0d * a_img.width)), 0, a_img.width);
+			const int    y0 = std::clamp(static_cast<int>(std::lround(y0d * a_img.height)), 0, a_img.height);
+			const int    x1 = std::clamp(static_cast<int>(std::lround((x0d + wd) * a_img.width)), x0, a_img.width);
+			const int    y1 = std::clamp(static_cast<int>(std::lround((y0d + hd) * a_img.height)), y0, a_img.height);
+
+			GrayImage out;
+			out.width = x1 - x0;
+			out.height = y1 - y0;
+			out.px.resize(static_cast<size_t>(out.width) * out.height);
+			for (int y = 0; y < out.height; ++y)
+				for (int x = 0; x < out.width; ++x)
+					out.px[static_cast<size_t>(y) * out.width + x] = a_img.px[static_cast<size_t>(y0 + y) * a_img.width + (x0 + x)];
+			return out;
+		}
+
+		// Windowed SSIM (Wang et al.), OVERLAPPING windows with a stride shorter than the window
+		// — a deliberately simpler approximation than skimage's Gaussian-weighted sliding window
+		// (used by visual.py) — uniform weighting, not Gaussian — but critically NOT
+		// non-overlapping blocks: a non-overlapping-block version was tried first and FAILED a
+		// basic sanity check (a fully value-inverted image scored 0.54, not strongly negative) —
+		// any image whose content happens to be flat within each block-sized tile has zero
+		// intra-block variance, which makes the contrast/structure term blind to inversion
+		// entirely, regardless of correlation sign. A stride shorter than the window guarantees
+		// most windows straddle any such boundary, restoring real sensitivity. Verified against
+		// synthetic images: identical -> ~1.0, a value-inverted image -> strongly negative,
+		// matching the standard algorithm's known behavior (confirmed independently against
+		// tests/http/visual.py's skimage-based SSIM on the same class of input). Standard
+		// constants (K1=0.01, K2=0.03, L=255 dynamic range).
+		double ComputeSsim(const GrayImage& a_a, const GrayImage& a_b)
+		{
+			constexpr double kC1 = (0.01 * 255.0) * (0.01 * 255.0);
+			constexpr double kC2 = (0.03 * 255.0) * (0.03 * 255.0);
+			constexpr int    kWindow = 8;
+			constexpr int    kStride = 3;  // < kWindow so windows overlap and straddle any block-periodic content
+
+			const int w = a_a.width, h = a_a.height;
+			if (w <= 0 || h <= 0)
+				return 0.0;
+			const int win = std::min({ kWindow, w, h });
+			if (win <= 1)
+				return 0.0;
+
+			double sum = 0.0;
+			int    windows = 0;
+			for (int by = 0; by <= h - win; by += kStride) {
+				for (int bx = 0; bx <= w - win; bx += kStride) {
+					const int n = win * win;
+
+					double meanA = 0.0, meanB = 0.0;
+					for (int y = 0; y < win; ++y)
+						for (int x = 0; x < win; ++x) {
+							const size_t idx = static_cast<size_t>(by + y) * w + (bx + x);
+							meanA += a_a.px[idx];
+							meanB += a_b.px[idx];
+						}
+					meanA /= n;
+					meanB /= n;
+
+					double varA = 0.0, varB = 0.0, covAB = 0.0;
+					for (int y = 0; y < win; ++y)
+						for (int x = 0; x < win; ++x) {
+							const size_t idx = static_cast<size_t>(by + y) * w + (bx + x);
+							const double da = a_a.px[idx] - meanA;
+							const double db = a_b.px[idx] - meanB;
+							varA += da * da;
+							varB += db * db;
+							covAB += da * db;
+						}
+					varA /= (n - 1);
+					varB /= (n - 1);
+					covAB /= (n - 1);
+
+					const double numerator = (2 * meanA * meanB + kC1) * (2 * covAB + kC2);
+					const double denominator = (meanA * meanA + meanB * meanB + kC1) * (varA + varB + kC2);
+					sum += denominator > 0.0 ? (numerator / denominator) : 1.0;
+					++windows;
+				}
+			}
+			// win > w or win > h (a crop smaller than the window) — fall back to one whole-image window.
+			if (windows == 0) {
+				double       meanA = 0.0, meanB = 0.0;
+				const size_t n = static_cast<size_t>(w) * h;
+				for (size_t i = 0; i < n; ++i) {
+					meanA += a_a.px[i];
+					meanB += a_b.px[i];
+				}
+				meanA /= n;
+				meanB /= n;
+				double varA = 0.0, varB = 0.0, covAB = 0.0;
+				for (size_t i = 0; i < n; ++i) {
+					const double da = a_a.px[i] - meanA;
+					const double db = a_b.px[i] - meanB;
+					varA += da * da;
+					varB += db * db;
+					covAB += da * db;
+				}
+				varA /= (n - 1);
+				varB /= (n - 1);
+				covAB /= (n - 1);
+				const double numerator = (2 * meanA * meanB + kC1) * (2 * covAB + kC2);
+				const double denominator = (meanA * meanA + meanB * meanB + kC1) * (varA + varB + kC2);
+				return denominator > 0.0 ? (numerator / denominator) : 1.0;
+			}
+			return sum / windows;
+		}
+
+		struct RegionScore
+		{
+			std::string name;
+			double      score = 0.0;
+			double      threshold = 0.0;
+			bool        passed = false;
+		};
+
+		// Everything a `golden` result needs, whether it succeeded or not — a decode failure
+		// (missing golden, corrupt file, dimension mismatch) is reported as `error`, not thrown:
+		// a checkpoint that can't be scored still has a real capture worth returning, it just
+		// can't carry a verdict.
+		struct GoldenScore
+		{
+			bool                     ok = false;
+			std::string              error;
+			double                   score = 0.0;
+			double                   threshold = 0.0;
+			bool                     passed = false;
+			std::vector<RegionScore> regions;
+		};
+
+		GoldenScore ScoreAgainstGolden(const fs::path& a_capturedPath, const json& a_goldenCfg)
+		{
+			GoldenScore       result;
+			const std::string goldenArg = a_goldenCfg.value("golden", std::string{});
+			if (goldenArg.empty()) {
+				result.error = "goldenCfg missing 'golden'";
+				return result;
+			}
+			fs::path goldenPath(goldenArg);
+			if (goldenPath.is_relative())
+				goldenPath = GameRoot() / goldenPath;
+
+			result.threshold = a_goldenCfg.value("threshold", 0.98);
+
+			if (!fs::exists(goldenPath)) {
+				result.error = std::format("no golden at {}", GenericPath(goldenPath));
+				return result;
+			}
+			const auto candidate = DecodeGray(a_capturedPath);
+			const auto golden = DecodeGray(goldenPath);
+			if (!candidate || !golden) {
+				result.error = "failed to decode candidate or golden image";
+				return result;
+			}
+			if (candidate->width != golden->width || candidate->height != golden->height) {
+				result.error = std::format("shape mismatch: candidate {}x{} vs golden {}x{}",
+					candidate->width, candidate->height, golden->width, golden->height);
+				return result;
+			}
+
+			const json regionCfgs = a_goldenCfg.value("regions", json::array());
+			if (!regionCfgs.empty()) {
+				double worst = 1.0;
+				bool   allPassed = true;
+				for (const auto& r : regionCfgs) {
+					const GrayImage rc = CropUv(*candidate, r);
+					const GrayImage rg = CropUv(*golden, r);
+					const double    score = ComputeSsim(rc, rg);
+					const double    threshold = r.value("threshold", result.threshold);
+					const bool      passed = score >= threshold;
+					result.regions.push_back(RegionScore{ r.value("name", std::string("?")), score, threshold, passed });
+					worst = std::min(worst, score);
+					allPassed = allPassed && passed;
+				}
+				result.ok = true;
+				result.score = worst;
+				result.passed = allPassed;
+				return result;
+			}
+
+			result.ok = true;
+			result.score = ComputeSsim(*candidate, *golden);
+			result.passed = result.score >= result.threshold;
+			return result;
+		}
+
+		// Merges {ssim, threshold, passed, regions?} into a_result IN PLACE when a_args carries a
+		// "golden" config -- a no-op (result unchanged) when it doesn't, so every existing caller
+		// that never passes a golden sees no behavior change at all.
+		void MaybeScoreAgainstGolden(json& a_result, const json& a_args, const fs::path& a_capturedPath)
+		{
+			if (!a_args.contains("golden") || !a_args["golden"].is_string() || a_args["golden"].get<std::string>().empty())
+				return;
+			const GoldenScore score = ScoreAgainstGolden(a_capturedPath, a_args);
+			if (!score.ok) {
+				a_result["goldenError"] = score.error;
+				return;
+			}
+			a_result["ssim"] = score.score;
+			a_result["threshold"] = score.threshold;
+			a_result["passed"] = score.passed;
+			if (!score.regions.empty()) {
+				json regions = json::array();
+				for (const auto& r : score.regions)
+					regions.push_back(json{ { "name", r.name }, { "ssim", r.score }, { "threshold", r.threshold }, { "passed", r.passed } });
+				a_result["regions"] = std::move(regions);
+			}
 		}
 
 		// ---- sidecar + events ----
@@ -296,7 +564,7 @@ namespace dvb::Capture
 			std::string       stem = checkpointId;
 			if (a_args.contains("repeat"))
 				stem += "__r" + std::to_string(a_args.value("repeat", 0));
-			const fs::path  capDir = fs::path(g_captureDir) / recording / variant;
+			const fs::path  capDir = CaptureDir(a_args);
 			std::error_code ec;
 			fs::create_directories(capDir, ec);
 			const fs::path dest = capDir / (stem + found.extension().string());
@@ -347,6 +615,7 @@ namespace dvb::Capture
 				if (a_args.contains(k))
 					result[k] = a_args[k];
 			result.update(sceneStamp);
+			MaybeScoreAgainstGolden(result, a_args, dest);
 
 			WriteSidecar(dest, result);
 			PublishSaved(result);
@@ -371,7 +640,7 @@ namespace dvb::Capture
 			if (a_args.contains("repeat"))
 				stem += "__r" + std::to_string(a_args.value("repeat", 0));
 
-			const fs::path  capDir = fs::path(g_captureDir) / recording / variant;
+			const fs::path  capDir = CaptureDir(a_args);
 			std::error_code ec;
 			fs::create_directories(capDir, ec);
 			const fs::path outputPath = capDir / (stem + ".png");
@@ -437,6 +706,7 @@ namespace dvb::Capture
 				if (a_args.contains(k))
 					result[k] = a_args[k];
 			result.update(sceneStamp);
+			MaybeScoreAgainstGolden(result, a_args, outputPath);
 
 			WriteSidecar(outputPath, result);
 			PublishSaved(result);
@@ -451,6 +721,22 @@ namespace dvb::Capture
 		if (length == 0 || length >= MAX_PATH)
 			return fs::current_path();
 		return fs::path(buffer).parent_path();
+	}
+
+	std::filesystem::path CaptureDir(const json& a_args)
+	{
+		// ALWAYS absolute — this is what the provider contract promises callers ("outputPath —
+		// absolute, forward-slash") and what a `capture` result's returned `path` must be too.
+		// A relative path here silently resolves against the GAME's cwd on the caller's end,
+		// not the caller's own — confirmed live as a real bug (an external tool's cwd rarely
+		// matches the Skyrim install dir). `outDir` overrides the configured base; both are
+		// resolved against GameRoot() when relative, absolute when already absolute.
+		fs::path base = a_args.value("outDir", g_captureDir);
+		if (base.is_relative())
+			base = GameRoot() / base;
+		const std::string recording = a_args.value("recording", std::string("adhoc"));
+		const std::string variant = a_args.value("variant", std::string("default"));
+		return base / recording / variant;
 	}
 
 	json ListScreenshots(const json& a_args)
@@ -542,16 +828,20 @@ namespace dvb::Capture
 		d.name = "capture";
 		d.description =
 			"Capture a frame (screenshot) and return its file path plus correlation metadata. "
-			"devbench never scores images — comparison/SSIM/thresholds/pass-fail are entirely an "
-			"external concern; this tool only captures and signals readiness. kind='auto' (default) "
-			"picks the sole registered capture provider (a mod that registered under the C-ABI "
-			"RegisterToolExtension(\"capture\", <key>, …) — see inspect kind=registrants); zero "
-			"registered providers is a 404 UNLESS allowNative=true, and two or more is a 400 naming "
-			"them (never silently guessed). kind='native' forces the low-fidelity vanilla fallback "
-			"(main-thread MenuControls::QueueScreenshot() + a directory poll — no path control, no "
-			"completion signal beyond polling, format fixed by the user's .ini, may include open UI) "
-			"— NOT comparable against a provider-authored golden image. kind='providers' lists "
-			"registered provider keys; kind='extensions' lists them with descriptors.";
+			"kind='auto' (default) picks the sole registered capture provider (a mod that "
+			"registered under the C-ABI RegisterToolExtension(\"capture\", <key>, …) — see inspect "
+			"kind=registrants); zero registered providers is a 404 UNLESS allowNative=true, and two "
+			"or more is a 400 naming them (never silently guessed). kind='native' forces the "
+			"low-fidelity vanilla fallback (main-thread MenuControls::QueueScreenshot() + a "
+			"directory poll — no path control, no completion signal beyond polling, format fixed by "
+			"the user's .ini, may include open UI) — NOT comparable against a provider-authored "
+			"golden image. kind='providers' lists registered provider keys; kind='extensions' lists "
+			"them with descriptors. Optional 'golden' compares the capture against a reference image "
+			"via SSIM and adds {ssim, threshold, passed} to the result (or 'regions' for independent "
+			"per-region scores, {name,ssim,threshold,passed} each, overall 'passed' is AND across "
+			"all — see record{action:'replay'}'s 'goldens' arg, the normal way this gets set for a "
+			"checkpoint). This is devbench's fast single-checkpoint verdict; batch/corpus regression "
+			"across many recordings stays in tests/http/visual.py.";
 		d.readOnly = false;
 		json kinds = json::array({ "auto", "native", "providers", "extensions" });
 		for (const auto& k : ToolExtensions::Keys("capture"))
@@ -570,6 +860,9 @@ namespace dvb::Capture
 								{ "pollMs", json{ { "type", "integer" }, { "description", "poll interval while waiting (default 100)" } } },
 								{ "subrect", json{ { "type", "object" }, { "description", "optional {x,y,w,h} in 0..1 UV — provider-only, native ignores it" } } },
 								{ "cleanup", json{ { "type", "boolean" }, { "description", "native only: delete the game's source screenshot after copying (default false)" } } },
+								{ "golden", json{ { "type", "string" }, { "description", "path to a reference image to SSIM-compare this capture against (absolute, or relative to the game root); adds {ssim,threshold,passed} to the result" } } },
+								{ "threshold", json{ { "type", "number" }, { "description", "golden: SSIM >= threshold passes (default 0.98)" } } },
+								{ "regions", json{ { "type", "array" }, { "description", "golden: optional [{name,x,y,w,h,threshold?}] in 0..1 UV — score independent regions instead of the whole frame; overall passed is AND across all" } } },
 							} },
 			{ "required", json::array({ "checkpointId" }) },
 		};

--- a/src/Capture.cpp
+++ b/src/Capture.cpp
@@ -4,17 +4,8 @@
 #include "EventBus.h"
 #include "GameState.h"
 #include "MainThread.h"
+#include "Ssim.h"
 #include "ToolExtensions.h"
-
-// Decode-only: two already-captured images -> pixel buffers, for the native SSIM comparison
-// below. STBI_ONLY_* keeps the codec surface to exactly the formats devbench's own captures can
-// actually be (provider captures are PNG per the provider contract; the native fallback can also
-// land BMP depending on the user's vanilla screenshot .ini setting) -- not a general-purpose
-// image loader.
-#define STB_IMAGE_IMPLEMENTATION
-#define STBI_ONLY_PNG
-#define STBI_ONLY_BMP
-#include <stb_image.h>
 
 #include <algorithm>
 #include <atomic>
@@ -142,220 +133,11 @@ namespace dvb::Capture
 		// SSIM has one universal definition and runs on two buffers devbench already has (one
 		// just came out of the capture call this same request made) — there's no competing
 		// "SSIM provider" ecosystem to be agnostic about the way there is for rendering backends.
-
-		struct GrayImage
-		{
-			std::vector<float> px;  // row-major, 0..255 range as float (SSIM math needs float)
-			int                width = 0;
-			int                height = 0;
-		};
-
-		std::optional<GrayImage> DecodeGray(const fs::path& a_path)
-		{
-			int            w = 0, h = 0, channels = 0;
-			const auto     pathStr = a_path.string();
-			unsigned char* data = stbi_load(pathStr.c_str(), &w, &h, &channels, 1);  // force 1-channel grayscale
-			if (!data)
-				return std::nullopt;
-			GrayImage img;
-			img.width = w;
-			img.height = h;
-			img.px.resize(static_cast<size_t>(w) * h);
-			for (size_t i = 0; i < img.px.size(); ++i)
-				img.px[i] = static_cast<float>(data[i]);
-			stbi_image_free(data);
-			return img;
-		}
-
-		// Crop a 0..1 UV rect {x,y,w,h} — the SAME convention the capture tool's own `subrect`
-		// arg and visual.py's regions both use, so one rect definition works everywhere.
-		GrayImage CropUv(const GrayImage& a_img, const json& a_uv)
-		{
-			const double x0d = a_uv.value("x", 0.0), y0d = a_uv.value("y", 0.0);
-			const double wd = a_uv.value("w", 1.0), hd = a_uv.value("h", 1.0);
-			const int    x0 = std::clamp(static_cast<int>(std::lround(x0d * a_img.width)), 0, a_img.width);
-			const int    y0 = std::clamp(static_cast<int>(std::lround(y0d * a_img.height)), 0, a_img.height);
-			const int    x1 = std::clamp(static_cast<int>(std::lround((x0d + wd) * a_img.width)), x0, a_img.width);
-			const int    y1 = std::clamp(static_cast<int>(std::lround((y0d + hd) * a_img.height)), y0, a_img.height);
-
-			GrayImage out;
-			out.width = x1 - x0;
-			out.height = y1 - y0;
-			out.px.resize(static_cast<size_t>(out.width) * out.height);
-			for (int y = 0; y < out.height; ++y)
-				for (int x = 0; x < out.width; ++x)
-					out.px[static_cast<size_t>(y) * out.width + x] = a_img.px[static_cast<size_t>(y0 + y) * a_img.width + (x0 + x)];
-			return out;
-		}
-
-		// Windowed SSIM (Wang et al.), OVERLAPPING windows with a stride shorter than the window
-		// — a deliberately simpler approximation than skimage's Gaussian-weighted sliding window
-		// (used by visual.py) — uniform weighting, not Gaussian — but critically NOT
-		// non-overlapping blocks: a non-overlapping-block version was tried first and FAILED a
-		// basic sanity check (a fully value-inverted image scored 0.54, not strongly negative) —
-		// any image whose content happens to be flat within each block-sized tile has zero
-		// intra-block variance, which makes the contrast/structure term blind to inversion
-		// entirely, regardless of correlation sign. A stride shorter than the window guarantees
-		// most windows straddle any such boundary, restoring real sensitivity. Verified against
-		// synthetic images: identical -> ~1.0, a value-inverted image -> strongly negative,
-		// matching the standard algorithm's known behavior (confirmed independently against
-		// tests/http/visual.py's skimage-based SSIM on the same class of input). Standard
-		// constants (K1=0.01, K2=0.03, L=255 dynamic range).
-		double ComputeSsim(const GrayImage& a_a, const GrayImage& a_b)
-		{
-			constexpr double kC1 = (0.01 * 255.0) * (0.01 * 255.0);
-			constexpr double kC2 = (0.03 * 255.0) * (0.03 * 255.0);
-			constexpr int    kWindow = 8;
-			constexpr int    kStride = 3;  // < kWindow so windows overlap and straddle any block-periodic content
-
-			const int w = a_a.width, h = a_a.height;
-			if (w <= 0 || h <= 0)
-				return 0.0;
-			const int win = std::min({ kWindow, w, h });
-			if (win <= 1)
-				return 0.0;
-
-			double sum = 0.0;
-			int    windows = 0;
-			for (int by = 0; by <= h - win; by += kStride) {
-				for (int bx = 0; bx <= w - win; bx += kStride) {
-					const int n = win * win;
-
-					double meanA = 0.0, meanB = 0.0;
-					for (int y = 0; y < win; ++y)
-						for (int x = 0; x < win; ++x) {
-							const size_t idx = static_cast<size_t>(by + y) * w + (bx + x);
-							meanA += a_a.px[idx];
-							meanB += a_b.px[idx];
-						}
-					meanA /= n;
-					meanB /= n;
-
-					double varA = 0.0, varB = 0.0, covAB = 0.0;
-					for (int y = 0; y < win; ++y)
-						for (int x = 0; x < win; ++x) {
-							const size_t idx = static_cast<size_t>(by + y) * w + (bx + x);
-							const double da = a_a.px[idx] - meanA;
-							const double db = a_b.px[idx] - meanB;
-							varA += da * da;
-							varB += db * db;
-							covAB += da * db;
-						}
-					varA /= (n - 1);
-					varB /= (n - 1);
-					covAB /= (n - 1);
-
-					const double numerator = (2 * meanA * meanB + kC1) * (2 * covAB + kC2);
-					const double denominator = (meanA * meanA + meanB * meanB + kC1) * (varA + varB + kC2);
-					sum += denominator > 0.0 ? (numerator / denominator) : 1.0;
-					++windows;
-				}
-			}
-			// win > w or win > h (a crop smaller than the window) — fall back to one whole-image window.
-			if (windows == 0) {
-				double       meanA = 0.0, meanB = 0.0;
-				const size_t n = static_cast<size_t>(w) * h;
-				for (size_t i = 0; i < n; ++i) {
-					meanA += a_a.px[i];
-					meanB += a_b.px[i];
-				}
-				meanA /= n;
-				meanB /= n;
-				double varA = 0.0, varB = 0.0, covAB = 0.0;
-				for (size_t i = 0; i < n; ++i) {
-					const double da = a_a.px[i] - meanA;
-					const double db = a_b.px[i] - meanB;
-					varA += da * da;
-					varB += db * db;
-					covAB += da * db;
-				}
-				varA /= (n - 1);
-				varB /= (n - 1);
-				covAB /= (n - 1);
-				const double numerator = (2 * meanA * meanB + kC1) * (2 * covAB + kC2);
-				const double denominator = (meanA * meanA + meanB * meanB + kC1) * (varA + varB + kC2);
-				return denominator > 0.0 ? (numerator / denominator) : 1.0;
-			}
-			return sum / windows;
-		}
-
-		struct RegionScore
-		{
-			std::string name;
-			double      score = 0.0;
-			double      threshold = 0.0;
-			bool        passed = false;
-		};
-
-		// Everything a `golden` result needs, whether it succeeded or not — a decode failure
-		// (missing golden, corrupt file, dimension mismatch) is reported as `error`, not thrown:
-		// a checkpoint that can't be scored still has a real capture worth returning, it just
-		// can't carry a verdict.
-		struct GoldenScore
-		{
-			bool                     ok = false;
-			std::string              error;
-			double                   score = 0.0;
-			double                   threshold = 0.0;
-			bool                     passed = false;
-			std::vector<RegionScore> regions;
-		};
-
-		GoldenScore ScoreAgainstGolden(const fs::path& a_capturedPath, const json& a_goldenCfg)
-		{
-			GoldenScore       result;
-			const std::string goldenArg = a_goldenCfg.value("golden", std::string{});
-			if (goldenArg.empty()) {
-				result.error = "goldenCfg missing 'golden'";
-				return result;
-			}
-			fs::path goldenPath(goldenArg);
-			if (goldenPath.is_relative())
-				goldenPath = GameRoot() / goldenPath;
-
-			result.threshold = a_goldenCfg.value("threshold", 0.98);
-
-			if (!fs::exists(goldenPath)) {
-				result.error = std::format("no golden at {}", GenericPath(goldenPath));
-				return result;
-			}
-			const auto candidate = DecodeGray(a_capturedPath);
-			const auto golden = DecodeGray(goldenPath);
-			if (!candidate || !golden) {
-				result.error = "failed to decode candidate or golden image";
-				return result;
-			}
-			if (candidate->width != golden->width || candidate->height != golden->height) {
-				result.error = std::format("shape mismatch: candidate {}x{} vs golden {}x{}",
-					candidate->width, candidate->height, golden->width, golden->height);
-				return result;
-			}
-
-			const json regionCfgs = a_goldenCfg.value("regions", json::array());
-			if (!regionCfgs.empty()) {
-				double worst = 1.0;
-				bool   allPassed = true;
-				for (const auto& r : regionCfgs) {
-					const GrayImage rc = CropUv(*candidate, r);
-					const GrayImage rg = CropUv(*golden, r);
-					const double    score = ComputeSsim(rc, rg);
-					const double    threshold = r.value("threshold", result.threshold);
-					const bool      passed = score >= threshold;
-					result.regions.push_back(RegionScore{ r.value("name", std::string("?")), score, threshold, passed });
-					worst = std::min(worst, score);
-					allPassed = allPassed && passed;
-				}
-				result.ok = true;
-				result.score = worst;
-				result.passed = allPassed;
-				return result;
-			}
-
-			result.ok = true;
-			result.score = ComputeSsim(*candidate, *golden);
-			result.passed = result.score >= result.threshold;
-			return result;
-		}
+		//
+		// The actual decode/crop/SSIM math lives in Ssim.h/.cpp — a module with zero RE/SKSE
+		// dependency, so it's unit-testable in the host-independent devbench-tests target (see
+		// tests/Ssim_test.cpp) with no game required. This file only resolves a relative golden
+		// path against GameRoot() before calling in.
 
 		// Mirrors tests/http/visual.py's capture_inconclusive_reason(): a sceneMismatch, any
 		// `degraded` stamp, or a native-fallback capture all mean "don't trust this as a real
@@ -388,7 +170,10 @@ namespace dvb::Capture
 		{
 			if (!a_args.contains("golden") || !a_args["golden"].is_string() || a_args["golden"].get<std::string>().empty())
 				return;
-			const GoldenScore score = ScoreAgainstGolden(a_capturedPath, a_args);
+			fs::path goldenPath(a_args["golden"].get<std::string>());
+			if (goldenPath.is_relative())
+				goldenPath = GameRoot() / goldenPath;
+			const Ssim::GoldenScore score = Ssim::ScoreAgainstGolden(a_capturedPath, goldenPath, a_args);
 			if (!score.ok) {
 				a_result["goldenError"] = score.error;
 				return;

--- a/src/Capture.cpp
+++ b/src/Capture.cpp
@@ -37,6 +37,16 @@ namespace dvb::Capture
 			return a_p.generic_string();  // forward slashes, per the provider contract
 		}
 
+		// recording/variant/checkpointId all become single path SEGMENTS under the capture
+		// root (never a sub-path) -- reject anything that could escape it (a separator, "..",
+		// or a bare ".") instead of silently building a path outside g_captureDir/outDir.
+		void ValidatePathSegment(std::string_view a_field, const std::string& a_value)
+		{
+			if (a_value.empty() || a_value == "." || a_value == ".." ||
+				a_value.find('/') != std::string::npos || a_value.find('\\') != std::string::npos)
+				throw ToolError(400, std::format("invalid '{}': must be a single path segment (no '/', '\\\\', '.', or '..')", a_field));
+		}
+
 		// ---- game root / directory scanning (shared by the native fallback and inspect kind=screenshots) ----
 
 		struct ScannedFile
@@ -97,22 +107,28 @@ namespace dvb::Capture
 
 		json ReadSceneStamp()
 		{
-			return MainThread::RunAndWait([]() -> json {
-				json  j;
-				auto* pc = RE::PlayerCharacter::GetSingleton();
-				if (pc) {
-					if (auto* cell = pc->GetParentCell())
-						j["cellFormID"] = cell->GetFormID();
-					if (auto* ws = pc->GetWorldspace())
-						j["worldspaceFormID"] = ws->GetFormID();
-				}
-				if (auto* cal = RE::Calendar::GetSingleton())
-					j["gameHour"] = cal->GetHour();
-				if (auto* sky = RE::Sky::GetSingleton(); sky && sky->currentWeather)
-					j["weatherFormID"] = sky->currentWeather->GetFormID();
-				return j;
-			},
-				milliseconds(1000));
+			try {
+				return MainThread::RunAndWait([]() -> json {
+					json  j;
+					auto* pc = RE::PlayerCharacter::GetSingleton();
+					if (pc) {
+						if (auto* cell = pc->GetParentCell())
+							j["cellFormID"] = cell->GetFormID();
+						if (auto* ws = pc->GetWorldspace())
+							j["worldspaceFormID"] = ws->GetFormID();
+					}
+					if (auto* cal = RE::Calendar::GetSingleton())
+						j["gameHour"] = cal->GetHour();
+					if (auto* sky = RE::Sky::GetSingleton(); sky && sky->currentWeather)
+						j["weatherFormID"] = sky->currentWeather->GetFormID();
+					return j;
+				},
+					milliseconds(1000));
+			} catch (const ToolError&) {
+				// e.g. a stalled main thread -- a scene stamp is enrichment, not a requirement;
+				// the capture itself already succeeded by the time this runs.
+				return json::object();
+			}
 		}
 
 		// ---- image comparison (SSIM) ----
@@ -256,10 +272,17 @@ namespace dvb::Capture
 							ready.error = ev.payload.value("error", std::string("provider reported failure"));
 							return ready;
 						}
+						// A provider reporting ok:true is not proof the file is actually on disk
+						// yet (event and write can race) — verify before trusting it, otherwise
+						// fall through to the file-based fallback below instead of reporting a
+						// false success.
 						std::error_code ec;
+						const auto      size = fs::file_size(a_path, ec);
+						if (ec || size == 0)
+							continue;
 						ready.ok = true;
 						ready.readyBy = "event";
-						ready.bytes = fs::file_size(a_path, ec);
+						ready.bytes = size;
 						if (ev.payload.contains("uiExcluded"))
 							ready.uiExcluded = ev.payload.value("uiExcluded", false);
 						if (ev.payload.contains("width"))
@@ -300,6 +323,7 @@ namespace dvb::Capture
 			const std::string checkpointId = a_args.value("checkpointId", std::string{});
 			if (checkpointId.empty())
 				throw ToolError(400, "capture requires 'checkpointId'");
+			ValidatePathSegment("checkpointId", checkpointId);
 
 			// Preflight: bAllowScreenShot can disable vanilla capture outright.
 			const bool allowed = MainThread::RunAndWait([]() -> json {
@@ -444,6 +468,7 @@ namespace dvb::Capture
 			const std::string checkpointId = a_args.value("checkpointId", std::string{});
 			if (checkpointId.empty())
 				throw ToolError(400, "capture requires 'checkpointId'");
+			ValidatePathSegment("checkpointId", checkpointId);
 			const std::string recording = a_args.value("recording", std::string("adhoc"));
 			const std::string variant = a_args.value("variant", std::string("default"));
 			std::string       stem = checkpointId;
@@ -547,6 +572,8 @@ namespace dvb::Capture
 			base = GameRoot() / base;
 		const std::string recording = a_args.value("recording", std::string("adhoc"));
 		const std::string variant = a_args.value("variant", std::string("default"));
+		ValidatePathSegment("recording", recording);
+		ValidatePathSegment("variant", variant);
 		return base / recording / variant;
 	}
 
@@ -571,7 +598,9 @@ namespace dvb::Capture
 				{ "file", f.path.filename().string() },
 				{ "path", GenericPath(f.path) },
 				{ "bytes", f.size },
-				{ "mtimeEpoch", duration_cast<seconds>(f.mtime.time_since_epoch()).count() },
+				// file_time_type's clock epoch is NOT the Unix epoch (e.g. 1601 on MSVC) --
+				// clock_cast to system_clock first, or this reports a nonsense timestamp.
+				{ "mtimeEpoch", duration_cast<seconds>(std::chrono::clock_cast<std::chrono::system_clock>(f.mtime).time_since_epoch()).count() },
 			});
 		}
 		json dirList = json::array();

--- a/src/Capture.cpp
+++ b/src/Capture.cpp
@@ -357,6 +357,30 @@ namespace dvb::Capture
 			return result;
 		}
 
+		// Mirrors tests/http/visual.py's capture_inconclusive_reason(): a sceneMismatch, any
+		// `degraded` stamp, or a native-fallback capture all mean "don't trust this as a real
+		// verdict." Computed HERE, once, in the result every caller already reads — a live
+		// multi-checkpoint test surfaced that without this, an LLM (or any caller) had to
+		// re-derive the same judgment from raw `sceneMismatch`/`degraded`/`provider` fields
+		// every time, which both surfaces (native and visual.py) would inevitably drift on.
+		void ComputeInconclusive(json& a_result)
+		{
+			std::string reason;
+			if (a_result.value("sceneMismatch", false)) {
+				reason = "sceneMismatch";
+			} else if (const json& degraded = a_result.value("degraded", json::array()); !degraded.empty()) {
+				std::string list;
+				for (const auto& d : degraded)
+					list += (list.empty() ? "" : ", ") + d.get<std::string>();
+				reason = "degraded: " + list;
+			} else if (a_result.value("provider", std::string{}) == "native") {
+				reason = "captured via the low-fidelity native fallback, not a registered provider";
+			}
+			a_result["inconclusive"] = !reason.empty();
+			if (!reason.empty())
+				a_result["inconclusiveReason"] = reason;
+		}
+
 		// Merges {ssim, threshold, passed, regions?} into a_result IN PLACE when a_args carries a
 		// "golden" config -- a no-op (result unchanged) when it doesn't, so every existing caller
 		// that never passes a golden sees no behavior change at all.
@@ -603,7 +627,7 @@ namespace dvb::Capture
 				{ "sceneMismatch", a_args.value("sceneMismatch", false) },
 				{ "uiExcluded", false },
 				{ "readyBy", "poll" },
-				{ "elapsedMs", duration_cast<milliseconds>(steady_clock::now() - start).count() },
+				{ "captureElapsedMs", duration_cast<milliseconds>(steady_clock::now() - start).count() },
 				{ "degraded", std::move(degraded) },
 				{ "sourcePath", GenericPath(found) },
 			};
@@ -615,6 +639,7 @@ namespace dvb::Capture
 				if (a_args.contains(k))
 					result[k] = a_args[k];
 			result.update(sceneStamp);
+			ComputeInconclusive(result);
 			MaybeScoreAgainstGolden(result, a_args, dest);
 
 			WriteSidecar(dest, result);
@@ -690,7 +715,7 @@ namespace dvb::Capture
 				{ "sceneMismatch", a_args.value("sceneMismatch", false) },
 				{ "uiExcluded", ready.uiExcluded.value_or(false) },
 				{ "readyBy", ready.readyBy },
-				{ "elapsedMs", duration_cast<milliseconds>(steady_clock::now() - start).count() },
+				{ "captureElapsedMs", duration_cast<milliseconds>(steady_clock::now() - start).count() },
 				{ "requestId", requestId },
 				{ "degraded", std::move(degraded) },
 			};
@@ -706,6 +731,7 @@ namespace dvb::Capture
 				if (a_args.contains(k))
 					result[k] = a_args[k];
 			result.update(sceneStamp);
+			ComputeInconclusive(result);
 			MaybeScoreAgainstGolden(result, a_args, outputPath);
 
 			WriteSidecar(outputPath, result);
@@ -840,7 +866,10 @@ namespace dvb::Capture
 			"via SSIM and adds {ssim, threshold, passed} to the result (or 'regions' for independent "
 			"per-region scores, {name,ssim,threshold,passed} each, overall 'passed' is AND across "
 			"all — see record{action:'replay'}'s 'goldens' arg, the normal way this gets set for a "
-			"checkpoint). This is devbench's fast single-checkpoint verdict; batch/corpus regression "
+			"checkpoint). Every result also carries {inconclusive, inconclusiveReason?} — true when "
+			"sceneMismatch, any 'degraded' entry, or a native-fallback capture means 'passed' (if "
+			"present) should NOT be trusted as a real verdict; always check this before acting on "
+			"'passed'. This is devbench's fast single-checkpoint verdict; batch/corpus regression "
 			"across many recordings stays in tests/http/visual.py.";
 		d.readOnly = false;
 		json kinds = json::array({ "auto", "native", "providers", "extensions" });

--- a/src/Capture.cpp
+++ b/src/Capture.cpp
@@ -1,0 +1,591 @@
+#include "Capture.h"
+
+#include "Config.h"
+#include "EventBus.h"
+#include "GameState.h"
+#include "MainThread.h"
+#include "ToolExtensions.h"
+
+#include <algorithm>
+#include <atomic>
+#include <chrono>
+#include <cstdio>
+#include <ctime>
+#include <fstream>
+#include <thread>
+
+namespace dvb::Capture
+{
+	namespace
+	{
+		namespace fs = std::filesystem;
+		using namespace std::chrono;
+
+		EventBus*                g_events = nullptr;
+		std::string              g_captureDir = "Data/SKSE/Plugins/devbench/captures";
+		long                     g_captureTimeoutMs = 8000;
+		long                     g_captureSettleMs = 500;  // not consumed here yet — read by the Part 2 checkpoint macro
+		std::vector<std::string> g_captureScanDirs = { "", "Screenshots" };
+
+		std::atomic<std::uint64_t> g_requestSeq{ 0 };
+
+		std::string GenericPath(const fs::path& a_p)
+		{
+			return a_p.generic_string();  // forward slashes, per the provider contract
+		}
+
+		// ---- game root / directory scanning (shared by the native fallback and inspect kind=screenshots) ----
+
+		struct ScannedFile
+		{
+			fs::path           path;
+			std::uintmax_t     size = 0;
+			fs::file_time_type mtime{};
+		};
+
+		std::vector<ScannedFile> ScanDirs(const std::vector<fs::path>& a_dirs)
+		{
+			std::vector<ScannedFile>          out;
+			static constexpr std::string_view kExts[] = { ".bmp", ".png", ".jpg", ".jpeg", ".dds" };
+			for (const auto& dir : a_dirs) {
+				std::error_code ec;
+				for (const auto& e : fs::directory_iterator(dir, ec)) {
+					if (!e.is_regular_file(ec))
+						continue;
+					const std::string ext = e.path().extension().string();
+					std::string       extLower = ext;
+					std::transform(extLower.begin(), extLower.end(), extLower.begin(), [](unsigned char c) { return static_cast<char>(std::tolower(c)); });
+					if (std::find(std::begin(kExts), std::end(kExts), extLower) == std::end(kExts))
+						continue;
+					std::error_code sizeEc, timeEc;
+					out.push_back({ e.path(), e.file_size(sizeEc), e.last_write_time(timeEc) });
+				}
+			}
+			return out;
+		}
+
+		// True only when no other handle is open on the file — the deterministic "is the writer
+		// still holding it" probe (a size-stability check alone can false-positive under OS write
+		// buffering; a magic-byte check can't prove completeness since the header is written first).
+		bool IsWriterDone(const fs::path& a_p)
+		{
+			HANDLE h = CreateFileW(a_p.c_str(), GENERIC_READ, 0 /*no sharing*/, nullptr,
+				OPEN_EXISTING, FILE_ATTRIBUTE_NORMAL, nullptr);
+			if (h == INVALID_HANDLE_VALUE)
+				return false;  // ERROR_SHARING_VIOLATION (or similar) → the writer still holds it
+			CloseHandle(h);
+			return true;
+		}
+
+		bool CopyWithRetry(const fs::path& a_from, const fs::path& a_to, std::string& a_err)
+		{
+			for (int i = 0; i < 5; ++i) {
+				std::error_code ec;
+				fs::copy_file(a_from, a_to, fs::copy_options::overwrite_existing, ec);
+				if (!ec)
+					return true;
+				a_err = ec.message();
+				std::this_thread::sleep_for(milliseconds(50 * (1 << i)));  // 50…800ms
+			}
+			return false;
+		}
+
+		// ---- scene stamp (best-effort correlation metadata; never fails the capture) ----
+
+		json ReadSceneStamp()
+		{
+			return MainThread::RunAndWait([]() -> json {
+				json  j;
+				auto* pc = RE::PlayerCharacter::GetSingleton();
+				if (pc) {
+					if (auto* cell = pc->GetParentCell())
+						j["cellFormID"] = cell->GetFormID();
+					if (auto* ws = pc->GetWorldspace())
+						j["worldspaceFormID"] = ws->GetFormID();
+				}
+				if (auto* cal = RE::Calendar::GetSingleton())
+					j["gameHour"] = cal->GetHour();
+				if (auto* sky = RE::Sky::GetSingleton(); sky && sky->currentWeather)
+					j["weatherFormID"] = sky->currentWeather->GetFormID();
+				return j;
+			},
+				milliseconds(1000));
+		}
+
+		// ---- sidecar + events ----
+
+		void WriteSidecar(const fs::path& a_imagePath, const json& a_result)
+		{
+			fs::path sidecar = a_imagePath;
+			sidecar.replace_extension(".json");
+			std::error_code ec;
+			fs::create_directories(sidecar.parent_path(), ec);
+			std::ofstream out(sidecar, std::ios::trunc);
+			if (out)
+				out << a_result.dump(2) << '\n';
+			else
+				logs::warn("devbench capture: could not write sidecar {}", sidecar.string());
+		}
+
+		void PublishSaved(const json& a_result)
+		{
+			if (g_events)
+				g_events->Publish("capture.saved", a_result);
+		}
+
+		void PublishAbandoned(const std::string& a_requestId, const std::string& a_path,
+			const json& a_args, const std::string& a_reason)
+		{
+			if (!g_events)
+				return;
+			g_events->Publish("capture.abandoned", json{
+													   { "requestId", a_requestId },
+													   { "path", a_path },
+													   { "checkpointId", a_args.value("checkpointId", std::string{}) },
+													   { "runId", a_args.value("runId", json(nullptr)) },
+													   { "reason", a_reason },
+												   });
+		}
+
+		// ---- provider readiness: capture.ready event, or a file-based fallback poll ----
+
+		struct Ready
+		{
+			bool                ok = false;
+			std::string         readyBy;  // "event" | "poll"
+			std::string         error;
+			std::uintmax_t      bytes = 0;
+			std::optional<bool> uiExcluded;
+			std::optional<int>  width, height;
+		};
+
+		Ready AwaitArtifact(std::uint64_t a_sinceSeq, const std::string& a_requestId,
+			const fs::path& a_path, long a_timeoutMs, long a_pollMs)
+		{
+			Ready      ready;
+			uint64_t   since = a_sinceSeq;
+			const auto deadline = steady_clock::now() + milliseconds(a_timeoutMs);
+			while (steady_clock::now() < deadline) {
+				if (g_events) {
+					for (const auto& ev : g_events->Since(since)) {
+						since = ev.seq;
+						if (ev.topic != "capture.ready")
+							continue;
+						if (ev.payload.value("requestId", std::string{}) != a_requestId)
+							continue;
+						if (!ev.payload.value("ok", false)) {
+							ready.ok = false;
+							ready.readyBy = "event";
+							ready.error = ev.payload.value("error", std::string("provider reported failure"));
+							return ready;
+						}
+						std::error_code ec;
+						ready.ok = true;
+						ready.readyBy = "event";
+						ready.bytes = fs::file_size(a_path, ec);
+						if (ev.payload.contains("uiExcluded"))
+							ready.uiExcluded = ev.payload.value("uiExcluded", false);
+						if (ev.payload.contains("width"))
+							ready.width = ev.payload.value("width", 0);
+						if (ev.payload.contains("height"))
+							ready.height = ev.payload.value("height", 0);
+						return ready;
+					}
+				}
+				// Fallback: the provider never emitted (or the event was evicted from the ring) —
+				// resolve from the file itself so a working-but-degraded provider is still visible
+				// rather than blocking the full timeout for nothing.
+				std::error_code ec;
+				if (fs::exists(a_path, ec) && IsWriterDone(a_path)) {
+					const auto size1 = fs::file_size(a_path, ec);
+					std::this_thread::sleep_for(milliseconds(a_pollMs));
+					const auto size2 = fs::file_size(a_path, ec);
+					if (size1 > 0 && size1 == size2) {
+						ready.ok = true;
+						ready.readyBy = "poll";
+						ready.bytes = size2;
+						return ready;
+					}
+				}
+				std::this_thread::sleep_for(milliseconds(a_pollMs));
+			}
+			ready.ok = false;
+			ready.readyBy = "poll";
+			ready.error = "timed out waiting for the capture provider";
+			return ready;
+		}
+
+		// ---- native fallback ----
+
+		json Native(const json& a_args)
+		{
+			const auto        start = steady_clock::now();
+			const std::string checkpointId = a_args.value("checkpointId", std::string{});
+			if (checkpointId.empty())
+				throw ToolError(400, "capture requires 'checkpointId'");
+
+			// Preflight: bAllowScreenShot can disable vanilla capture outright.
+			const bool allowed = MainThread::RunAndWait([]() -> json {
+				if (auto* ini = RE::INISettingCollection::GetSingleton()) {
+					if (auto* s = ini->GetSetting("bAllowScreenShot:Display"))
+						return json(s->GetBool());
+				}
+				return json(true);  // absent → assume allowed rather than block on a guess
+			},
+				milliseconds(1000))
+			                         .get<bool>();
+			if (!allowed)
+				throw ToolError(409, "vanilla screenshots disabled (bAllowScreenShot:Display=0)");
+
+			std::vector<fs::path> dirs;
+			for (const auto& rel : g_captureScanDirs)
+				dirs.push_back(rel.empty() ? GameRoot() : GameRoot() / rel);
+
+			// Snapshot BEFORE queueing, so the post-queue scan can tell "new" from "pre-existing".
+			auto                                         before = ScanDirs(dirs);
+			std::unordered_map<std::string, ScannedFile> beforeByPath;
+			for (auto& f : before)
+				beforeByPath[f.path.string()] = f;
+
+			const bool queued = MainThread::RunAndWait([]() -> json {
+				auto* mc = RE::MenuControls::GetSingleton();
+				return json(mc && mc->QueueScreenshot());
+			},
+				milliseconds(1000))
+			                        .get<bool>();
+			if (!queued)
+				throw ToolError(409, "no ScreenshotHandler, or a shot is already queued");
+
+			const long timeoutMs = a_args.value("timeoutMs", g_captureTimeoutMs);
+			const long pollMs = a_args.value("pollMs", static_cast<long>(100));
+			const auto deadline = steady_clock::now() + milliseconds(timeoutMs);
+
+			fs::path found;
+			while (steady_clock::now() < deadline && found.empty()) {
+				for (const auto& f : ScanDirs(dirs)) {
+					const std::string key = f.path.string();
+					const auto        it = beforeByPath.find(key);
+					// Three-way candidate rule: new path, OR changed size, OR newer mtime — mtime
+					// compared per-file against ITS OWN prior snapshot, never against a wall-clock
+					// t0 (the engine writes a fresh auto-incremented filename every time, so the
+					// set-difference branch is primary and granularity-independent; the other two
+					// are defence in depth).
+					const bool isCandidate = it == beforeByPath.end() ||
+					                         it->second.size != f.size ||
+					                         f.mtime > it->second.mtime;
+					if (!isCandidate)
+						continue;
+					if (f.size == 0 || !IsWriterDone(f.path))
+						continue;
+					found = f.path;
+					break;
+				}
+				if (found.empty())
+					std::this_thread::sleep_for(milliseconds(pollMs));
+			}
+			if (found.empty()) {
+				std::string dirList;
+				for (const auto& d : dirs)
+					dirList += (dirList.empty() ? "" : ", ") + d.string();
+				PublishAbandoned("", "", a_args, "timeout");
+				throw ToolError(504, std::format("no new screenshot appeared within {}ms (scanned: {})", timeoutMs, dirList));
+			}
+
+			const std::string recording = a_args.value("recording", std::string("adhoc"));
+			const std::string variant = a_args.value("variant", std::string("default"));
+			std::string       stem = checkpointId;
+			if (a_args.contains("repeat"))
+				stem += "__r" + std::to_string(a_args.value("repeat", 0));
+			const fs::path  capDir = fs::path(g_captureDir) / recording / variant;
+			std::error_code ec;
+			fs::create_directories(capDir, ec);
+			const fs::path dest = capDir / (stem + found.extension().string());
+
+			std::string copyErr;
+			bool        cleanupFailed = false;
+			if (!CopyWithRetry(found, dest, copyErr))
+				throw ToolError(500, std::format("failed to copy captured screenshot: {}", copyErr));
+			if (a_args.value("cleanup", false)) {
+				std::string     rmErr;
+				std::error_code rmEc;
+				fs::remove(found, rmEc);
+				if (rmEc)
+					cleanupFailed = true;
+			}
+
+			const auto sceneStamp = ReadSceneStamp();
+			json       degraded = json::array({ "nativeFallback", "formatFromIni", "hudNotSuppressed" });
+			if (cleanupFailed)
+				degraded.push_back("cleanupFailed");
+			if (a_args.value("sceneMismatch", false))
+				degraded.push_back("sceneMismatch");
+
+			json result{
+				{ "ok", true },
+				{ "provider", "native" },
+				{ "kind", "screenshot" },
+				{ "path", GenericPath(dest) },
+				{ "file", dest.filename().string() },
+				{ "bytes", static_cast<std::uintmax_t>(fs::file_size(dest, ec)) },
+				{ "checkpointId", checkpointId },
+				{ "recording", recording },
+				{ "variant", variant },
+				{ "frame", game::CurrentFrame() },
+				{ "epoch", static_cast<long long>(std::time(nullptr)) },
+				{ "sceneMismatch", a_args.value("sceneMismatch", false) },
+				{ "uiExcluded", false },
+				{ "readyBy", "poll" },
+				{ "elapsedMs", duration_cast<milliseconds>(steady_clock::now() - start).count() },
+				{ "degraded", std::move(degraded) },
+				{ "sourcePath", GenericPath(found) },
+			};
+			if (a_args.contains("runId"))
+				result["runId"] = a_args["runId"];
+			if (a_args.contains("repeat"))
+				result["repeat"] = a_args["repeat"];
+			for (const char* k : { "atMs", "resolvedAtMs", "resolvedIndex" })
+				if (a_args.contains(k))
+					result[k] = a_args[k];
+			result.update(sceneStamp);
+
+			WriteSidecar(dest, result);
+			PublishSaved(result);
+			return result;
+		}
+
+		// ---- provider dispatch ----
+
+		json DispatchToProvider(const std::string& a_providerKey, const json& a_args, const ToolContext& a_ctx)
+		{
+			const auto start = steady_clock::now();
+			auto       entry = ToolExtensions::Find("capture", a_providerKey);
+			if (!entry)
+				throw ToolError(404, std::format("no capture provider registered under '{}'", a_providerKey));
+
+			const std::string checkpointId = a_args.value("checkpointId", std::string{});
+			if (checkpointId.empty())
+				throw ToolError(400, "capture requires 'checkpointId'");
+			const std::string recording = a_args.value("recording", std::string("adhoc"));
+			const std::string variant = a_args.value("variant", std::string("default"));
+			std::string       stem = checkpointId;
+			if (a_args.contains("repeat"))
+				stem += "__r" + std::to_string(a_args.value("repeat", 0));
+
+			const fs::path  capDir = fs::path(g_captureDir) / recording / variant;
+			std::error_code ec;
+			fs::create_directories(capDir, ec);
+			const fs::path outputPath = capDir / (stem + ".png");
+
+			const std::string requestId = std::format("{}#{}#{}", checkpointId,
+				a_args.value("runId", 0), g_requestSeq.fetch_add(1, std::memory_order_relaxed));
+
+			json providerArgs = a_args;
+			providerArgs["outputPath"] = GenericPath(outputPath);
+			providerArgs["requestId"] = requestId;
+
+			// Snapshot BEFORE invoking the provider — a fast provider could publish its
+			// capture.ready event before an after-the-fact snapshot, causing a false timeout.
+			const std::uint64_t sinceSeq = g_events ? g_events->HeadSeq() : 0;
+
+			const json queued = entry->handler(providerArgs, a_ctx);
+			if (queued.contains("error"))
+				throw ToolError(502, queued.value("error", std::string("capture provider failed")));
+
+			const long  timeoutMs = a_args.value("timeoutMs", g_captureTimeoutMs);
+			const long  pollMs = a_args.value("pollMs", static_cast<long>(100));
+			const Ready ready = AwaitArtifact(sinceSeq, requestId, outputPath, timeoutMs, pollMs);
+			if (!ready.ok) {
+				PublishAbandoned(requestId, GenericPath(outputPath), a_args, "timeout");
+				throw ToolError(504, std::format("capture provider '{}' did not deliver: {}", a_providerKey, ready.error));
+			}
+
+			const auto sceneStamp = ReadSceneStamp();
+			json       degraded = json::array();
+			if (a_args.value("sceneMismatch", false))
+				degraded.push_back("sceneMismatch");
+			if (ready.uiExcluded.has_value() && !*ready.uiExcluded)
+				degraded.push_back("uiIncluded");
+
+			json result{
+				{ "ok", true },
+				{ "provider", a_providerKey },
+				{ "kind", "screenshot" },
+				{ "path", GenericPath(outputPath) },
+				{ "file", outputPath.filename().string() },
+				{ "bytes", ready.bytes },
+				{ "checkpointId", checkpointId },
+				{ "recording", recording },
+				{ "variant", variant },
+				{ "frame", game::CurrentFrame() },
+				{ "epoch", static_cast<long long>(std::time(nullptr)) },
+				{ "sceneMismatch", a_args.value("sceneMismatch", false) },
+				{ "uiExcluded", ready.uiExcluded.value_or(false) },
+				{ "readyBy", ready.readyBy },
+				{ "elapsedMs", duration_cast<milliseconds>(steady_clock::now() - start).count() },
+				{ "requestId", requestId },
+				{ "degraded", std::move(degraded) },
+			};
+			if (ready.width)
+				result["width"] = *ready.width;
+			if (ready.height)
+				result["height"] = *ready.height;
+			if (a_args.contains("runId"))
+				result["runId"] = a_args["runId"];
+			if (a_args.contains("repeat"))
+				result["repeat"] = a_args["repeat"];
+			for (const char* k : { "atMs", "resolvedAtMs", "resolvedIndex" })
+				if (a_args.contains(k))
+					result[k] = a_args[k];
+			result.update(sceneStamp);
+
+			WriteSidecar(outputPath, result);
+			PublishSaved(result);
+			return result;
+		}
+	}
+
+	std::filesystem::path GameRoot()
+	{
+		wchar_t     buffer[MAX_PATH]{};
+		const DWORD length = GetModuleFileNameW(nullptr, buffer, MAX_PATH);
+		if (length == 0 || length >= MAX_PATH)
+			return fs::current_path();
+		return fs::path(buffer).parent_path();
+	}
+
+	json ListScreenshots(const json& a_args)
+	{
+		std::vector<fs::path> dirs;
+		if (const std::string dirArg = a_args.value("dir", std::string{}); !dirArg.empty()) {
+			dirs.push_back(dirArg);
+		} else {
+			for (const auto& rel : g_captureScanDirs)
+				dirs.push_back(rel.empty() ? GameRoot() : GameRoot() / rel);
+		}
+		auto files = ScanDirs(dirs);
+		std::sort(files.begin(), files.end(), [](const ScannedFile& a, const ScannedFile& b) { return a.mtime > b.mtime; });
+
+		const int limit = a_args.value("limit", 50);
+		json      shots = json::array();
+		for (std::size_t i = 0; i < files.size() && static_cast<int>(i) < limit; ++i) {
+			const auto&     f = files[i];
+			std::error_code ec;
+			shots.push_back(json{
+				{ "file", f.path.filename().string() },
+				{ "path", GenericPath(f.path) },
+				{ "bytes", f.size },
+				{ "mtimeEpoch", duration_cast<seconds>(f.mtime.time_since_epoch()).count() },
+			});
+		}
+		json dirList = json::array();
+		for (const auto& d : dirs)
+			dirList.push_back(GenericPath(d));
+		return json{
+			{ "dirs", std::move(dirList) },
+			{ "count", static_cast<int>(files.size()) },
+			{ "returned", static_cast<int>(shots.size()) },
+			{ "truncated", static_cast<int>(files.size()) > static_cast<int>(shots.size()) },
+			{ "screenshots", std::move(shots) },
+		};
+	}
+
+	json Handle(const json& a_args, const ToolContext& a_ctx)
+	{
+		const std::string kind = a_args.value("kind", std::string("auto"));
+
+		if (kind == "native")
+			return Native(a_args);
+
+		if (kind == "providers") {
+			json keys = json::array();
+			for (const auto& k : ToolExtensions::Keys("capture"))
+				keys.push_back(k);
+			return json{ { "providers", std::move(keys) } };
+		}
+
+		if (kind == "extensions") {
+			json out = json::array();
+			for (const auto& k : ToolExtensions::Keys("capture")) {
+				json e{ { "kind", k } };
+				if (auto entry = ToolExtensions::Find("capture", k))
+					e["descriptor"] = entry->descriptor;
+				out.push_back(std::move(e));
+			}
+			return json{ { "extensions", std::move(out) } };
+		}
+
+		if (kind == "auto") {
+			const auto keys = ToolExtensions::Keys("capture");
+			if (keys.size() == 1)
+				return DispatchToProvider(keys.front(), a_args, a_ctx);
+			if (keys.empty()) {
+				if (a_args.value("allowNative", false))
+					return Native(a_args);
+				throw ToolError(404,
+					"no capture provider registered; install one (see inspect kind=registrants), "
+					"or pass kind='native' / allowNative:true for the low-fidelity vanilla fallback "
+					"(NOT comparable against provider-authored goldens)");
+			}
+			std::string names;
+			for (const auto& k : keys)
+				names += (names.empty() ? "" : ", ") + k;
+			throw ToolError(400, std::format("multiple capture providers registered ({}) — pass an explicit kind", names));
+		}
+
+		// A named provider.
+		return DispatchToProvider(kind, a_args, a_ctx);
+	}
+
+	ToolDescriptor BuildCaptureDescriptor()
+	{
+		ToolDescriptor d;
+		d.name = "capture";
+		d.description =
+			"Capture a frame (screenshot) and return its file path plus correlation metadata. "
+			"devbench never scores images — comparison/SSIM/thresholds/pass-fail are entirely an "
+			"external concern; this tool only captures and signals readiness. kind='auto' (default) "
+			"picks the sole registered capture provider (a mod that registered under the C-ABI "
+			"RegisterToolExtension(\"capture\", <key>, …) — see inspect kind=registrants); zero "
+			"registered providers is a 404 UNLESS allowNative=true, and two or more is a 400 naming "
+			"them (never silently guessed). kind='native' forces the low-fidelity vanilla fallback "
+			"(main-thread MenuControls::QueueScreenshot() + a directory poll — no path control, no "
+			"completion signal beyond polling, format fixed by the user's .ini, may include open UI) "
+			"— NOT comparable against a provider-authored golden image. kind='providers' lists "
+			"registered provider keys; kind='extensions' lists them with descriptors.";
+		d.readOnly = false;
+		json kinds = json::array({ "auto", "native", "providers", "extensions" });
+		for (const auto& k : ToolExtensions::Keys("capture"))
+			kinds.push_back(k);
+		d.inputSchema = json{
+			{ "type", "object" },
+			{ "properties", json{
+								{ "kind", json{ { "type", "string" }, { "enum", kinds }, { "description", "auto (default) | native | providers | extensions | a registered provider key" } } },
+								{ "checkpointId", json{ { "type", "string" }, { "description", "REQUIRED — stable file stem and correlation key" } } },
+								{ "recording", json{ { "type", "string" }, { "description", "recording file stem, for correlation (default 'adhoc')" } } },
+								{ "variant", json{ { "type", "string" }, { "description", "variant under test, for correlation (default 'default')" } } },
+								{ "allowNative", json{ { "type", "boolean" }, { "description", "permit kind=auto to fall back to the vanilla path when no provider is registered (default false)" } } },
+								{ "excludeUi", json{ { "type", "boolean" }, { "description", "request a pre-UI capture source; native cannot honor this (default true)" } } },
+								{ "outDir", json{ { "type", "string" }, { "description", "override the capture bundle directory" } } },
+								{ "timeoutMs", json{ { "type", "integer" }, { "description", "how long to wait for the capture to be ready (default 8000)" } } },
+								{ "pollMs", json{ { "type", "integer" }, { "description", "poll interval while waiting (default 100)" } } },
+								{ "subrect", json{ { "type", "object" }, { "description", "optional {x,y,w,h} in 0..1 UV — provider-only, native ignores it" } } },
+								{ "cleanup", json{ { "type", "boolean" }, { "description", "native only: delete the game's source screenshot after copying (default false)" } } },
+							} },
+			{ "required", json::array({ "checkpointId" }) },
+		};
+		return d;
+	}
+
+	void SetEvents(EventBus* a_events)
+	{
+		g_events = a_events;
+	}
+
+	void SetDefaults(const Config& a_cfg)
+	{
+		g_captureDir = a_cfg.captureDir;
+		g_captureScanDirs = a_cfg.captureScanDirs;
+		g_captureTimeoutMs = a_cfg.captureTimeoutMs;
+		g_captureSettleMs = a_cfg.captureSettleMs;
+	}
+}

--- a/src/Capture.h
+++ b/src/Capture.h
@@ -38,6 +38,13 @@ namespace dvb::Capture
 	/// not against Documents/My Games (that's SKSE's log/save convention, a different one).
 	std::filesystem::path GameRoot();
 
+	/// The (always absolute) directory a checkpoint's capture bundle lands in:
+	/// <outDir|config.captureDir>/<recording>/<variant>, resolved against GameRoot() when
+	/// relative. Always absolute because it feeds the `path` a capture result returns to the
+	/// caller — a relative path there resolves against the GAME's cwd on the caller's end, not
+	/// the caller's own, which is a real bug for any external tool.
+	std::filesystem::path CaptureDir(const json& a_args);
+
 	ToolDescriptor BuildCaptureDescriptor();
 
 	/// Wired from RegisterCoreTools/main.cpp before the tool is reachable.

--- a/src/Capture.h
+++ b/src/Capture.h
@@ -1,0 +1,46 @@
+#pragma once
+
+#include <filesystem>
+
+#include "Json.h"
+#include "ToolRegistry.h"  // ToolContext, ToolDescriptor
+
+namespace dvb
+{
+	class EventBus;
+	struct Config;
+}
+
+// capture: take a screenshot at a replay checkpoint (or ad hoc), and return its path plus
+// correlation metadata. Devbench never scores images — that is entirely an external (Python)
+// concern; this tool's only job is capture + a reliable "the file is ready" signal.
+//
+// Capture is deliberately PLUGIN-AGNOSTIC: devbench does not implement its own D3D11/image-codec
+// capture pipeline (real graphics-engine code it doesn't own anywhere else). Instead it defines a
+// capability CONTRACT any consumer plugin can implement via the existing C-ABI
+// `RegisterToolExtension("capture", <key>, …)` mechanism — Open Shaders is the reference
+// implementation, not a hardcoded dependency. A small `kind=native` fallback exists for when no
+// provider is registered: a main-thread flag flip against vanilla's own `MenuControls::
+// QueueScreenshot()` plus a directory poll — no D3D11, no image codec, deliberately lower quality
+// than any registered provider (see Handle's kind-resolution rule).
+namespace dvb::Capture
+{
+	json Handle(const json& a_args, const ToolContext& a_ctx);
+
+	/// `inspect kind=screenshots` — list image files sitting in the vanilla screenshot
+	/// directories (game root + `Screenshots/`), independent of the `capture` tool. Shares the
+	/// directory-snapshot logic the native fallback needs, and lets a human/agent discover where
+	/// vanilla actually writes on this install (see the GameRoot() assumption below) in one call.
+	json ListScreenshots(const json& a_args);
+
+	/// The game install directory (the running executable's parent directory). Vanilla
+	/// screenshots and Open Shaders' own default capture path both resolve relative paths here,
+	/// not against Documents/My Games (that's SKSE's log/save convention, a different one).
+	std::filesystem::path GameRoot();
+
+	ToolDescriptor BuildCaptureDescriptor();
+
+	/// Wired from RegisterCoreTools/main.cpp before the tool is reachable.
+	void SetEvents(EventBus* a_events);
+	void SetDefaults(const Config& a_cfg);
+}

--- a/src/Config.cpp
+++ b/src/Config.cpp
@@ -40,6 +40,10 @@ namespace dvb
 				{ "couplingCellMs", a_cfg.couplingCellMs },
 				{ "cleanTransition", a_cfg.cleanTransition },
 				{ "cleanTransitionCell", a_cfg.cleanTransitionCell },
+				{ "captureDir", a_cfg.captureDir },
+				{ "captureScanDirs", a_cfg.captureScanDirs },
+				{ "captureTimeoutMs", a_cfg.captureTimeoutMs },
+				{ "captureSettleMs", a_cfg.captureSettleMs },
 			};
 			out << j.dump(2) << '\n';
 		}
@@ -113,6 +117,10 @@ namespace dvb
 			cfg.couplingCellMs = j.value("couplingCellMs", cfg.couplingCellMs);
 			cfg.cleanTransition = j.value("cleanTransition", cfg.cleanTransition);
 			cfg.cleanTransitionCell = j.value("cleanTransitionCell", cfg.cleanTransitionCell);
+			cfg.captureDir = j.value("captureDir", cfg.captureDir);
+			cfg.captureScanDirs = j.value("captureScanDirs", cfg.captureScanDirs);
+			cfg.captureTimeoutMs = j.value("captureTimeoutMs", cfg.captureTimeoutMs);
+			cfg.captureSettleMs = j.value("captureSettleMs", cfg.captureSettleMs);
 
 			// Migrate forward: if the file predates any key (e.g. an install from before
 			// the record hotkeys existed), rewrite it so the new keys appear with their
@@ -122,7 +130,8 @@ namespace dvb
 				"enabled", "port", "logLevel", "recordHotkey", "replayHotkey",
 				"recordHotkeyShift", "replayHotkeyShift", "replayPath", "replayRestoreScene",
 				"recordIntervalMs", "autoRunPath", "autoRunRestoreScene", "loadSettleMs",
-				"couplingAnchorMs", "couplingCellMs", "cleanTransition", "cleanTransitionCell"
+				"couplingAnchorMs", "couplingCellMs", "cleanTransition", "cleanTransitionCell",
+				"captureDir", "captureScanDirs", "captureTimeoutMs", "captureSettleMs"
 			};
 			const bool complete = std::all_of(std::begin(kKeys), std::end(kKeys),
 				[&](const char* k) { return j.contains(k); });

--- a/src/Config.h
+++ b/src/Config.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <string>
+#include <vector>
 
 namespace dvb
 {
@@ -51,6 +52,16 @@ namespace dvb
 		// loading screen. Save-loads already tear down, so they skip the bounce.
 		bool        cleanTransition = true;
 		std::string cleanTransitionCell = "QASmoke";
+
+		// `capture` tool: where captured images are written, where the native (vanilla) fallback
+		// looks for the screenshot it just triggered, and default timeouts. captureScanDirs are
+		// relative to the game install root (GetModuleFileNameW's parent dir — vanilla screenshots
+		// and Open Shaders' own default capture path both resolve there, NOT Documents/My Games,
+		// which is a different, SKSE-log-specific convention); "" means the root itself.
+		std::string              captureDir = "Data/SKSE/Plugins/devbench/captures";
+		std::vector<std::string> captureScanDirs = { "", "Screenshots" };
+		int                      captureTimeoutMs = 8000;
+		int                      captureSettleMs = 500;  // default settle before a checkpoint capture
 	};
 
 	// Load Data/SKSE/Plugins/devbench/config.json. If the file is missing it is

--- a/src/HostApi.cpp
+++ b/src/HostApi.cpp
@@ -2,10 +2,14 @@
 
 #include "DevBenchAPI.h"
 #include "EventBus.h"
+#include "GameState.h"
 #include "Json.h"
 #include "ToolExtensions.h"
 #include "ToolRegistry.h"
 #include "Version.h"
+
+#include <ctime>
+#include <mutex>
 
 namespace dvb::HostApi
 {
@@ -13,6 +17,37 @@ namespace dvb::HostApi
 	{
 		ToolRegistry* g_registry = nullptr;
 		EventBus*     g_events = nullptr;
+
+		// Registrant ledger: who asked for the C-ABI interface, and what they registered
+		// through it. Both grow only (append-only, process lifetime) — a plugin unregistering
+		// mid-session isn't a thing the C-ABI supports, so there's nothing to remove. One mutex
+		// covers both since they're written from the same call sites and read together by
+		// `inspect kind=registrants`.
+		std::mutex                g_ledgerMutex;
+		std::vector<Consumer>     g_consumers;
+		std::vector<Registration> g_registrations;
+
+		void NoteConsumer(const char* a_sender)
+		{
+			std::lock_guard<std::mutex> lock(g_ledgerMutex);
+			g_consumers.push_back(Consumer{
+				a_sender ? std::string(a_sender) : std::string("<?>"),
+				static_cast<long long>(std::time(nullptr)),
+				static_cast<std::uint32_t>(game::CurrentFrame()),
+			});
+		}
+
+		void NoteRegistration(std::string a_kind, std::string a_name, bool a_replacedExisting)
+		{
+			std::lock_guard<std::mutex> lock(g_ledgerMutex);
+			g_registrations.push_back(Registration{
+				std::move(a_kind),
+				std::move(a_name),
+				static_cast<long long>(std::time(nullptr)),
+				static_cast<std::uint32_t>(game::CurrentFrame()),
+				a_replacedExisting,
+			});
+		}
 
 		// Wrap a consumer's C callback (fn + ctx) as a ToolHandler: args in as a JSON string, result
 		// collected via our host-owned sink. Nothing C++ crosses the DLL boundary — only const char*
@@ -63,7 +98,9 @@ namespace dvb::HostApi
 				d.inputSchema = desc.value("inputSchema", json::object());
 				d.readOnly = desc.value("readOnly", false);
 
-				return g_registry->Register(std::move(d), MakeHandler(a_handler, a_ctx));
+				const bool isNew = g_registry->Register(std::move(d), MakeHandler(a_handler, a_ctx));
+				NoteRegistration("tool", a_name, !isNew);
+				return isNew;
 			}
 
 			bool RegisterMenuHandler(const char* a_menuName, const char* a_descriptorJson,
@@ -87,7 +124,9 @@ namespace dvb::HostApi
 				}
 				if (!desc.is_object())  // a scalar/array descriptor would break the descriptor object contract
 					desc = json::object();
-				return ToolExtensions::Register(a_baseTool, a_key, std::move(desc), MakeHandler(a_handler, a_ctx));
+				const bool isNew = ToolExtensions::Register(a_baseTool, a_key, std::move(desc), MakeHandler(a_handler, a_ctx));
+				NoteRegistration("extension", std::string(a_baseTool) + ":" + a_key, !isNew);
+				return isNew;
 			}
 
 			void EmitEvent(const char* a_topic, const char* a_payloadJson) override
@@ -158,7 +197,20 @@ namespace dvb::HostApi
 	{
 		if (a_message && a_message->type == DevBenchAPI::DevBenchMessage::kMessage_GetInterface && a_message->data) {
 			static_cast<DevBenchAPI::DevBenchMessage*>(a_message->data)->GetApiFunction = GetApi;
+			NoteConsumer(a_message->sender);
 			logs::info("devbench: provided plugin interface to {}", a_message->sender ? a_message->sender : "<?>");
 		}
+	}
+
+	std::vector<Consumer> Consumers()
+	{
+		std::lock_guard<std::mutex> lock(g_ledgerMutex);
+		return g_consumers;
+	}
+
+	std::vector<Registration> Registrations()
+	{
+		std::lock_guard<std::mutex> lock(g_ledgerMutex);
+		return g_registrations;
 	}
 }

--- a/src/HostApi.h
+++ b/src/HostApi.h
@@ -1,5 +1,9 @@
 #pragma once
 
+#include <cstdint>
+#include <string>
+#include <vector>
+
 namespace dvb
 {
 	class ToolRegistry;
@@ -16,5 +20,37 @@ namespace dvb
 		// Handle a DevBenchMessage::kMessage_GetInterface request. Call from the SKSE
 		// message listener for every message — it no-ops unless it's the request.
 		void OnInterfaceRequest(SKSE::MessagingInterface::Message* a_message);
+
+		// A plugin that requested the C-ABI interface (one entry per GetInterface call — a
+		// plugin that calls it more than once appears more than once, oldest first). NOTE: the
+		// requested revision is NOT captured here — GetApiFunction is a pointer the consumer
+		// calls itself, later, on its own; devbench never observes that call or its argument,
+		// only that the pointer was handed out. Reporting a revision here would be a guess
+		// dressed up as an observation.
+		struct Consumer
+		{
+			std::string   name;  // a_message->sender, or "<?>" if unset
+			long long     atEpoch;
+			std::uint32_t atFrame;
+		};
+
+		// A successful RegisterTool/RegisterToolExtension call over the C-ABI.
+		struct Registration
+		{
+			std::string   kind;  // "tool" | "extension"
+			std::string   name;  // tool name, or "<baseTool>:<key>"
+			long long     atEpoch;
+			std::uint32_t atFrame;
+			bool          replaced;  // true if this call overwrote an earlier registration
+		};
+
+		// Every GetInterface request seen so far, oldest first. Thread-safe.
+		std::vector<Consumer> Consumers();
+
+		// Every successful tool/extension registration seen so far, oldest first. Thread-safe.
+		// There is no reliable per-registration caller identity (the C-ABI interface is one
+		// shared singleton — see ROADMAP.md's "Event source tagging" item), so this cannot be
+		// joined against Consumers() by plugin name; both lists are exposed side by side instead.
+		std::vector<Registration> Registrations();
 	}
 }

--- a/src/Recording.cpp
+++ b/src/Recording.cpp
@@ -730,6 +730,12 @@ namespace dvb::Recording
 		// reported warning instead of an abort. The consumer explicitly opted into "may not work".
 		const bool force = a_args.value("force", false);
 
+		// A recording's meta.checkpoints is metadata, not a mandate — the same file can serve a
+		// plain tour replay (no provider needed, no captures written) and a visual-review run
+		// (checkpoints expanded, goldens scored) depending on what THIS call wants. Default true
+		// preserves the existing "checkpoints always fire" behavior for every current caller.
+		const bool captureCheckpoints = a_args.value("captureCheckpoints", true);
+
 		// Runtime gate: a flat setpos/setangle recording gives non-comparable frames on VR (HMD
 		// drives pitch + culling), and a VR recording won't drive a flat game. Abort on a runtime
 		// the recording wasn't marked for; force downgrades it to a warning. Unmarked (v1) = ungated.
@@ -752,7 +758,7 @@ namespace dvb::Recording
 		// clearly and early instead of 400ing on the first checkpoint's capture step deep
 		// into the trajectory.
 		const json captureCap = FindCaptureCapability(meta);
-		if (!captureCap.empty() && captureCap.value("required", true)) {
+		if (captureCheckpoints && !captureCap.empty() && captureCap.value("required", true)) {
 			const std::string want = captureCap.value("provider", std::string{});
 			const auto        keys = ToolExtensions::Keys("capture");
 			bool              ok = want.empty() ? !keys.empty() : ToolExtensions::Find("capture", want).has_value();
@@ -875,7 +881,7 @@ namespace dvb::Recording
 		// steps below — the coc/cow settle steps injected right after them, and the restore
 		// prologue's settle waits above, are NOT part of that clock and must never be added in.
 		const long        txnSettleMs = a_args.value("settleMs", static_cast<long>(g_loadSettleMs));
-		const json        checkpoints = SortedCheckpoints(meta);
+		const json        checkpoints = captureCheckpoints ? SortedCheckpoints(meta) : json::array();
 		const std::string recordingStem = fs::path(path).stem().string();
 		long              cumMs = 0;
 		size_t            cpIdx = 0;

--- a/src/Recording.cpp
+++ b/src/Recording.cpp
@@ -613,6 +613,24 @@ namespace dvb::Recording
 			};
 			if (a_cp.contains("subrect"))
 				capArgs["subrect"] = a_cp["subrect"];
+
+			// golden/threshold/regions come from THIS replay call's "goldens" map, keyed by
+			// checkpoint id — never from the checkpoint itself (meta.checkpoints carries no
+			// golden; see record{action:"checkpoint"}'s doc comment for why). Lets the same
+			// recording be replayed against different variants' goldens without touching the
+			// recording file at all.
+			if (const json goldens = a_args.value("goldens", json::object());
+				goldens.is_object() && goldens.contains(a_cp.at("id").get<std::string>())) {
+				const json& g = goldens.at(a_cp.at("id").get<std::string>());
+				if (g.is_object()) {
+					if (g.contains("golden"))
+						capArgs["golden"] = g["golden"];
+					if (g.contains("threshold"))
+						capArgs["threshold"] = g["threshold"];
+					if (g.contains("regions"))
+						capArgs["regions"] = g["regions"];
+				}
+			}
 			a_steps.push_back(json{ { "tool", "capture" }, { "args", std::move(capArgs) } });
 		}
 	}

--- a/src/Recording.cpp
+++ b/src/Recording.cpp
@@ -730,10 +730,6 @@ namespace dvb::Recording
 		// reported warning instead of an abort. The consumer explicitly opted into "may not work".
 		const bool force = a_args.value("force", false);
 
-		// A recording's meta.checkpoints is metadata, not a mandate — the same file can serve a
-		// plain tour replay (no provider needed, no captures written) and a visual-review run
-		// (checkpoints expanded, goldens scored) depending on what THIS call wants. Default true
-		// preserves the existing "checkpoints always fire" behavior for every current caller.
 		const bool captureCheckpoints = a_args.value("captureCheckpoints", true);
 
 		// Runtime gate: a flat setpos/setangle recording gives non-comparable frames on VR (HMD

--- a/src/Recording.cpp
+++ b/src/Recording.cpp
@@ -181,7 +181,8 @@ namespace dvb::Recording
 			std::thread              worker;
 			std::mutex               mtx;
 			std::vector<json>        samples;
-			std::vector<json>        commands;  // console commands seen mid-recording: { command, frame }
+			std::vector<json>        commands;     // console commands seen mid-recording: { command, frame }
+			std::vector<json>        checkpoints;  // screenshot checkpoints marked mid-recording: { id, atMs, excludeUi }
 			json                     manifest;
 			long                     intervalMs = kDefaultIntervalMs;
 			steady_clock::time_point startTick;
@@ -283,6 +284,12 @@ namespace dvb::Recording
 			meta["commandCount"] = a_rec.commands.size();
 			meta["recordedMs"] = a_recordedMs;
 			meta["recordedAt"] = static_cast<long long>(std::time(nullptr));  // record-time epoch, for tooling
+			// Checkpoints marked live via record{action:"checkpoint"} during this session. Each
+			// entry's atMs is already the recorder's own elapsed-ms clock (steady_clock since
+			// startTick) -- the SAME clock BuildReplaySteps reconstructs by summing this scenario's
+			// own "wait" values, so no reconciliation is needed here; the values just carry over.
+			if (!a_rec.checkpoints.empty())
+				meta["checkpoints"] = a_rec.checkpoints;
 			return json{ { "meta", std::move(meta) }, { "steps", std::move(steps) } };
 		}
 
@@ -358,6 +365,7 @@ namespace dvb::Recording
 				std::lock_guard lock(rec.mtx);
 				rec.samples.clear();
 				rec.commands.clear();
+				rec.checkpoints.clear();
 				rec.manifest = std::move(manifest);
 				rec.intervalMs = interval;
 			}
@@ -370,6 +378,39 @@ namespace dvb::Recording
 			Notify("devbench: recording started");
 			logs::info("devbench: recording started (interval {}ms)", interval);
 			return json{ { "action", "start" }, { "recording", true }, { "intervalMs", interval } };
+		}
+
+		if (action == "checkpoint") {
+			// Mark a screenshot checkpoint at THIS moment of an active recording -- mirrors how
+			// `stop` already captures the trajectory with zero manual JSON editing after the fact.
+			// Deliberately carries NO golden/threshold here: at mark-time there is by definition
+			// no golden yet for a first-time checkpoint, and for a regression check the comparison
+			// target belongs to replay (see record{action:"replay"}'s `goldens` arg), not to the
+			// act of marking a moment -- baking it in here would reintroduce exactly the kind of
+			// side-channel bookkeeping this action exists to eliminate.
+			if (!rec.running.load())
+				return json{ { "error", "not recording — call action=start first" } };
+			const std::string id = a_args.value("id", std::string{});
+			if (id.empty())
+				return json{ { "error", "checkpoint requires a non-empty 'id'" } };
+
+			const long atMs = static_cast<long>(
+				duration_cast<milliseconds>(steady_clock::now() - rec.startTick).count());
+			json entry{ { "id", id }, { "atMs", atMs }, { "excludeUi", a_args.value("excludeUi", true) } };
+
+			size_t count = 0;
+			{
+				std::lock_guard lock(rec.mtx);
+				if (std::any_of(rec.checkpoints.begin(), rec.checkpoints.end(),
+						[&](const json& c) { return c.value("id", std::string{}) == id; }))
+					return json{ { "error", std::format("checkpoint id '{}' already marked this recording", id) } };
+				rec.checkpoints.push_back(entry);
+				count = rec.checkpoints.size();
+			}
+			a_events.Publish("record.checkpoint", entry);
+			Notify(std::format("devbench: checkpoint '{}' marked", id));
+			logs::info("devbench: checkpoint '{}' marked at {}ms", id, atMs);
+			return json{ { "action", "checkpoint" }, { "id", id }, { "atMs", atMs }, { "checkpointCount", count } };
 		}
 
 		if (action == "stop") {
@@ -396,6 +437,7 @@ namespace dvb::Recording
 			return json{
 				{ "action", "stop" },
 				{ "sampleCount", rec.samples.size() },
+				{ "checkpointCount", rec.checkpoints.size() },
 				{ "recordedMs", recordedMs },
 				{ "path", pathStr },
 				{ "meta", scenario["meta"] },
@@ -408,10 +450,11 @@ namespace dvb::Recording
 				{ "recording", rec.running.load() },
 				{ "sampleCount", rec.samples.size() },
 				{ "intervalMs", rec.intervalMs },
+				{ "checkpointCount", rec.checkpoints.size() },
 			};
 		}
 
-		return json{ { "error", "unknown action (start|stop|status)" }, { "action", action } };
+		return json{ { "error", "unknown action (start|stop|status|checkpoint)" }, { "action", action } };
 	}
 
 	void Notify(const std::string& a_msg)

--- a/src/Recording.cpp
+++ b/src/Recording.cpp
@@ -588,8 +588,12 @@ namespace dvb::Recording
 		void AppendCheckpointSteps(json& a_steps, const json& a_cp, const json& a_cap,
 			const std::string& a_recordingStem, const json& a_args, long a_cumMs, long a_defaultSettleMs)
 		{
-			a_steps.push_back(json{ { "assert", "noBlockingMenu" } });
+			// waitUntil FIRST so a transient menu (a loading spinner, a fading message box) can
+			// clear within its timeout; assert only fails the checkpoint if it's STILL blocked
+			// afterward. The reverse order made the wait pointless -- assert fired on whatever
+			// was open at this exact instant, before the wait ever got a chance to run.
 			a_steps.push_back(json{ { "waitUntil", "noBlockingMenu" }, { "timeoutMs", 5000 }, { "pollMs", 100 } });
+			a_steps.push_back(json{ { "assert", "noBlockingMenu" } });
 			if (a_cp.contains("pov"))
 				a_steps.push_back(json{ { "tool", "camera" }, { "args", json{ { "action", "setPov" }, { "pov", a_cp["pov"] } } } });
 			if (const long settleMs = a_cp.value("settleMs", a_defaultSettleMs); settleMs > 0)
@@ -599,9 +603,13 @@ namespace dvb::Recording
 			// bare "auto" independent of the gate that already validated it above — otherwise the
 			// gate and the macro could disagree (gate passes because the named provider IS
 			// registered, but "auto" 400s at runtime if a second provider also happens to be
-			// registered).
+			// registered). ".value()" only substitutes the default when the key is ABSENT, so an
+			// explicit-but-empty "provider": "" (a malformed recipe) needs its own fallback too.
+			std::string provider = a_cap.value("provider", std::string("auto"));
+			if (provider.empty())
+				provider = "auto";
 			json capArgs{
-				{ "kind", a_cap.value("provider", std::string("auto")) },
+				{ "kind", provider },
 				{ "allowNative", a_cap.value("allowNative", false) },
 				{ "checkpointId", a_cp.at("id") },
 				{ "recording", a_recordingStem },

--- a/src/Recording.cpp
+++ b/src/Recording.cpp
@@ -2,6 +2,7 @@
 
 #include "GameState.h"
 #include "MainThread.h"
+#include "ToolExtensions.h"
 #include "ToolRegistry.h"
 
 #include <RE/Skyrim.h>
@@ -52,6 +53,10 @@ namespace dvb::Recording
 		long        g_cellMs = 60000;
 		bool        g_cleanTransition = true;
 		std::string g_cleanTransitionCell = "QASmoke";
+
+		// Default settle (ms) inserted before a checkpoint's capture, when the checkpoint doesn't
+		// specify its own settleMs. Set from config via SetCaptureDefaults.
+		long g_captureSettleMs = 500;
 
 		// True while devbench is replaying a scenario (teleporting the player). The pose sampler
 		// skips these ticks: the replay's own setpos/setangle commands — captured via the console
@@ -488,6 +493,87 @@ namespace dvb::Recording
 		g_cleanTransitionCell = a_transitionCell;
 	}
 
+	void SetCaptureDefaults(int a_settleMs)
+	{
+		g_captureSettleMs = (a_settleMs < 0) ? 0 : a_settleMs;
+	}
+
+	namespace
+	{
+		// The recording's meta.capabilities entry for "capture", or an empty object if it
+		// declares none (which means: no gate, any/no provider is fine).
+		json FindCaptureCapability(const json& a_meta)
+		{
+			for (const auto& cap : a_meta.value("capabilities", json::array()))
+				if (cap.value("capability", std::string{}) == "capture")
+					return cap;
+			return json::object();
+		}
+
+		// Validate + sort meta.checkpoints by atMs. Throws on a duplicate/missing id or a
+		// negative atMs — a bad checkpoint should fail the replay call up front, not silently
+		// misfire mid-trajectory.
+		json SortedCheckpoints(const json& a_meta)
+		{
+			json checkpoints = a_meta.value("checkpoints", json::array());
+			if (!checkpoints.is_array())
+				throw ToolError(400, "meta.checkpoints must be an array");
+			std::vector<std::string> seen;
+			for (const auto& cp : checkpoints) {
+				if (!cp.contains("id") || !cp["id"].is_string() || cp["id"].get<std::string>().empty())
+					throw ToolError(400, "each checkpoint requires a non-empty string 'id'");
+				const std::string id = cp["id"].get<std::string>();
+				if (std::find(seen.begin(), seen.end(), id) != seen.end())
+					throw ToolError(400, std::format("duplicate checkpoint id '{}'", id));
+				seen.push_back(id);
+				if (cp.value("atMs", 0LL) < 0)
+					throw ToolError(400, std::format("checkpoint '{}' has negative atMs", id));
+			}
+			std::stable_sort(checkpoints.begin(), checkpoints.end(),
+				[](const json& a, const json& b) { return a.value("atMs", 0LL) < b.value("atMs", 0LL); });
+			return checkpoints;
+		}
+
+		// Expand one checkpoint into existing scenario primitives — a MACRO, not a new step
+		// kind (the scenario step list stays a thin sequencer; see ROADMAP.md's "keep scenario
+		// thin" scope guard). No pose step is emitted: the trajectory's own immediately-preceding
+		// `pose` step already set position/angle, so re-issuing it would be a redundant no-op;
+		// only POV is re-asserted (Skyrim's idle-vanity timer can flip it). No HUD-suppression
+		// step either — UI exclusion is the capture provider's job (`excludeUi` in the capture
+		// args), not something the step list can do reliably (a console `tm` toggle leaks HUD-
+		// hidden state on any aborted step).
+		void AppendCheckpointSteps(json& a_steps, const json& a_cp, const json& a_cap,
+			const std::string& a_recordingStem, const json& a_args, long a_cumMs, long a_defaultSettleMs)
+		{
+			a_steps.push_back(json{ { "assert", "noBlockingMenu" } });
+			a_steps.push_back(json{ { "waitUntil", "noBlockingMenu" }, { "timeoutMs", 5000 }, { "pollMs", 100 } });
+			if (a_cp.contains("pov"))
+				a_steps.push_back(json{ { "tool", "camera" }, { "args", json{ { "action", "setPov" }, { "pov", a_cp["pov"] } } } });
+			if (const long settleMs = a_cp.value("settleMs", a_defaultSettleMs); settleMs > 0)
+				a_steps.push_back(json{ { "wait", settleMs } });
+
+			// kind is the CAPABILITY-RESOLVED provider (or "auto" if none was declared), never a
+			// bare "auto" independent of the gate that already validated it above — otherwise the
+			// gate and the macro could disagree (gate passes because the named provider IS
+			// registered, but "auto" 400s at runtime if a second provider also happens to be
+			// registered).
+			json capArgs{
+				{ "kind", a_cap.value("provider", std::string("auto")) },
+				{ "allowNative", a_cap.value("allowNative", false) },
+				{ "checkpointId", a_cp.at("id") },
+				{ "recording", a_recordingStem },
+				{ "variant", a_args.value("variant", std::string("default")) },
+				{ "excludeUi", a_cp.value("excludeUi", true) },
+				{ "atMs", a_cp.value("atMs", 0LL) },
+				{ "resolvedAtMs", a_cumMs },
+				{ "resolvedIndex", static_cast<long>(a_steps.size()) },
+			};
+			if (a_cp.contains("subrect"))
+				capArgs["subrect"] = a_cp["subrect"];
+			a_steps.push_back(json{ { "tool", "capture" }, { "args", std::move(capArgs) } });
+		}
+	}
+
 	json BuildReplaySteps(const json& a_args)
 	{
 		std::string path = a_args.value("path", std::string{});
@@ -591,6 +677,30 @@ namespace dvb::Recording
 										 compat.dump(), curVR ? "vr" : "flat (se/ae)"));
 		}
 
+		// Capability gate: if this recording declares checkpoints need a capture provider,
+		// check it's actually available BEFORE running anything — same shape as the runtime
+		// gate above (force downgrades an abort to a warning), so a missing provider fails
+		// clearly and early instead of 400ing on the first checkpoint's capture step deep
+		// into the trajectory.
+		const json captureCap = FindCaptureCapability(meta);
+		if (!captureCap.empty() && captureCap.value("required", true)) {
+			const std::string want = captureCap.value("provider", std::string{});
+			const auto        keys = ToolExtensions::Keys("capture");
+			bool              ok = want.empty() ? !keys.empty() : ToolExtensions::Find("capture", want).has_value();
+			if (!ok && captureCap.value("allowNative", false))
+				ok = true;  // native is always available as a (lower-fidelity) fallback
+			if (!ok && !force) {
+				std::string names;
+				for (const auto& k : keys)
+					names += (names.empty() ? "" : ", ") + k;
+				throw ToolError(409, std::format(
+										 "recording requires capture provider '{}' but none is registered (registered: [{}]) — "
+										 "install the provider mod (see inspect kind=registrants), set "
+										 "meta.capabilities[].allowNative, or pass force",
+										 want.empty() ? "<any>" : want, names));
+			}
+		}
+
 		const bool restoreScene = a_args.value("restoreScene", false);
 		const long settleMs = a_args.value("settleMs", static_cast<long>(g_loadSettleMs));
 		const bool cleanTransition = a_args.value("cleanTransition", g_cleanTransition);
@@ -686,9 +796,24 @@ namespace dvb::Recording
 		// the destination cell must finish loading before the following setpos teleports the player,
 		// or the replay teleports onto a not-yet-valid ref mid-load and CTDs. Done here (not baked
 		// into the recording) so existing recipes get the fix too.
-		const long txnSettleMs = a_args.value("settleMs", static_cast<long>(g_loadSettleMs));
+		//
+		// Interleaved: checkpoint capture steps, flushed once cumMs (the cumulative sum of the
+		// RECORDING'S OWN "wait" values — the same clock BuildScenario stamped from tMs deltas)
+		// reaches each checkpoint's atMs. This is resolved HERE, once, at plan time — nothing
+		// during replay execution (a slow cell load, a long waitFor) can move it, because the
+		// checkpoint's insertion point is a fixed index in the already-built step list by the
+		// time replay starts. cumMs deliberately sums ONLY the original recording's own "wait"
+		// steps below — the coc/cow settle steps injected right after them, and the restore
+		// prologue's settle waits above, are NOT part of that clock and must never be added in.
+		const long        txnSettleMs = a_args.value("settleMs", static_cast<long>(g_loadSettleMs));
+		const json        checkpoints = SortedCheckpoints(meta);
+		const std::string recordingStem = fs::path(path).stem().string();
+		long              cumMs = 0;
+		size_t            cpIdx = 0;
 		for (const auto& s : rec["steps"]) {
 			steps.push_back(s);
+			if (s.contains("wait"))
+				cumMs += s["wait"].get<long>();
 			if (s.value("tool", std::string{}) == "console") {
 				const std::string c = s.value("args", json::object()).value("command", std::string{});
 				if (c.size() >= 4 && c[3] == ' ' && (c[0] | 0x20) == 'c' && (c[1] | 0x20) == 'o' &&
@@ -698,7 +823,13 @@ namespace dvb::Recording
 						steps.push_back(json{ { "wait", txnSettleMs } });
 				}
 			}
+			while (cpIdx < checkpoints.size() && checkpoints[cpIdx].value("atMs", 0LL) <= cumMs)
+				AppendCheckpointSteps(steps, checkpoints[cpIdx++], captureCap, recordingStem, a_args, cumMs, g_captureSettleMs);
 		}
+		// Checkpoints anchored past the end of the trajectory still fire, at the end.
+		while (cpIdx < checkpoints.size())
+			AppendCheckpointSteps(steps, checkpoints[cpIdx++], captureCap, recordingStem, a_args, cumMs, g_captureSettleMs);
+
 		// Return the steps plus the effective coupling so the caller can surface what it
 		// actually did (which tier ran, whether the consumer overrode the producer's signal).
 		return json{

--- a/src/Recording.h
+++ b/src/Recording.h
@@ -56,6 +56,10 @@ namespace dvb::Recording
 	/// A recipe's meta.coupling block and a replay call's args override these.
 	void SetCoupling(int a_anchorMs, int a_cellMs, bool a_cleanTransition, const std::string& a_transitionCell);
 
+	/// Default settle delay (ms) inserted before a checkpoint's capture when the checkpoint
+	/// doesn't specify its own settleMs. Local/per-machine (set from config's captureSettleMs).
+	void SetCaptureDefaults(int a_settleMs);
+
 	/// Show a corner HUD message (marshaled to the main thread). Used for hotkey feedback
 	/// (record start/stop, replay) since devbench is otherwise headless. No-op if no task interface.
 	void Notify(const std::string& a_msg);
@@ -67,6 +71,14 @@ namespace dvb::Recording
 	/// scene. The recipe's tier is the producer's signal; a_args.coupling overrides it (run
 	/// looser) and a_args.force turns the scene mismatch from an abort into a reported warning.
 	/// Throws ToolError on a missing/invalid file or an invalid coupling override.
+	///
+	/// A recording's meta.checkpoints (each { id, atMs, pov?, settleMs?, excludeUi?, subrect? })
+	/// expand into `capture` tool steps interleaved into the trajectory at the point the
+	/// recorder's own wait-accumulated clock (atMs) reaches them — a macro over existing scenario
+	/// primitives, not a new step kind. meta.capabilities (currently just {capability:"capture",
+	/// provider?, required?, allowNative?}) is checked up front: a required capture provider that
+	/// isn't registered throws ToolError(409) before anything runs, unless a_args.force or the
+	/// capability's own allowNative permits the low-fidelity native fallback.
 	json BuildReplaySteps(const json& a_args);
 
 	/// `recordings` tool: manage the on-disk recording library (the data layer an in-game menu —

--- a/src/Ssim.cpp
+++ b/src/Ssim.cpp
@@ -1,0 +1,183 @@
+#include "Ssim.h"
+
+// Decode-only: two already-captured images -> pixel buffers. STBI_ONLY_* keeps the codec
+// surface to exactly the formats devbench's own captures can actually be (provider captures are
+// PNG per the provider contract; the native fallback can also land BMP depending on the user's
+// vanilla screenshot .ini setting) -- not a general-purpose image loader.
+#define STB_IMAGE_IMPLEMENTATION
+#define STBI_ONLY_PNG
+#define STBI_ONLY_BMP
+#include <stb_image.h>
+
+#include <algorithm>
+#include <cmath>
+#include <format>
+
+namespace dvb::Ssim
+{
+	namespace
+	{
+		namespace fs = std::filesystem;
+	}
+
+	std::optional<GrayImage> DecodeGray(const fs::path& a_path)
+	{
+		int            w = 0, h = 0, channels = 0;
+		const auto     pathStr = a_path.string();
+		unsigned char* data = stbi_load(pathStr.c_str(), &w, &h, &channels, 1);  // force 1-channel grayscale
+		if (!data)
+			return std::nullopt;
+		GrayImage img;
+		img.width = w;
+		img.height = h;
+		img.px.resize(static_cast<size_t>(w) * h);
+		for (size_t i = 0; i < img.px.size(); ++i)
+			img.px[i] = static_cast<float>(data[i]);
+		stbi_image_free(data);
+		return img;
+	}
+
+	GrayImage CropUv(const GrayImage& a_img, const json& a_uv)
+	{
+		const double x0d = a_uv.value("x", 0.0), y0d = a_uv.value("y", 0.0);
+		const double wd = a_uv.value("w", 1.0), hd = a_uv.value("h", 1.0);
+		const int    x0 = std::clamp(static_cast<int>(std::lround(x0d * a_img.width)), 0, a_img.width);
+		const int    y0 = std::clamp(static_cast<int>(std::lround(y0d * a_img.height)), 0, a_img.height);
+		const int    x1 = std::clamp(static_cast<int>(std::lround((x0d + wd) * a_img.width)), x0, a_img.width);
+		const int    y1 = std::clamp(static_cast<int>(std::lround((y0d + hd) * a_img.height)), y0, a_img.height);
+
+		GrayImage out;
+		out.width = x1 - x0;
+		out.height = y1 - y0;
+		out.px.resize(static_cast<size_t>(out.width) * out.height);
+		for (int y = 0; y < out.height; ++y)
+			for (int x = 0; x < out.width; ++x)
+				out.px[static_cast<size_t>(y) * out.width + x] = a_img.px[static_cast<size_t>(y0 + y) * a_img.width + (x0 + x)];
+		return out;
+	}
+
+	double ComputeSsim(const GrayImage& a_a, const GrayImage& a_b)
+	{
+		constexpr double kC1 = (0.01 * 255.0) * (0.01 * 255.0);
+		constexpr double kC2 = (0.03 * 255.0) * (0.03 * 255.0);
+		constexpr int    kWindow = 8;
+		constexpr int    kStride = 3;  // < kWindow so windows overlap and straddle any block-periodic content
+
+		const int w = a_a.width, h = a_a.height;
+		if (w <= 0 || h <= 0)
+			return 0.0;
+		const int win = std::min({ kWindow, w, h });
+		if (win <= 1)
+			return 0.0;
+
+		double sum = 0.0;
+		int    windows = 0;
+		for (int by = 0; by <= h - win; by += kStride) {
+			for (int bx = 0; bx <= w - win; bx += kStride) {
+				const int n = win * win;
+
+				double meanA = 0.0, meanB = 0.0;
+				for (int y = 0; y < win; ++y)
+					for (int x = 0; x < win; ++x) {
+						const size_t idx = static_cast<size_t>(by + y) * w + (bx + x);
+						meanA += a_a.px[idx];
+						meanB += a_b.px[idx];
+					}
+				meanA /= n;
+				meanB /= n;
+
+				double varA = 0.0, varB = 0.0, covAB = 0.0;
+				for (int y = 0; y < win; ++y)
+					for (int x = 0; x < win; ++x) {
+						const size_t idx = static_cast<size_t>(by + y) * w + (bx + x);
+						const double da = a_a.px[idx] - meanA;
+						const double db = a_b.px[idx] - meanB;
+						varA += da * da;
+						varB += db * db;
+						covAB += da * db;
+					}
+				varA /= (n - 1);
+				varB /= (n - 1);
+				covAB /= (n - 1);
+
+				const double numerator = (2 * meanA * meanB + kC1) * (2 * covAB + kC2);
+				const double denominator = (meanA * meanA + meanB * meanB + kC1) * (varA + varB + kC2);
+				sum += denominator > 0.0 ? (numerator / denominator) : 1.0;
+				++windows;
+			}
+		}
+		// win > w or win > h (a crop smaller than the window) — fall back to one whole-image window.
+		if (windows == 0) {
+			double       meanA = 0.0, meanB = 0.0;
+			const size_t n = static_cast<size_t>(w) * h;
+			for (size_t i = 0; i < n; ++i) {
+				meanA += a_a.px[i];
+				meanB += a_b.px[i];
+			}
+			meanA /= n;
+			meanB /= n;
+			double varA = 0.0, varB = 0.0, covAB = 0.0;
+			for (size_t i = 0; i < n; ++i) {
+				const double da = a_a.px[i] - meanA;
+				const double db = a_b.px[i] - meanB;
+				varA += da * da;
+				varB += db * db;
+				covAB += da * db;
+			}
+			varA /= (n - 1);
+			varB /= (n - 1);
+			covAB /= (n - 1);
+			const double numerator = (2 * meanA * meanB + kC1) * (2 * covAB + kC2);
+			const double denominator = (meanA * meanA + meanB * meanB + kC1) * (varA + varB + kC2);
+			return denominator > 0.0 ? (numerator / denominator) : 1.0;
+		}
+		return sum / windows;
+	}
+
+	GoldenScore ScoreAgainstGolden(const fs::path& a_capturedPath, const fs::path& a_goldenPath, const json& a_goldenCfg)
+	{
+		GoldenScore result;
+		result.threshold = a_goldenCfg.value("threshold", 0.98);
+
+		if (!fs::exists(a_goldenPath)) {
+			result.error = std::format("no golden at {}", a_goldenPath.generic_string());
+			return result;
+		}
+		const auto candidate = DecodeGray(a_capturedPath);
+		const auto golden = DecodeGray(a_goldenPath);
+		if (!candidate || !golden) {
+			result.error = "failed to decode candidate or golden image";
+			return result;
+		}
+		if (candidate->width != golden->width || candidate->height != golden->height) {
+			result.error = std::format("shape mismatch: candidate {}x{} vs golden {}x{}",
+				candidate->width, candidate->height, golden->width, golden->height);
+			return result;
+		}
+
+		const json regionCfgs = a_goldenCfg.value("regions", json::array());
+		if (!regionCfgs.empty()) {
+			double worst = 1.0;
+			bool   allPassed = true;
+			for (const auto& r : regionCfgs) {
+				const GrayImage rc = CropUv(*candidate, r);
+				const GrayImage rg = CropUv(*golden, r);
+				const double    score = ComputeSsim(rc, rg);
+				const double    threshold = r.value("threshold", result.threshold);
+				const bool      passed = score >= threshold;
+				result.regions.push_back(RegionScore{ r.value("name", std::string("?")), score, threshold, passed });
+				worst = std::min(worst, score);
+				allPassed = allPassed && passed;
+			}
+			result.ok = true;
+			result.score = worst;
+			result.passed = allPassed;
+			return result;
+		}
+
+		result.ok = true;
+		result.score = ComputeSsim(*candidate, *golden);
+		result.passed = result.score >= result.threshold;
+		return result;
+	}
+}

--- a/src/Ssim.h
+++ b/src/Ssim.h
@@ -1,0 +1,67 @@
+#pragma once
+
+#include <filesystem>
+#include <optional>
+#include <string>
+#include <vector>
+
+#include "Json.h"
+
+// Pure image-comparison primitives — decode, crop, SSIM, golden scoring. Zero dependency on
+// RE/SKSE (only stb_image + std::filesystem + json), so this is unit-testable in the
+// host-independent `devbench-tests` target (see tests/Ssim_test.cpp) with no game required.
+// `Capture.cpp` is the only real caller — it resolves a relative golden path against GameRoot()
+// BEFORE calling in here, so this module never needs to know anything about "the game" at all.
+namespace dvb::Ssim
+{
+	struct GrayImage
+	{
+		std::vector<float> px;  // row-major, 0..255 range as float (SSIM math needs float)
+		int                width = 0;
+		int                height = 0;
+	};
+
+	/// Decode a PNG/BMP file into a single-channel grayscale buffer, or nullopt if the file
+	/// doesn't exist, isn't readable, or isn't a supported format.
+	std::optional<GrayImage> DecodeGray(const std::filesystem::path& a_path);
+
+	/// Crop a 0..1 UV rect {x,y,w,h} — the SAME convention the `capture` tool's own `subrect`
+	/// arg and tests/http/visual.py's regions both use, so one rect definition works everywhere.
+	GrayImage CropUv(const GrayImage& a_img, const json& a_uv);
+
+	/// Windowed SSIM (Wang et al.), OVERLAPPING windows (stride shorter than the window) — see
+	/// Ssim.cpp for why overlap is load-bearing, not stylistic: a first non-overlapping-block
+	/// version failed a basic sanity check (a fully value-inverted image scored 0.54, not
+	/// strongly negative) because content flat within each block has zero intra-block variance,
+	/// blinding the contrast term to inversion regardless of sign.
+	double ComputeSsim(const GrayImage& a_a, const GrayImage& a_b);
+
+	struct RegionScore
+	{
+		std::string name;
+		double      score = 0.0;
+		double      threshold = 0.0;
+		bool        passed = false;
+	};
+
+	// Everything a `golden` result needs, whether it succeeded or not — a decode failure
+	// (missing golden, corrupt file, dimension mismatch) is reported via `error`, not thrown: a
+	// checkpoint that can't be scored still has a real capture worth returning, it just can't
+	// carry a verdict.
+	struct GoldenScore
+	{
+		bool                     ok = false;
+		std::string              error;
+		double                   score = 0.0;
+		double                   threshold = 0.0;
+		bool                     passed = false;
+		std::vector<RegionScore> regions;
+	};
+
+	/// Score `a_capturedPath` against `a_goldenPath` — BOTH must already be resolved, absolute
+	/// paths; this module does no path resolution of its own. `a_goldenCfg`'s optional
+	/// "threshold" (default 0.98) and "regions" ([{name,x,y,w,h,threshold?}]) control scoring.
+	/// Never throws.
+	GoldenScore ScoreAgainstGolden(const std::filesystem::path& a_capturedPath,
+		const std::filesystem::path& a_goldenPath, const json& a_goldenCfg);
+}

--- a/src/Tools.cpp
+++ b/src/Tools.cpp
@@ -2278,7 +2278,11 @@ namespace dvb
 			"async:false to block the request for the run's duration and get the result object "
 			"directly. If the recording has meta.checkpoints, each expands into a `capture` step "
 			"at the point in the trajectory its atMs was recorded, tagged with 'variant' for "
-			"correlation (default 'default') — see the `capture` tool. Pass 'goldens' to also get "
+			"correlation (default 'default') — see the `capture` tool. Pass "
+			"captureCheckpoints:false to replay the same recording as a plain trajectory-only run "
+			"instead — checkpoints are skipped entirely (no capture provider required, nothing "
+			"captured), so one recording can serve as both a general tour and a visual-review run "
+			"depending on the call. Pass 'goldens' to also get "
 			"an inline SSIM verdict per checkpoint: {\"<checkpointId>\": {golden, threshold?, "
 			"regions?}}; a checkpoint with no matching entry is captured but not scored. The "
 			"result's top-level 'checkpoints' array rolls up every capture step into "
@@ -2294,6 +2298,7 @@ namespace dvb
 								{ "path", json{ { "type", "string" }, { "description", "replay: recording file to play back (from stop's 'path')" } } },
 								{ "restoreScene", json{ { "type", "boolean" }, { "description", "replay: re-establish the recorded entryPoint + wait for load before the trajectory (default false)" } } },
 								{ "variant", json{ { "type", "string" }, { "description", "replay: tag for any meta.checkpoints captures, for correlation (default 'default')" } } },
+								{ "captureCheckpoints", json{ { "type", "boolean" }, { "description", "replay: expand meta.checkpoints into capture steps (default true) — pass false for a plain trajectory-only replay of a checkpoint-bearing recording (no provider required, nothing captured)" } } },
 								{ "goldens", json{ { "type", "object" }, { "description", "replay: per-checkpoint SSIM comparison config, keyed by checkpoint id — {\"<id>\": {golden, threshold?, regions?}} — see the `capture` tool. Never stored in the recording itself; supply it fresh per replay so the same recording can check against different variants' goldens." } } },
 								{ "coupling", json{ { "type", "string" }, { "enum", json::array({ "anchored", "cell", "worldspace" }) }, { "description", "replay: override the recipe's coupling tier — run looser than the producer signaled (worldspace skips the scene restore)" } } },
 								{ "force", json{ { "type", "boolean" }, { "description", "replay: proceed even if the scene doesn't match the recording — report the mismatch as a warning instead of aborting (default false)" } } },

--- a/src/Tools.cpp
+++ b/src/Tools.cpp
@@ -2214,9 +2214,15 @@ namespace dvb
 			"intervalMs (default from config recordIntervalMs, min 10) on a background thread "
 			"and captures a one-time scene manifest "
 			"(worldspace/cell, time of day, weather, anchor pose, and the entryPoint — the save "
-			"loaded or coc'd to reach the scene, or 'unknown'); a game must be loaded. 'stop' "
+			"loaded or coc'd to reach the scene, or 'unknown'); a game must be loaded. "
+			"'checkpoint' marks THIS moment (while recording is active) as a screenshot checkpoint "
+			"— requires 'id' (unique this recording); optional excludeUi (default true). Mirrors "
+			"'stop' capturing the trajectory: no manual JSON editing needed. Carries no golden/"
+			"threshold — those are supplied later, per-checkpoint, on replay's 'goldens' arg, since "
+			"a golden reference doesn't exist yet at mark-time. 'stop' "
 			"writes the trajectory to Data/SKSE/Plugins/devbench/recordings/recording_<stamp>.json "
-			"and returns its path + meta. 'status' reports recording/sampleCount/intervalMs. "
+			"and returns its path + meta (meta.checkpoints holds any marked via 'checkpoint'). "
+			"'status' reports recording/sampleCount/intervalMs/checkpointCount. "
 			"'replay' runs a recording file ('path'): with restoreScene=true it re-establishes "
 			"the entryPoint and waits for the player before the trajectory, so the run reproduces "
 			"the recorded scene (interiors coc the cell; exterior entries use cow with the "
@@ -2241,8 +2247,10 @@ namespace dvb
 		record.inputSchema = json{
 			{ "type", "object" },
 			{ "properties", json{
-								{ "action", json{ { "type", "string" }, { "enum", json::array({ "start", "stop", "status", "replay" }) }, { "description", "start | stop | status | replay" } } },
+								{ "action", json{ { "type", "string" }, { "enum", json::array({ "start", "stop", "status", "replay", "checkpoint" }) }, { "description", "start | stop | status | replay | checkpoint" } } },
 								{ "intervalMs", json{ { "type", "integer" }, { "description", "start: pose sample period in ms (default = config recordIntervalMs, min 10)" } } },
+								{ "id", json{ { "type", "string" }, { "description", "checkpoint: unique id for this checkpoint (required)" } } },
+								{ "excludeUi", json{ { "type", "boolean" }, { "description", "checkpoint: request a pre-UI capture source at replay (default true) — see the `capture` tool" } } },
 								{ "path", json{ { "type", "string" }, { "description", "replay: recording file to play back (from stop's 'path')" } } },
 								{ "restoreScene", json{ { "type", "boolean" }, { "description", "replay: re-establish the recorded entryPoint + wait for load before the trajectory (default false)" } } },
 								{ "variant", json{ { "type", "string" }, { "description", "replay: tag for any meta.checkpoints captures, for correlation (default 'default')" } } },

--- a/src/Tools.cpp
+++ b/src/Tools.cpp
@@ -1574,6 +1574,9 @@ namespace dvb
 			} replayGuard;
 
 			for (int rep = 0; rep < repeat && !aborted; ++rep) {
+				// Per-repetition, not per-run: a scene mismatch on rep N must not poison rep N+1's
+				// captures if rep N+1's own scene assert succeeds.
+				bool runSceneMismatch = false;
 				for (size_t i = 0; i < steps.size() && !aborted; ++i) {
 					const json& step = steps[i];
 					json        r{ { "index", i } };
@@ -1710,11 +1713,22 @@ namespace dvb
 							}
 						} else if (step.contains("tool")) {
 							const std::string tool = step["tool"].get<std::string>();
-							const json        args = step.value("args", json::object());
+							json              args = step.value("args", json::object());  // non-const: run-scoped injection below
 							r["kind"] = "tool";
 							r["tool"] = tool;
 							if (step.contains("label"))
 								r["label"] = step["label"];
+							if (tool == "capture") {
+								// Context the static step list can't carry — a checkpoint's capture step
+								// doesn't know its own runId or whether an earlier scene assert this
+								// repetition failed. Reaches the transcript via the tool's RESULT (which
+								// Capture::Handle echoes these back into), not via these mutated args.
+								args["runId"] = runId;
+								if (repeat > 1)
+									args["repeat"] = rep;
+								if (runSceneMismatch)
+									args["sceneMismatch"] = true;
+							}
 							ToolContext stepCtx = a_ctx;
 							stepCtx.internal = true;  // scenario-driven — don't log each step (replay logs a summary)
 							const ToolResult tr = a_registry.Invoke(tool, args, stepCtx);
@@ -1779,6 +1793,9 @@ namespace dvb
 
 								if (!ready) {
 									// soft: don't fail the run, just note we couldn't confirm the scene.
+									// An unconfirmed scene is as unusable a golden reference as a mismatched
+									// one — a capture step after this must know not to trust it either.
+									runSceneMismatch = true;
 									r["ok"] = soft;
 									r["sceneConfirmed"] = false;
 									(soft ? r["warning"] : r["error"]) = "scene assert: player never finished loading";
@@ -1793,6 +1810,7 @@ namespace dvb
 										interior ? "cell" : "worldspace", wantEid, interior ? cellWant : wsWant, cur,
 										soft ? " — forced, proceeding" : " — aborting replay");
 									r["sceneMismatch"] = true;
+									runSceneMismatch = true;
 									r["worldspaceFormID"] = check.value("worldspaceFormID", 0u);
 									r["cellFormID"] = check.value("cellFormID", 0u);
 									// soft: a forced consumer accepted that the scene may not match — warn, don't abort.

--- a/src/Tools.cpp
+++ b/src/Tools.cpp
@@ -2234,7 +2234,10 @@ namespace dvb
 			"replay.finished on GET /api/events (both carry runId; the runId space is shared with "
 			"scenario, so a replay's runId also resolves via scenario{action:'status'}). Pass "
 			"async:false to block the request for the run's duration and get the result object "
-			"directly instead.";
+			"directly. If the recording has meta.checkpoints, each expands into a `capture` step "
+			"at the point in the trajectory its atMs was recorded, tagged with 'variant' for "
+			"correlation (default 'default') — see the `capture` tool; devbench never scores the "
+			"resulting images, only captures them.";
 		record.inputSchema = json{
 			{ "type", "object" },
 			{ "properties", json{
@@ -2242,6 +2245,7 @@ namespace dvb
 								{ "intervalMs", json{ { "type", "integer" }, { "description", "start: pose sample period in ms (default = config recordIntervalMs, min 10)" } } },
 								{ "path", json{ { "type", "string" }, { "description", "replay: recording file to play back (from stop's 'path')" } } },
 								{ "restoreScene", json{ { "type", "boolean" }, { "description", "replay: re-establish the recorded entryPoint + wait for load before the trajectory (default false)" } } },
+								{ "variant", json{ { "type", "string" }, { "description", "replay: tag for any meta.checkpoints captures, for correlation (default 'default')" } } },
 								{ "coupling", json{ { "type", "string" }, { "enum", json::array({ "anchored", "cell", "worldspace" }) }, { "description", "replay: override the recipe's coupling tier — run looser than the producer signaled (worldspace skips the scene restore)" } } },
 								{ "force", json{ { "type", "boolean" }, { "description", "replay: proceed even if the scene doesn't match the recording — report the mismatch as a warning instead of aborting (default false)" } } },
 								{ "closeMenus", json{ { "type", "boolean" }, { "description", "replay: if a MODAL is open at start, cancel it and continue instead of erroring; non-modal gameplay menus still error (default false)" } } },

--- a/src/Tools.cpp
+++ b/src/Tools.cpp
@@ -1,9 +1,11 @@
 #include "Tools.h"
 
+#include "Capture.h"
 #include "ConsoleLogCapture.h"
 #include "EventBus.h"
 #include "GameEvents.h"
 #include "GameState.h"
+#include "HostApi.h"
 #include "Json.h"
 #include "MainThread.h"
 #include "Papyrus.h"
@@ -1097,6 +1099,46 @@ namespace dvb
 				});
 			}
 
+			// 'registrants': who has requested the C-ABI interface, and what they registered
+			// through it — the human/agent-facing view of the ledger HostApi keeps. `capabilities`
+			// is the same ToolExtensions::Keys() data the capture-provider gate reads, surfaced
+			// here so a person can see why a gate failed without reading source. Consumers and
+			// registrations are NOT joined by plugin name — the C-ABI interface has no per-call
+			// caller identity (see ROADMAP.md's "Event source tagging" item), so guessing which
+			// consumer owns which registration would be a confident lie; both lists are returned
+			// side by side instead.
+			if (kind == "registrants") {
+				json consumers = json::array();
+				for (const auto& c : HostApi::Consumers())
+					consumers.push_back(json{ { "name", c.name }, { "atEpoch", c.atEpoch }, { "atFrame", c.atFrame } });
+
+				json registrations = json::array();
+				for (const auto& r : HostApi::Registrations())
+					registrations.push_back(json{
+						{ "kind", r.kind }, { "name", r.name },
+						{ "atEpoch", r.atEpoch }, { "atFrame", r.atFrame }, { "replaced", r.replaced } });
+
+				json capabilities = json::object();
+				for (const char* base : { "capture", "inspect", "menu" }) {
+					json keys = json::array();
+					for (const auto& k : ToolExtensions::Keys(base))
+						keys.push_back(k);
+					capabilities[base] = std::move(keys);
+				}
+
+				return json{
+					{ "consumers", std::move(consumers) },
+					{ "registrations", std::move(registrations) },
+					{ "capabilities", std::move(capabilities) },
+				};
+			}
+
+			// 'screenshots': list image files sitting in the vanilla screenshot directories,
+			// independent of the `capture` tool — lets a human/agent confirm where THIS install
+			// actually writes before relying on the capture tool's native fallback.
+			if (kind == "screenshots")
+				return Capture::ListScreenshots(a_args);
+
 			// 'extensions' lists consumer-registered inspect kinds (C-ABI RegisterToolExtension).
 			if (kind == "extensions") {
 				json out = json::array();
@@ -1113,7 +1155,7 @@ namespace dvb
 			if (auto entry = ToolExtensions::Find("inspect", kind))
 				return entry->handler(a_args, a_ctx);
 
-			throw ToolError(400, std::format("unknown kind '{}' (state|vm|scene|mods|player|inventory|quests|effects|refs|extensions, or a registered kind — see inspect kind=extensions)", kind));
+			throw ToolError(400, std::format("unknown kind '{}' (state|vm|scene|mods|player|inventory|quests|effects|refs|registrants|screenshots|extensions, or a registered kind — see inspect kind=extensions)", kind));
 		}
 
 		// camera: read or set the player camera point of view, so a recording can capture the
@@ -1862,18 +1904,28 @@ namespace dvb
 				"'refs' → identify reference(s) sharing one shape { formId, formType, name, "
 				"editorId, base, position } — pass 'formId' for one form, 'selected'=true for the "
 				"console/crosshair ref (set via prid), or neither to enumerate loaded refs in the grid "
-				"(optional 'formType' filter, 'radius' from player, 'limit' default 100). A consumer mod "
+				"(optional 'formType' filter, 'radius' from player, 'limit' default 100). "
+				"'registrants' → who has requested the C-ABI interface and what they registered "
+				"through it { consumers:[{name,atEpoch,atFrame}], registrations:[{kind,name,atEpoch,"
+				"atFrame,replaced}], capabilities:{capture,inspect,menu → [registered keys]} } — "
+				"consumers and registrations are reported side by side, not joined, since the C-ABI "
+				"has no per-call caller identity. "
+				"'screenshots' → image files in the vanilla screenshot directories (game root + "
+				"'Screenshots/') { dirs, count, returned, truncated, screenshots:[{file,path,bytes,"
+				"mtimeEpoch}] } newest-first (optional 'dir' override, 'limit' default 50) — see also "
+				"the `capture` tool, which has its own native fallback using the same directories. "
+				"A consumer mod "
 				"can add a custom kind via the C-ABI RegisterToolExtension (e.g. load-timing data); "
 				"'extensions' lists those registered kinds + descriptors, and kind=<registered> dispatches.";
 			inspect.description += RegisteredExtensionSummary("inspect", "kinds");
 			inspect.readOnly = true;
-			json kinds = json::array({ "state", "health", "vm", "scene", "mods", "player", "inventory", "quests", "effects", "refs", "extensions" });
+			json kinds = json::array({ "state", "health", "vm", "scene", "mods", "player", "inventory", "quests", "effects", "refs", "registrants", "screenshots", "extensions" });
 			for (const auto& k : ToolExtensions::Keys("inspect"))
 				kinds.push_back(k);
 			inspect.inputSchema = json{
 				{ "type", "object" },
 				{ "properties", json{
-									{ "kind", json{ { "type", "string" }, { "enum", kinds }, { "description", "state | health | vm | scene | mods | player | inventory | quests | effects | refs | extensions (health answers off-thread for liveness+identity; or a registered mod kind — listed here + via kind=extensions)" } } },
+									{ "kind", json{ { "type", "string" }, { "enum", kinds }, { "description", "state | health | vm | scene | mods | player | inventory | quests | effects | refs | registrants | screenshots | extensions (health answers off-thread for liveness+identity; or a registered mod kind — listed here + via kind=extensions)" } } },
 									{ "formId", json{ { "type", "string" }, { "description", "refs: identify this form; inventory: the container ref to read (default player); effects: the actor to read (default player) (hex formId, e.g. 0x14, or EditorID)" } } },
 									{ "selected", json{ { "type", "boolean" }, { "description", "refs: identify the console-selected / crosshair ref instead" } } },
 									{ "formType", json{ { "type", "string" }, { "description", "refs/inventory: keep only entries whose type matches (e.g. Actor, Weapon, Potion)" } } },
@@ -1998,14 +2050,16 @@ namespace dvb
 		};
 		a_registry.Register(std::move(camera), &CameraHandler);
 
-		// inspect/menu are rebuilt (not frozen) so registered mod kinds/menus show in tools/list.
+		// inspect/menu/capture are rebuilt (not frozen) so registered mod kinds/menus/providers
+		// show in tools/list.
 		a_registry.Register(BuildInspectDescriptor(), &InspectHandler);
 		a_registry.Register(BuildMenuDescriptor(), &MenuHandler);
+		a_registry.Register(Capture::BuildCaptureDescriptor(), &Capture::Handle);
 
-		// When a mod registers a kind/menu, rebuild that base tool's descriptor so the new key is
-		// discoverable on the first call (the registry's registration path re-registers it with the
-		// adapters and fires tools/list_changed). Captures the registry by pointer — it outlives this
-		// function (owned by the Server).
+		// When a mod registers a kind/menu/provider, rebuild that base tool's descriptor so the new
+		// key is discoverable on the first call (the registry's registration path re-registers it
+		// with the adapters and fires tools/list_changed). Captures the registry by pointer — it
+		// outlives this function (owned by the Server).
 		ToolExtensions::SetChangeListener([reg = &a_registry](const std::string& a_baseTool) {
 			std::string base = a_baseTool;
 			std::transform(base.begin(), base.end(), base.begin(), [](unsigned char c) { return static_cast<char>(std::tolower(c)); });
@@ -2013,6 +2067,8 @@ namespace dvb
 				reg->Register(BuildInspectDescriptor(), &InspectHandler);
 			else if (base == "menu")
 				reg->Register(BuildMenuDescriptor(), &MenuHandler);
+			else if (base == "capture")
+				reg->Register(Capture::BuildCaptureDescriptor(), &Capture::Handle);
 		});
 
 		ToolDescriptor papyrus;

--- a/src/Tools.cpp
+++ b/src/Tools.cpp
@@ -2242,8 +2242,9 @@ namespace dvb
 			"async:false to block the request for the run's duration and get the result object "
 			"directly. If the recording has meta.checkpoints, each expands into a `capture` step "
 			"at the point in the trajectory its atMs was recorded, tagged with 'variant' for "
-			"correlation (default 'default') — see the `capture` tool; devbench never scores the "
-			"resulting images, only captures them.";
+			"correlation (default 'default') — see the `capture` tool. Pass 'goldens' to also get "
+			"an inline SSIM verdict per checkpoint: {\"<checkpointId>\": {golden, threshold?, "
+			"regions?}}; a checkpoint with no matching entry is captured but not scored.";
 		record.inputSchema = json{
 			{ "type", "object" },
 			{ "properties", json{
@@ -2254,6 +2255,7 @@ namespace dvb
 								{ "path", json{ { "type", "string" }, { "description", "replay: recording file to play back (from stop's 'path')" } } },
 								{ "restoreScene", json{ { "type", "boolean" }, { "description", "replay: re-establish the recorded entryPoint + wait for load before the trajectory (default false)" } } },
 								{ "variant", json{ { "type", "string" }, { "description", "replay: tag for any meta.checkpoints captures, for correlation (default 'default')" } } },
+								{ "goldens", json{ { "type", "object" }, { "description", "replay: per-checkpoint SSIM comparison config, keyed by checkpoint id — {\"<id>\": {golden, threshold?, regions?}} — see the `capture` tool. Never stored in the recording itself; supply it fresh per replay so the same recording can check against different variants' goldens." } } },
 								{ "coupling", json{ { "type", "string" }, { "enum", json::array({ "anchored", "cell", "worldspace" }) }, { "description", "replay: override the recipe's coupling tier — run looser than the producer signaled (worldspace skips the scene restore)" } } },
 								{ "force", json{ { "type", "boolean" }, { "description", "replay: proceed even if the scene doesn't match the recording — report the mismatch as a warning instead of aborting (default false)" } } },
 								{ "closeMenus", json{ { "type", "boolean" }, { "description", "replay: if a MODAL is open at start, cancel it and continue instead of erroring; non-modal gameplay menus still error (default false)" } } },

--- a/src/Tools.cpp
+++ b/src/Tools.cpp
@@ -1343,6 +1343,42 @@ namespace dvb
 			return out;
 		}
 
+		// Summarizes a scenario transcript's `capture` steps into a flat, per-checkpoint rollup
+		// — {id, ok, path, inconclusive, inconclusiveReason?, ssim?, threshold?, passed?} — so a
+		// caller doesn't have to filter the full step transcript (which can run into the hundreds
+		// for a multi-checkpoint recording; a live test with 3 checkpoints produced 467 steps) to
+		// answer "did my checkpoints pass." Every field devbench already computed per capture; this
+		// just collects them where a caller — an LLM in particular — can find them in one place
+		// without re-deriving anything.
+		json SummarizeCheckpoints(const json& a_scenarioResult)
+		{
+			json out = json::array();
+			for (const auto& r : a_scenarioResult.value("results", json::array())) {
+				if (r.value("kind", std::string{}) != "tool" || r.value("tool", std::string{}) != "capture")
+					continue;
+				if (!r.value("ok", false) || !r.contains("result"))
+					continue;
+				const json& cap = r["result"];
+				if (!cap.contains("checkpointId"))
+					continue;
+				json entry{
+					{ "id", cap.value("checkpointId", std::string{}) },
+					{ "ok", cap.value("ok", false) },
+					{ "path", cap.value("path", std::string{}) },
+					{ "inconclusive", cap.value("inconclusive", false) },
+				};
+				if (cap.contains("inconclusiveReason"))
+					entry["inconclusiveReason"] = cap["inconclusiveReason"];
+				if (cap.contains("ssim")) {
+					entry["ssim"] = cap["ssim"];
+					entry["threshold"] = cap["threshold"];
+					entry["passed"] = cap["passed"];
+				}
+				out.push_back(std::move(entry));
+			}
+			return out;
+		}
+
 		// Open menus that would make a replay meaningless — they pause the sim, are modal, or grab the
 		// cursor into menu-mode (inventory/dialogue/lockpick/messagebox). Always-open menus (HUD/cursor)
 		// and the console (SKSE task exec still runs) never block. Reads live UI flags on the main thread.
@@ -2244,7 +2280,10 @@ namespace dvb
 			"at the point in the trajectory its atMs was recorded, tagged with 'variant' for "
 			"correlation (default 'default') — see the `capture` tool. Pass 'goldens' to also get "
 			"an inline SSIM verdict per checkpoint: {\"<checkpointId>\": {golden, threshold?, "
-			"regions?}}; a checkpoint with no matching entry is captured but not scored.";
+			"regions?}}; a checkpoint with no matching entry is captured but not scored. The "
+			"result's top-level 'checkpoints' array rolls up every capture step into "
+			"{id, ok, path, inconclusive, inconclusiveReason?, ssim?, threshold?, passed?} — read "
+			"this instead of filtering the (often much larger) 'results' step transcript yourself.";
 		record.inputSchema = json{
 			{ "type", "object" },
 			{ "properties", json{
@@ -2319,6 +2358,7 @@ namespace dvb
 							throw;
 						}
 						result["coupling"] = coupling;  // surface effective tier / override
+						result["checkpoints"] = SummarizeCheckpoints(result);
 						logs::info("devbench: replay finished — {} steps, ok={}",
 							result.value("stepsRun", 0), result.value("ok", false));
 						a_events.Publish("replay.finished", json{ { "runId", runId }, { "ok", result.value("ok", false) }, { "stepsRun", result.value("stepsRun", 0) } });

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -82,6 +82,7 @@ namespace
 				dvb::Recording::SetLoadSettleMs(cfg.loadSettleMs);
 				dvb::Recording::SetDefaultIntervalMs(cfg.recordIntervalMs);
 				dvb::Recording::SetCoupling(cfg.couplingAnchorMs, cfg.couplingCellMs, cfg.cleanTransition, cfg.cleanTransitionCell);
+				dvb::Recording::SetCaptureDefaults(cfg.captureSettleMs);
 				dvb::Capture::SetEvents(&g_server->Events());
 				dvb::Capture::SetDefaults(cfg);
 				dvb::ArmAutoRun(g_server->Tools(), cfg.autoRunPath, cfg.autoRunRestoreScene);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,4 +1,5 @@
 #include "Autorun.h"
+#include "Capture.h"
 #include "Config.h"
 #include "ConsoleHook.h"
 #include "GameEvents.h"
@@ -81,6 +82,8 @@ namespace
 				dvb::Recording::SetLoadSettleMs(cfg.loadSettleMs);
 				dvb::Recording::SetDefaultIntervalMs(cfg.recordIntervalMs);
 				dvb::Recording::SetCoupling(cfg.couplingAnchorMs, cfg.couplingCellMs, cfg.cleanTransition, cfg.cleanTransitionCell);
+				dvb::Capture::SetEvents(&g_server->Events());
+				dvb::Capture::SetDefaults(cfg);
 				dvb::ArmAutoRun(g_server->Tools(), cfg.autoRunPath, cfg.autoRunRestoreScene);
 				dvb::HostApi::Init(g_server->Tools(), g_server->Events());
 				g_server->Start();

--- a/tests/Ssim_test.cpp
+++ b/tests/Ssim_test.cpp
@@ -1,0 +1,310 @@
+// Host-independent coverage for the native SSIM comparison pipeline (Ssim.h/.cpp): decode,
+// crop, windowed SSIM, and golden scoring. No game/provider involved — every image here is a
+// small synthetic BMP written to a temp dir by this file, decoded back through the same
+// stb_image path a real capture goes through.
+
+#include "test_framework.h"
+
+#include "Ssim.h"
+
+#include <cmath>
+#include <cstdint>
+#include <fstream>
+#include <functional>
+
+using dvb::json;
+using dvb::Ssim::ComputeSsim;
+using dvb::Ssim::CropUv;
+using dvb::Ssim::DecodeGray;
+using dvb::Ssim::GrayImage;
+using dvb::Ssim::ScoreAgainstGolden;
+
+namespace
+{
+	namespace fs = std::filesystem;
+
+	fs::path TestDir()
+	{
+		const fs::path  dir = fs::temp_directory_path() / "devbench_ssim_tests";
+		std::error_code ec;
+		fs::create_directories(dir, ec);
+		return dir;
+	}
+
+	// Minimal 24bpp, uncompressed BMP writer — just enough to round-trip through stb_image's
+	// BMP decoder, which is all these tests need (no PNG encoder is available in-tree; stb_image
+	// only decodes).
+	void WriteBmp24(const fs::path& a_path, int a_w, int a_h, const std::function<uint8_t(int, int)>& a_px)
+	{
+		const int            rowSize = ((a_w * 3 + 3) / 4) * 4;
+		const uint32_t       pixelBytes = static_cast<uint32_t>(rowSize) * a_h;
+		const uint32_t       fileSize = 14 + 40 + pixelBytes;
+		std::vector<uint8_t> buf;
+		buf.reserve(fileSize);
+
+		auto put16 = [&](uint16_t v) { buf.push_back(v & 0xFF); buf.push_back((v >> 8) & 0xFF); };
+		auto put32 = [&](uint32_t v) {
+			buf.push_back(v & 0xFF);
+			buf.push_back((v >> 8) & 0xFF);
+			buf.push_back((v >> 16) & 0xFF);
+			buf.push_back((v >> 24) & 0xFF);
+		};
+
+		buf.push_back('B');
+		buf.push_back('M');
+		put32(fileSize);
+		put32(0);
+		put32(54);
+
+		put32(40);
+		put32(static_cast<uint32_t>(a_w));
+		put32(static_cast<uint32_t>(a_h));
+		put16(1);
+		put16(24);
+		put32(0);
+		put32(pixelBytes);
+		put32(0);
+		put32(0);
+		put32(0);
+		put32(0);
+
+		for (int y = a_h - 1; y >= 0; --y) {
+			int written = 0;
+			for (int x = 0; x < a_w; ++x) {
+				const uint8_t v = a_px(x, y);
+				buf.push_back(v);
+				buf.push_back(v);
+				buf.push_back(v);
+				written += 3;
+			}
+			while (written < rowSize) {
+				buf.push_back(0);
+				++written;
+			}
+		}
+
+		std::ofstream out(a_path, std::ios::binary | std::ios::trunc);
+		out.write(reinterpret_cast<const char*>(buf.data()), static_cast<std::streamsize>(buf.size()));
+	}
+
+	uint8_t Checker(int a_x, int a_y, int a_cell)
+	{
+		return ((a_x / a_cell) + (a_y / a_cell)) % 2 == 0 ? 220 : 30;
+	}
+
+	void WriteChecker(const fs::path& a_path, int a_w, int a_h, int a_cell, bool a_invert = false)
+	{
+		WriteBmp24(a_path, a_w, a_h, [&](int x, int y) {
+			const uint8_t v = Checker(x, y, a_cell);
+			return a_invert ? static_cast<uint8_t>(255 - v) : v;
+		});
+	}
+
+	void WriteSolid(const fs::path& a_path, int a_w, int a_h, uint8_t a_value)
+	{
+		WriteBmp24(a_path, a_w, a_h, [&](int, int) { return a_value; });
+	}
+}
+
+TEST_CASE("DecodeGray returns nullopt for a missing file")
+{
+	CHECK(!DecodeGray(TestDir() / "does_not_exist.bmp").has_value());
+}
+
+TEST_CASE("DecodeGray round-trips dimensions and pixel values")
+{
+	const fs::path path = TestDir() / "checker_small.bmp";
+	WriteChecker(path, 16, 16, 4);
+
+	const auto img = DecodeGray(path);
+	CHECK(img.has_value());
+	CHECK(img->width == 16);
+	CHECK(img->height == 16);
+	CHECK(std::abs(img->px[0] - 220.0f) < 1.0f);  // (0,0) is an "on" checker cell
+}
+
+TEST_CASE("identical images score SSIM close to 1.0")
+{
+	const fs::path a = TestDir() / "id_a.bmp";
+	const fs::path b = TestDir() / "id_b.bmp";
+	WriteChecker(a, 24, 24, 4);
+	WriteChecker(b, 24, 24, 4);
+
+	const auto ia = DecodeGray(a);
+	const auto ib = DecodeGray(b);
+	CHECK(ia.has_value() && ib.has_value());
+	CHECK(std::abs(ComputeSsim(*ia, *ib) - 1.0) < 0.01);
+}
+
+TEST_CASE("fully value-inverted images score strongly negative")
+{
+	const fs::path a = TestDir() / "inv_a.bmp";
+	const fs::path b = TestDir() / "inv_b.bmp";
+	WriteChecker(a, 24, 24, 4, false);
+	WriteChecker(b, 24, 24, 4, true);
+
+	const auto ia = DecodeGray(a);
+	const auto ib = DecodeGray(b);
+	CHECK(ia.has_value() && ib.has_value());
+	// Regression guard for the non-overlapping-block bug: a naive block-aligned SSIM scored
+	// this exact case 0.54 (near-flat blocks blind the contrast term to sign inversion).
+	CHECK(ComputeSsim(*ia, *ib) < -0.5);
+}
+
+TEST_CASE("a partial difference scores strictly between identical and fully inverted")
+{
+	const fs::path a = TestDir() / "part_a.bmp";
+	const fs::path b = TestDir() / "part_b.bmp";
+	WriteChecker(a, 24, 24, 4, false);
+	// Right half inverted, left half untouched.
+	WriteBmp24(b, 24, 24, [](int x, int y) {
+		const uint8_t v = Checker(x, y, 4);
+		return x >= 12 ? static_cast<uint8_t>(255 - v) : v;
+	});
+
+	const auto ia = DecodeGray(a);
+	const auto ib = DecodeGray(b);
+	CHECK(ia.has_value() && ib.has_value());
+	const double score = ComputeSsim(*ia, *ib);
+	CHECK(score < 1.0);
+	CHECK(score > -0.5);
+}
+
+TEST_CASE("flat single-color images compare identical without a div-by-zero blowup")
+{
+	const fs::path a = TestDir() / "flat_a.bmp";
+	const fs::path b = TestDir() / "flat_b.bmp";
+	WriteSolid(a, 16, 16, 128);
+	WriteSolid(b, 16, 16, 128);
+
+	const auto ia = DecodeGray(a);
+	const auto ib = DecodeGray(b);
+	CHECK(ia.has_value() && ib.has_value());
+	CHECK(std::abs(ComputeSsim(*ia, *ib) - 1.0) < 0.01);
+}
+
+TEST_CASE("an image with height 1 defensively returns 0.0")
+{
+	const fs::path a = TestDir() / "thin_a.bmp";
+	const fs::path b = TestDir() / "thin_b.bmp";
+	WriteSolid(a, 16, 1, 128);
+	WriteSolid(b, 16, 1, 128);
+
+	const auto ia = DecodeGray(a);
+	const auto ib = DecodeGray(b);
+	CHECK(ia.has_value() && ib.has_value());
+	// win = min(8, w, h) = 1 -> the "win <= 1" guard fires regardless of content.
+	CHECK(ComputeSsim(*ia, *ib) == 0.0);
+}
+
+TEST_CASE("an image smaller than the SSIM window still scores via the whole-image fallback")
+{
+	const fs::path a = TestDir() / "tiny_a.bmp";
+	const fs::path b = TestDir() / "tiny_b.bmp";
+	WriteChecker(a, 4, 4, 2);
+	WriteChecker(b, 4, 4, 2);
+
+	const auto ia = DecodeGray(a);
+	const auto ib = DecodeGray(b);
+	CHECK(ia.has_value() && ib.has_value());
+	CHECK(std::abs(ComputeSsim(*ia, *ib) - 1.0) < 0.01);
+}
+
+TEST_CASE("CropUv extracts the requested UV rect")
+{
+	const fs::path path = TestDir() / "crop_src.bmp";
+	WriteBmp24(path, 10, 10, [](int x, int y) { return static_cast<uint8_t>(x + y); });
+	const auto img = DecodeGray(path);
+	CHECK(img.has_value());
+
+	const GrayImage right = CropUv(*img, json{ { "x", 0.5 }, { "y", 0.0 }, { "w", 0.5 }, { "h", 1.0 } });
+	CHECK(right.width == 5);
+	CHECK(right.height == 10);
+	// (x=5,y=0) in the source maps to (0,0) in the crop.
+	CHECK(std::abs(right.px[0] - 5.0f) < 0.5f);
+}
+
+TEST_CASE("ScoreAgainstGolden reports an error when the golden file is missing")
+{
+	const fs::path a = TestDir() / "golden_missing_candidate.bmp";
+	WriteSolid(a, 8, 8, 100);
+
+	const auto result = ScoreAgainstGolden(a, TestDir() / "no_such_golden.bmp", json::object());
+	CHECK(!result.ok);
+	CHECK(!result.error.empty());
+}
+
+TEST_CASE("ScoreAgainstGolden reports an error on a candidate/golden shape mismatch")
+{
+	const fs::path candidate = TestDir() / "shape_candidate.bmp";
+	const fs::path golden = TestDir() / "shape_golden.bmp";
+	WriteSolid(candidate, 8, 8, 100);
+	WriteSolid(golden, 16, 16, 100);
+
+	const auto result = ScoreAgainstGolden(candidate, golden, json::object());
+	CHECK(!result.ok);
+	CHECK(!result.error.empty());
+}
+
+TEST_CASE("ScoreAgainstGolden passes an identical capture against the default threshold")
+{
+	const fs::path candidate = TestDir() / "pass_candidate.bmp";
+	const fs::path golden = TestDir() / "pass_golden.bmp";
+	WriteChecker(candidate, 24, 24, 4);
+	WriteChecker(golden, 24, 24, 4);
+
+	const auto result = ScoreAgainstGolden(candidate, golden, json::object());
+	CHECK(result.ok);
+	CHECK(result.error.empty());
+	CHECK(result.passed);
+	CHECK(std::abs(result.threshold - 0.98) < 1e-9);
+	CHECK(result.regions.empty());
+}
+
+TEST_CASE("ScoreAgainstGolden fails a mismatched capture against a strict threshold")
+{
+	const fs::path candidate = TestDir() / "fail_candidate.bmp";
+	const fs::path golden = TestDir() / "fail_golden.bmp";
+	WriteChecker(candidate, 24, 24, 4, false);
+	WriteChecker(golden, 24, 24, 4, true);
+
+	const auto result = ScoreAgainstGolden(candidate, golden, json{ { "threshold", 0.98 } });
+	CHECK(result.ok);
+	CHECK(!result.passed);
+	CHECK(result.score < 0.98);
+}
+
+TEST_CASE("ScoreAgainstGolden with regions scores each region and propagates the worst")
+{
+	const fs::path candidate = TestDir() / "region_candidate.bmp";
+	const fs::path golden = TestDir() / "region_golden.bmp";
+	WriteChecker(golden, 24, 24, 4, false);
+	// Left half matches the golden; right half is inverted.
+	WriteBmp24(candidate, 24, 24, [](int x, int y) {
+		const uint8_t v = Checker(x, y, 4);
+		return x >= 12 ? static_cast<uint8_t>(255 - v) : v;
+	});
+
+	const json cfg{
+		{ "threshold", 0.98 },
+		{ "regions", json::array({ json{ { "name", "left" }, { "x", 0.0 }, { "y", 0.0 }, { "w", 0.5 }, { "h", 1.0 } },
+						 json{ { "name", "right" }, { "x", 0.5 }, { "y", 0.0 }, { "w", 0.5 }, { "h", 1.0 }, { "threshold", -1.0 } } }) }
+	};
+	const auto result = ScoreAgainstGolden(candidate, golden, cfg);
+	CHECK(result.ok);
+	CHECK(result.regions.size() == 2);
+
+	const auto& left = result.regions[0];
+	const auto& right = result.regions[1];
+	CHECK(left.name == "left");
+	CHECK(left.passed);
+	CHECK(std::abs(left.score - 1.0) < 0.05);
+
+	CHECK(right.name == "right");
+	CHECK(right.threshold == -1.0);
+	CHECK(right.passed);  // loose per-region threshold overrides the top-level one
+
+	// Overall verdict is the worst region, and passes only because the loose region threshold let it.
+	CHECK(result.passed);
+	CHECK(std::abs(result.score - right.score) < 1e-9);
+}

--- a/tests/http/README.md
+++ b/tests/http/README.md
@@ -74,14 +74,18 @@ how to play a recipe.
 
 ## Layout
 
-| File              | Covers                                                                                 |
-| ----------------- | -------------------------------------------------------------------------------------- |
-| `conftest.py`     | discovery, `base_url`/`client`/`tool_schema` fixtures, `requires_player`, skip helpers |
-| `test_smoke.py`   | discovery (`/api/tools`, `inspect` present) + console/camera/game smoke                |
-| `test_inspect.py` | `inspect` state / vm / scene / refs                                                    |
-| `test_papyrus.py` | `papyrus` list / describe / call (globals + members) + error                           |
-| `test_menu.py`    | `menu` list, and the open→list→close round-trip (guarded)                              |
-| `examples/`       | hand-run example recipes (not collected by pytest) — see below                         |
+| File                        | Covers                                                                                 |
+| --------------------------- | -------------------------------------------------------------------------------------- |
+| `conftest.py`               | discovery, `base_url`/`client`/`tool_schema` fixtures, `requires_player`, skip helpers |
+| `test_smoke.py`             | discovery (`/api/tools`, `inspect` present) + console/camera/game smoke                |
+| `test_inspect.py`           | `inspect` state / vm / scene / refs                                                    |
+| `test_papyrus.py`           | `papyrus` list / describe / call (globals + members) + error                           |
+| `test_menu.py`              | `menu` list, and the open→list→close round-trip (guarded)                              |
+| `visual.py`                 | SSIM/threshold/ROI scoring for capture checkpoints — pure, no server needed            |
+| `test_visual.py`            | unit tests for `visual.py` against synthetic PNGs — no server, no game                 |
+| `test_visual_regression.py` | live: replay a recording's `meta.checkpoints`, score captures against `goldens/`       |
+| `goldens/`                  | reference images for `test_visual_regression.py` — see `goldens/README.md`             |
+| `examples/`                 | hand-run example recipes (not collected by pytest) — see below                         |
 
 ## Examples
 

--- a/tests/http/README.md
+++ b/tests/http/README.md
@@ -74,18 +74,25 @@ how to play a recipe.
 
 ## Layout
 
-| File                        | Covers                                                                                 |
-| --------------------------- | -------------------------------------------------------------------------------------- |
-| `conftest.py`               | discovery, `base_url`/`client`/`tool_schema` fixtures, `requires_player`, skip helpers |
-| `test_smoke.py`             | discovery (`/api/tools`, `inspect` present) + console/camera/game smoke                |
-| `test_inspect.py`           | `inspect` state / vm / scene / refs                                                    |
-| `test_papyrus.py`           | `papyrus` list / describe / call (globals + members) + error                           |
-| `test_menu.py`              | `menu` list, and the open→list→close round-trip (guarded)                              |
-| `visual.py`                 | SSIM/threshold/ROI scoring for capture checkpoints — pure, no server needed            |
-| `test_visual.py`            | unit tests for `visual.py` against synthetic PNGs — no server, no game                 |
-| `test_visual_regression.py` | live: replay a recording's `meta.checkpoints`, score captures against `goldens/`       |
-| `goldens/`                  | reference images for `test_visual_regression.py` — see `goldens/README.md`             |
-| `examples/`                 | hand-run example recipes (not collected by pytest) — see below                         |
+| File                        | Covers                                                                                                                                    |
+| --------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------- |
+| `conftest.py`               | discovery, `base_url`/`client`/`tool_schema` fixtures, `requires_player`, skip helpers                                                    |
+| `test_smoke.py`             | discovery (`/api/tools`, `inspect` present) + console/camera/game smoke                                                                   |
+| `test_inspect.py`           | `inspect` state / vm / scene / refs                                                                                                       |
+| `test_papyrus.py`           | `papyrus` list / describe / call (globals + members) + error                                                                              |
+| `test_menu.py`              | `menu` list, and the open→list→close round-trip (guarded)                                                                                 |
+| `visual.py`                 | BATCH/corpus SSIM/threshold/ROI scoring across many recordings — pure, no server needed. NOT the primary mod-author interface — see below |
+| `test_visual.py`            | unit tests for `visual.py` against synthetic PNGs — no server, no game                                                                    |
+| `test_visual_regression.py` | live: replay a recording's `meta.checkpoints`, batch-score captures against `goldens/`                                                    |
+| `goldens/`                  | reference images for `test_visual_regression.py` — see `goldens/README.md`                                                                |
+| `examples/`                 | hand-run example recipes (not collected by pytest) — see below                                                                            |
+
+**Native single-checkpoint verdict (the primary interface):** the `capture` tool's `golden`/
+`threshold`/`regions` args — normally supplied via `record{action:"replay", goldens:{"<id>":
+{golden,threshold?,regions?}}}` — return `{ssim, threshold, passed}` inline in the same HTTP/MCP
+call that ran the replay. No Python, no second process. `visual.py`/`test_visual_regression.py`
+above are for batch/corpus work (many recordings, report generation, `--visual-update` across a
+whole tree) — reach for them only when that's actually the job.
 
 ## Examples
 

--- a/tests/http/conftest.py
+++ b/tests/http/conftest.py
@@ -352,6 +352,14 @@ def pytest_configure(config: pytest.Config) -> None:
     )
 
 
+def pytest_addoption(parser: pytest.Parser) -> None:
+    parser.addoption(
+        "--visual-update", action="store_true", default=False,
+        help="test_visual_regression.py: promote captured images over their goldens "
+        "instead of asserting against them (review the diff before committing).",
+    )
+
+
 @pytest.fixture
 def requires_player(player_loaded: bool) -> None:
     """Skip only if no player is loaded and the bootstrap couldn't establish one

--- a/tests/http/goldens/README.md
+++ b/tests/http/goldens/README.md
@@ -1,0 +1,52 @@
+# Visual-regression goldens
+
+Reference images for `test_visual_regression.py`, scored via `visual.py`
+(SSIM). Never generated or scored by devbench itself — comparison is entirely
+external, on purpose (see `docs/plans/replay-checkpoint-capture.md`).
+
+## Layout
+
+```
+goldens/<recording>/thresholds.json           # optional, see below
+goldens/<recording>/<variant>/<checkpointId>.png
+```
+
+`<recording>` is the recording file's stem, `<variant>` is whatever `record
+action=replay`'s `variant` arg was (default `"default"`), `<checkpointId>`
+matches a `meta.checkpoints[].id` in the recording.
+
+## `thresholds.json`
+
+Optional, per-recording. All keys optional:
+
+```jsonc
+{
+  "_default": { "threshold": 0.98 },
+  "<checkpointId>": {
+    "threshold": 0.98,
+    "regions": [
+      {
+        "name": "water",
+        "x": 0.0,
+        "y": 0.4,
+        "w": 1.0,
+        "h": 0.3,
+        "threshold": 0.9,
+      },
+    ],
+  },
+}
+```
+
+`regions` are optional 0..1 UV crops (same convention as the `capture` tool's
+`subrect` arg) scored independently — use this to give a noisy area (weather,
+particles) a looser threshold instead of loosening the whole frame.
+
+## Creating/updating a golden
+
+```sh
+pytest tests/http/test_visual_regression.py --visual-update
+```
+
+Review the resulting PNG diff before committing — this overwrites the golden
+unconditionally, it doesn't ask.

--- a/tests/http/requirements.txt
+++ b/tests/http/requirements.txt
@@ -1,2 +1,8 @@
 pytest>=7.0
 requests>=2.28
+
+# visual.py / test_visual*.py — SSIM-based capture-checkpoint scoring. Pure
+# Python; the numpy/scikit-image/Pillow trio never runs inside devbench itself.
+numpy>=1.24
+pillow>=10.0
+scikit-image>=0.22

--- a/tests/http/test_visual.py
+++ b/tests/http/test_visual.py
@@ -1,0 +1,183 @@
+"""Unit tests for visual.py's SSIM/threshold/ROI scoring.
+
+Pure — no devbench server, no game, no Skyrim install needed. Synthesizes tiny
+PNGs with Pillow and scores them directly, so this validates the scoring math
+itself independent of the (not-yet-live) capture pipeline it will eventually
+score real output from.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import numpy as np
+import pytest
+from PIL import Image
+
+from visual import capture_inconclusive_reason, promote_golden, score_checkpoint
+
+
+def _write_png(path: Path, pixels: np.ndarray) -> None:
+    Image.fromarray(pixels.astype(np.uint8), mode="L").save(path)
+
+
+def _solid(size: tuple[int, int], value: int) -> np.ndarray:
+    w, h = size
+    return np.full((h, w), value, dtype=np.uint8)
+
+
+def _checker(size: tuple[int, int], a: int, b: int, block: int = 4) -> np.ndarray:
+    w, h = size
+    yy, xx = np.mgrid[0:h, 0:w]
+    return np.where(((xx // block) + (yy // block)) % 2 == 0, a, b).astype(np.uint8)
+
+
+def test_identical_images_score_near_one(tmp_path: Path) -> None:
+    img = _checker((32, 32), 60, 200)
+    cand = tmp_path / "cand.png"
+    gold = tmp_path / "gold.png"
+    _write_png(cand, img)
+    _write_png(gold, img)
+
+    result = score_checkpoint(cand, gold, "cp1", {})
+    assert result.passed is True
+    assert result.score > 0.99, result
+    assert result.inconclusive_reason is None
+
+
+def test_very_different_images_fail(tmp_path: Path) -> None:
+    cand = tmp_path / "cand.png"
+    gold = tmp_path / "gold.png"
+    _write_png(cand, _solid((32, 32), 0))
+    _write_png(gold, _solid((32, 32), 255))
+
+    result = score_checkpoint(cand, gold, "cp1", {})
+    assert result.passed is False
+    assert result.score < 0.5, result
+
+
+def test_custom_threshold_from_config(tmp_path: Path) -> None:
+    img = _checker((32, 32), 100, 150)
+    noisy = img.copy()
+    noisy[0, 0] = 255  # a tiny, deliberate perturbation
+    cand, gold = tmp_path / "cand.png", tmp_path / "gold.png"
+    _write_png(cand, noisy)
+    _write_png(gold, img)
+
+    strict = score_checkpoint(cand, gold, "cp1", {"cp1": {"threshold": 0.999999}})
+    lenient = score_checkpoint(cand, gold, "cp1", {"cp1": {"threshold": 0.0}})
+    assert strict.passed is False
+    assert lenient.passed is True
+    assert strict.score == lenient.score  # same measurement, different gate
+
+
+def test_default_threshold_applies_when_checkpoint_unlisted(tmp_path: Path) -> None:
+    img = _checker((32, 32), 60, 200)
+    cand, gold = tmp_path / "cand.png", tmp_path / "gold.png"
+    _write_png(cand, img)
+    _write_png(gold, img)
+
+    result = score_checkpoint(cand, gold, "unlisted_checkpoint", {"_default": {"threshold": 0.5}})
+    assert result.threshold == 0.5
+
+
+def test_missing_golden_is_inconclusive_not_a_crash(tmp_path: Path) -> None:
+    cand = tmp_path / "cand.png"
+    _write_png(cand, _solid((16, 16), 128))
+
+    result = score_checkpoint(cand, tmp_path / "no_such_golden.png", "cp1", {})
+    assert result.passed is False
+    assert result.inconclusive_reason is not None
+    assert "no golden" in result.inconclusive_reason
+
+
+def test_shape_mismatch_raises_as_a_setup_error(tmp_path: Path) -> None:
+    cand, gold = tmp_path / "cand.png", tmp_path / "gold.png"
+    _write_png(cand, _solid((16, 16), 128))
+    _write_png(gold, _solid((32, 32), 128))
+
+    with pytest.raises(ValueError, match="shape mismatch"):
+        score_checkpoint(cand, gold, "cp1", {})
+
+
+def test_region_scoring_is_independent_per_region(tmp_path: Path) -> None:
+    # Left half identical, right half wildly different.
+    base = _checker((32, 32), 60, 200)
+    cand = base.copy()
+    cand[:, 16:] = 255 - cand[:, 16:]
+    cand_path, gold_path = tmp_path / "cand.png", tmp_path / "gold.png"
+    _write_png(cand_path, cand)
+    _write_png(gold_path, base)
+
+    thresholds = {
+        "cp1": {
+            "threshold": 0.9,
+            "regions": [
+                {"name": "left", "x": 0.0, "y": 0.0, "w": 0.5, "h": 1.0, "threshold": 0.9},
+                {"name": "right", "x": 0.5, "y": 0.0, "w": 0.5, "h": 1.0, "threshold": 0.9},
+            ],
+        }
+    }
+    result = score_checkpoint(cand_path, gold_path, "cp1", thresholds)
+    assert len(result.regions) == 2
+    left = next(r for r in result.regions if r.name == "left")
+    right = next(r for r in result.regions if r.name == "right")
+    assert left.passed is True, left
+    assert right.passed is False, right
+    assert result.passed is False  # overall fails if ANY region fails
+    assert result.score == right.score  # overall score is the worst region
+
+
+def test_region_with_looser_threshold_can_still_pass(tmp_path: Path) -> None:
+    base = _checker((32, 32), 60, 200)
+    cand = base.copy()
+    cand[:, 16:] = 255 - cand[:, 16:]  # right half noisy — e.g. weather/particles
+    cand_path, gold_path = tmp_path / "cand.png", tmp_path / "gold.png"
+    _write_png(cand_path, cand)
+    _write_png(gold_path, base)
+
+    # SSIM ranges -1..1, not 0..1 (a fully-inverted region scores strongly
+    # NEGATIVE, not merely low) — a "loose" threshold that should accept
+    # anything must reach down to -1.0, not 0.0.
+    thresholds = {
+        "cp1": {
+            "threshold": 0.9,
+            "regions": [
+                {"name": "left", "x": 0.0, "y": 0.0, "w": 0.5, "h": 1.0, "threshold": 0.9},
+                {"name": "right", "x": 0.5, "y": 0.0, "w": 0.5, "h": 1.0, "threshold": -1.0},
+            ],
+        }
+    }
+    result = score_checkpoint(cand_path, gold_path, "cp1", thresholds)
+    assert result.passed is True
+
+
+def test_promote_golden_copies_candidate_over_golden(tmp_path: Path) -> None:
+    cand = tmp_path / "cand.png"
+    golden = tmp_path / "goldens" / "rec" / "default" / "cp1.png"
+    _write_png(cand, _solid((8, 8), 42))
+    assert not golden.exists()
+
+    promote_golden(cand, golden)
+
+    assert golden.is_file()
+    result = score_checkpoint(cand, golden, "cp1", {})
+    assert result.passed is True
+    assert result.inconclusive_reason is None
+
+
+@pytest.mark.parametrize(
+    ("capture_result", "expect_reason_contains"),
+    [
+        ({"sceneMismatch": True}, "sceneMismatch"),
+        ({"degraded": ["nativeFallback"]}, "nativeFallback"),
+        ({"provider": "native"}, "native fallback"),
+        ({"provider": "openshaders", "sceneMismatch": False, "degraded": []}, None),
+    ],
+)
+def test_capture_inconclusive_reason(capture_result, expect_reason_contains) -> None:
+    reason = capture_inconclusive_reason(capture_result)
+    if expect_reason_contains is None:
+        assert reason is None
+    else:
+        assert reason is not None and expect_reason_contains in reason

--- a/tests/http/test_visual_regression.py
+++ b/tests/http/test_visual_regression.py
@@ -1,0 +1,128 @@
+"""Live shader-checkpoint visual regression: replay a recording with
+meta.checkpoints, capture the frames, score each against its golden.
+
+All comparison logic lives in visual.py (pure, server-independent — see its unit
+tests in test_visual.py); this module is only the live-server plumbing: run the
+replay, walk the transcript for `capture` steps, and either assert against
+goldens or (with --visual-update) promote the captures to be the new goldens.
+
+Skip-safe:
+  - No `capture` tool in the live schema -> skip (older build).
+  - No registered capture provider AND the recording doesn't allow native ->
+    skip (nothing would produce a comparable image).
+  - Server can't read the local temp recording path (remote server) -> skip.
+  - A capture whose result is inconclusive (scene mismatch, degraded, native
+    fallback) is reported as inconclusive, NEVER as a failure — see
+    visual.capture_inconclusive_reason.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import tempfile
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from conftest import require_tool
+from visual import capture_inconclusive_reason, load_thresholds, promote_golden, score_checkpoint
+
+GOLDENS_DIR = Path(__file__).parent / "goldens"
+
+# A minimal one-checkpoint recording: no trajectory beyond a single wait, so the
+# checkpoint (anchored at atMs=0) fires almost immediately. Good enough to
+# exercise the capture step's plumbing without needing a real recorded session.
+_RECORDING_NAME = "visual_smoke"
+_CHECKPOINT_ID = "smoke"
+
+
+def _write_recording(*, variant: str, allow_native: bool) -> str:
+    meta: dict[str, Any] = {
+        "checkpoints": [{"id": _CHECKPOINT_ID, "atMs": 0, "excludeUi": True}],
+    }
+    if allow_native:
+        meta["capabilities"] = [
+            {"capability": "capture", "required": True, "allowNative": True}
+        ]
+    fd, path = tempfile.mkstemp(suffix=".json", prefix=f"devbench_{_RECORDING_NAME}_")
+    with os.fdopen(fd, "w", encoding="utf-8") as f:
+        json.dump({"meta": meta, "steps": [{"wait": 50}]}, f)
+    return path
+
+
+@pytest.fixture
+def capture(tool_schema):
+    return require_tool(tool_schema, "capture")
+
+
+@pytest.fixture
+def record(tool_schema):
+    return require_tool(tool_schema, "record")
+
+
+def _capture_provider_registered(client) -> bool:
+    status, body = client.call("inspect", {"kind": "registrants"})
+    if status != 200 or not isinstance(body, dict):
+        return False
+    return bool(body.get("capabilities", {}).get("capture"))
+
+
+@pytest.mark.requires_player
+def test_checkpoint_capture_and_score(client, capture, record, request: pytest.FixtureRequest):
+    allow_native = not _capture_provider_registered(client)
+    if allow_native:
+        pytest.skip(
+            "no capture provider registered (see inspect kind=registrants) — "
+            "run with a provider mod loaded (e.g. Open Shaders) for a comparable image, "
+            "or rerun this test after a provider is present"
+        )
+
+    path = _write_recording(variant="default", allow_native=allow_native)
+    try:
+        status, body = client.call(
+            "record",
+            {"action": "replay", "path": path, "variant": "default", "async": False},
+            timeout=60.0,
+        )
+    finally:
+        os.unlink(path)
+
+    if status == 404:
+        pytest.skip("server can't read the local recording path (remote server)")
+    assert status == 200, body
+
+    capture_results = [
+        r["result"] for r in body.get("results", [])
+        if r.get("kind") == "tool" and r.get("tool") == "capture" and r.get("ok") and "result" in r
+    ]
+    assert capture_results, f"no successful capture step in replay transcript: {body}"
+    result = capture_results[0]
+    assert result.get("checkpointId") == _CHECKPOINT_ID, result
+
+    reason = capture_inconclusive_reason(result)
+    if reason is not None:
+        pytest.skip(f"capture is not comparable: {reason}")
+
+    recording_dir = GOLDENS_DIR / _RECORDING_NAME
+    golden_path = recording_dir / "default" / f"{_CHECKPOINT_ID}.png"
+    candidate_path = Path(result["path"])
+
+    if request.config.getoption("--visual-update"):
+        promote_golden(candidate_path, golden_path)
+        pytest.skip(f"--visual-update: promoted {candidate_path} -> {golden_path}")
+
+    if not golden_path.is_file():
+        pytest.skip(
+            f"no golden yet at {golden_path} — run with --visual-update once to create it "
+            "(review the image before committing it)"
+        )
+
+    thresholds = load_thresholds(recording_dir)
+    score = score_checkpoint(candidate_path, golden_path, _CHECKPOINT_ID, thresholds)
+    assert score.inconclusive_reason is None, score
+    assert score.passed, (
+        f"checkpoint '{_CHECKPOINT_ID}' SSIM {score.score:.4f} below threshold "
+        f"{score.threshold:.4f} (candidate: {candidate_path}, golden: {golden_path})"
+    )

--- a/tests/http/visual.py
+++ b/tests/http/visual.py
@@ -1,0 +1,185 @@
+"""Visual-regression scoring for devbench capture checkpoints.
+
+ALL image comparison lives here, in Python — devbench and its capture providers
+never compute pixel similarity in-process (see
+docs/plans/replay-checkpoint-capture.md for why). This module is pure: it never
+talks to the devbench server, only to PNG files on disk, so it's unit-testable
+against static fixtures with no game running (see test_visual.py).
+
+Layout convention (not enforced elsewhere — just what this module expects):
+
+    tests/http/goldens/<recording>/<variant>/<checkpointId>.png   golden reference
+    tests/http/goldens/<recording>/thresholds.json                per-checkpoint config
+
+thresholds.json shape (all keys optional):
+
+    {
+      "_default": {"threshold": 0.98},
+      "<checkpointId>": {
+        "threshold": 0.98,
+        "regions": [
+          {"name": "water", "x": 0.0, "y": 0.4, "w": 1.0, "h": 0.3, "threshold": 0.90}
+        ]
+      }
+    }
+
+`regions` are optional per-checkpoint ROI overrides in 0..1 UV — the same
+convention the `capture` tool's own `subrect` argument uses — scored
+independently so a noisy area (particles, weather) can carry a looser threshold
+than the frame as a whole, instead of loosening the whole-frame threshold to
+tolerate it.
+"""
+
+from __future__ import annotations
+
+import json
+import shutil
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+import numpy as np
+from PIL import Image
+from skimage.metrics import structural_similarity as ssim
+
+DEFAULT_THRESHOLD = 0.98
+
+
+@dataclass
+class RegionScore:
+    name: str
+    score: float
+    threshold: float
+    passed: bool
+
+
+@dataclass
+class CheckpointScore:
+    checkpoint_id: str
+    score: float  # whole-frame SSIM, or the worst region's score when regions are configured
+    threshold: float
+    passed: bool
+    regions: list[RegionScore] = field(default_factory=list)
+    # Set (to a human-readable reason) whenever `passed` should NOT be treated as a
+    # real verdict — e.g. the capture was stamped sceneMismatch/degraded, or there's
+    # no golden yet. Callers must check this before trusting `passed`.
+    inconclusive_reason: str | None = None
+
+
+def load_thresholds(recording_dir: Path) -> dict[str, Any]:
+    """Read <recording_dir>/thresholds.json, or {} if absent (all-defaults)."""
+    path = recording_dir / "thresholds.json"
+    if not path.is_file():
+        return {}
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def _checkpoint_config(thresholds: dict[str, Any], checkpoint_id: str) -> dict[str, Any]:
+    cfg: dict[str, Any] = dict(thresholds.get("_default", {}))
+    cfg.update(thresholds.get(checkpoint_id, {}))
+    cfg.setdefault("threshold", DEFAULT_THRESHOLD)
+    return cfg
+
+
+def _load_gray(path: Path) -> np.ndarray:
+    return np.asarray(Image.open(path).convert("L"), dtype=np.float64)
+
+
+def _crop_uv(arr: np.ndarray, uv: dict[str, float]) -> np.ndarray:
+    """Crop a 0..1 UV rect {x,y,w,h} — the same convention the capture tool's
+    `subrect` argument uses, so a region here can be copy-pasted from there."""
+    h, w = arr.shape[:2]
+    x0 = int(round(uv.get("x", 0.0) * w))
+    y0 = int(round(uv.get("y", 0.0) * h))
+    x1 = int(round((uv.get("x", 0.0) + uv.get("w", 1.0)) * w))
+    y1 = int(round((uv.get("y", 0.0) + uv.get("h", 1.0)) * h))
+    return arr[max(0, y0):min(h, y1), max(0, x0):min(w, x1)]
+
+
+def _ssim(a: np.ndarray, b: np.ndarray) -> float:
+    if a.shape != b.shape:
+        # A resolution/crop mismatch is a setup error (wrong golden, resized capture
+        # window), not a shader regression — the caller should not report this as a
+        # normal fail without noting why.
+        raise ValueError(f"shape mismatch: candidate {a.shape} vs golden {b.shape}")
+    if a.size == 0:
+        raise ValueError("empty region")
+    # skimage's default 7x7 window doesn't fit a smaller region (e.g. a tight ROI
+    # crop) — shrink it (odd, >=3) rather than let structural_similarity raise.
+    shortest = min(a.shape[0], a.shape[1])
+    win = min(7, shortest if shortest % 2 else shortest - 1)
+    win = max(3, win)
+    return float(ssim(a, b, data_range=255.0, win_size=win))
+
+
+def score_checkpoint(
+    candidate_path: Path,
+    golden_path: Path,
+    checkpoint_id: str,
+    thresholds: dict[str, Any],
+    *,
+    inconclusive_reason: str | None = None,
+) -> CheckpointScore:
+    """Score one checkpoint's candidate PNG against its golden.
+
+    Never raises for a genuine visual mismatch — that's an ordinary
+    `passed=False` result. Only raises for setup errors (unreadable image,
+    shape mismatch); a missing golden is reported as inconclusive, not raised,
+    since "no golden yet" is an expected first-run state, not a bug.
+    """
+    cfg = _checkpoint_config(thresholds, checkpoint_id)
+    threshold = float(cfg["threshold"])
+
+    if not golden_path.is_file():
+        return CheckpointScore(
+            checkpoint_id=checkpoint_id, score=0.0, threshold=threshold, passed=False,
+            inconclusive_reason=inconclusive_reason or f"no golden at {golden_path}",
+        )
+
+    cand = _load_gray(candidate_path)
+    gold = _load_gray(golden_path)
+
+    region_cfgs = cfg.get("regions", [])
+    if region_cfgs:
+        regions = []
+        for r in region_cfgs:
+            r_score = _ssim(_crop_uv(cand, r), _crop_uv(gold, r))
+            r_threshold = float(r.get("threshold", threshold))
+            regions.append(RegionScore(
+                name=r.get("name", "?"), score=r_score,
+                threshold=r_threshold, passed=r_score >= r_threshold,
+            ))
+        return CheckpointScore(
+            checkpoint_id=checkpoint_id, score=min(r.score for r in regions), threshold=threshold,
+            passed=all(r.passed for r in regions), regions=regions,
+            inconclusive_reason=inconclusive_reason,
+        )
+
+    score = _ssim(cand, gold)
+    return CheckpointScore(
+        checkpoint_id=checkpoint_id, score=score, threshold=threshold,
+        passed=score >= threshold, inconclusive_reason=inconclusive_reason,
+    )
+
+
+def promote_golden(candidate_path: Path, golden_path: Path) -> None:
+    """Copy a candidate over its golden — the `--visual-update` path. Callers
+    decide when this is appropriate (a reviewed, intentional shader change)."""
+    golden_path.parent.mkdir(parents=True, exist_ok=True)
+    shutil.copyfile(candidate_path, golden_path)
+
+
+def capture_inconclusive_reason(capture_result: dict[str, Any]) -> str | None:
+    """Why a `capture` tool result should NOT be scored as a real pass/fail, or
+    None if it's trustworthy. Mirrors the rules in
+    docs/plans/replay-checkpoint-capture.md Part 4: a mismatched/unsettled scene,
+    any `degraded` stamp (native fallback, UI included, etc.), or a non-provider
+    capture are all reported as inconclusive rather than a false regression."""
+    if capture_result.get("sceneMismatch"):
+        return "sceneMismatch"
+    degraded = capture_result.get("degraded") or []
+    if degraded:
+        return f"degraded: {', '.join(degraded)}"
+    if capture_result.get("provider") == "native":
+        return "captured via the low-fidelity native fallback, not a registered provider"
+    return None

--- a/tests/http/visual.py
+++ b/tests/http/visual.py
@@ -1,10 +1,22 @@
-"""Visual-regression scoring for devbench capture checkpoints.
+"""Batch/corpus visual-regression scoring for devbench capture checkpoints.
 
-ALL image comparison lives here, in Python — devbench and its capture providers
-never compute pixel similarity in-process (see
-docs/plans/replay-checkpoint-capture.md for why). This module is pure: it never
-talks to the devbench server, only to PNG files on disk, so it's unit-testable
-against static fixtures with no game running (see test_visual.py).
+devbench ALSO has a native, single-checkpoint SSIM verdict now (the `capture`
+tool's `golden`/`threshold`/`regions` args, normally supplied via
+`record{action:"replay", goldens:{...}}`) — that is the primary, mod-author-
+facing way to get "did this checkpoint match" as {ssim, threshold, passed}
+inline in the SAME HTTP/MCP call that ran the replay, no Python required. This
+module is NOT that interface. It exists for the different job of scoring many
+recordings/checkpoints at once, generating reports, and managing a `goldens/`
+tree with `--visual-update` — genuine batch/corpus work, not a single
+checkpoint's fast pass/fail. Reach for this when you're comfortable with Python
+and want that; otherwise use the native `capture`/`record` args directly.
+
+This module is pure: it never talks to the devbench server, only to PNG files
+on disk, so it's unit-testable against static fixtures with no game running
+(see test_visual.py). Its SSIM implementation (scikit-image, Gaussian-weighted
+sliding window) is independent of devbench's own native C++ implementation
+(uniform-weighted overlapping window) — the two are NOT guaranteed bit-exact
+against each other, by design; each is suited to its own use case.
 
 Layout convention (not enforced elsewhere — just what this module expects):
 

--- a/xmake-requires.lock
+++ b/xmake-requires.lock
@@ -3,6 +3,101 @@
         version = "1.0"
     },
     ["windows|x64"] = {
+        ["cmake#31fecfc4"] = {
+            repo = {
+                branch = "master",
+                commit = "b0b316eb13e79e5ea7e7a56b80117a3526dedeeb",
+                url = "https://gitlab.com/tboox/xmake-repo.git"
+            },
+            version = "4.0.3"
+        },
+        ["directxmath 2024.02#31fecfc4"] = {
+            repo = {
+                branch = "master",
+                commit = "b0b316eb13e79e5ea7e7a56b80117a3526dedeeb",
+                url = "https://gitlab.com/tboox/xmake-repo.git"
+            },
+            version = "2024.02"
+        },
+        ["directxtk 24.2.0#31fecfc4"] = {
+            repo = {
+                branch = "master",
+                commit = "b0b316eb13e79e5ea7e7a56b80117a3526dedeeb",
+                url = "https://gitlab.com/tboox/xmake-repo.git"
+            },
+            version = "24.2.0"
+        },
+        ["fuck-api 1.0.0#31fecfc4"] = {
+            repo = {
+                url = "xmake-pkgs"
+            },
+            version = "1.0.0"
+        },
+        ["imgui#31fecfc4"] = {
+            repo = {
+                branch = "master",
+                commit = "b0b316eb13e79e5ea7e7a56b80117a3526dedeeb",
+                url = "https://gitlab.com/tboox/xmake-repo.git"
+            },
+            version = "v1.92.0"
+        },
+        ["ninja#31fecfc4"] = {
+            repo = {
+                branch = "master",
+                commit = "b0b316eb13e79e5ea7e7a56b80117a3526dedeeb",
+                url = "https://gitlab.com/tboox/xmake-repo.git"
+            },
+            version = "v1.12.1"
+        },
+        ["nlohmann_json#31fecfc4"] = {
+            repo = {
+                branch = "master",
+                commit = "b0b316eb13e79e5ea7e7a56b80117a3526dedeeb",
+                url = "https://gitlab.com/tboox/xmake-repo.git"
+            },
+            version = "v3.12.0"
+        },
+        ["rapidcsv v8.92#31fecfc4"] = {
+            branch = "v8.92",
+            repo = {
+                branch = "master",
+                commit = "b0b316eb13e79e5ea7e7a56b80117a3526dedeeb",
+                url = "https://gitlab.com/tboox/xmake-repo.git"
+            },
+            version = "v8.92"
+        },
+        ["simpleini v4.25#31fecfc4"] = {
+            branch = "v4.25",
+            repo = {
+                branch = "master",
+                commit = "b0b316eb13e79e5ea7e7a56b80117a3526dedeeb",
+                url = "https://gitlab.com/tboox/xmake-repo.git"
+            },
+            version = "v4.25"
+        },
+        ["simpleini#31fecfc4"] = {
+            repo = {
+                branch = "master",
+                commit = "b0b316eb13e79e5ea7e7a56b80117a3526dedeeb",
+                url = "https://gitlab.com/tboox/xmake-repo.git"
+            },
+            version = "v4.22"
+        },
+        ["skse-menu-framework-api 3.7.0#31fecfc4"] = {
+            repo = {
+                url = "xmake-pkgs"
+            },
+            version = "3.7.0"
+        },
+        ["spdlog v1.16.0#9c36f0a9"] = {
+            branch = "v1.16.0",
+            repo = {
+                branch = "master",
+                commit = "b0b316eb13e79e5ea7e7a56b80117a3526dedeeb",
+                url = "https://gitlab.com/tboox/xmake-repo.git"
+            },
+            version = "v1.16.0"
+        },
         ["stb#31fecfc4"] = {
             repo = {
                 branch = "master",
@@ -10,6 +105,14 @@
                 url = "https://gitlab.com/tboox/xmake-repo.git"
             },
             version = "2025.03.14"
+        },
+        ["xbyak v7.06#31fecfc4"] = {
+            repo = {
+                branch = "master",
+                commit = "e81b38d77a76847788811a838c0e7fbdb199221d",
+                url = "https://gitlab.com/tboox/xmake-repo.git"
+            },
+            version = "v7.06"
         }
     }
 }

--- a/xmake-requires.lock
+++ b/xmake-requires.lock
@@ -3,108 +3,13 @@
         version = "1.0"
     },
     ["windows|x64"] = {
-        ["cmake#31fecfc4"] = {
+        ["stb#31fecfc4"] = {
             repo = {
                 branch = "master",
                 commit = "b0b316eb13e79e5ea7e7a56b80117a3526dedeeb",
                 url = "https://gitlab.com/tboox/xmake-repo.git"
             },
-            version = "4.0.3"
-        },
-        ["directxmath 2024.02#31fecfc4"] = {
-            repo = {
-                branch = "master",
-                commit = "b0b316eb13e79e5ea7e7a56b80117a3526dedeeb",
-                url = "https://gitlab.com/tboox/xmake-repo.git"
-            },
-            version = "2024.02"
-        },
-        ["directxtk 24.2.0#31fecfc4"] = {
-            repo = {
-                branch = "master",
-                commit = "b0b316eb13e79e5ea7e7a56b80117a3526dedeeb",
-                url = "https://gitlab.com/tboox/xmake-repo.git"
-            },
-            version = "24.2.0"
-        },
-        ["fuck-api 1.0.0#31fecfc4"] = {
-            repo = {
-                url = "xmake-pkgs"
-            },
-            version = "1.0.0"
-        },
-        ["imgui#31fecfc4"] = {
-            repo = {
-                branch = "master",
-                commit = "b0b316eb13e79e5ea7e7a56b80117a3526dedeeb",
-                url = "https://gitlab.com/tboox/xmake-repo.git"
-            },
-            version = "v1.92.0"
-        },
-        ["ninja#31fecfc4"] = {
-            repo = {
-                branch = "master",
-                commit = "b0b316eb13e79e5ea7e7a56b80117a3526dedeeb",
-                url = "https://gitlab.com/tboox/xmake-repo.git"
-            },
-            version = "v1.12.1"
-        },
-        ["nlohmann_json#31fecfc4"] = {
-            repo = {
-                branch = "master",
-                commit = "b0b316eb13e79e5ea7e7a56b80117a3526dedeeb",
-                url = "https://gitlab.com/tboox/xmake-repo.git"
-            },
-            version = "v3.12.0"
-        },
-        ["rapidcsv v8.92#31fecfc4"] = {
-            branch = "v8.92",
-            repo = {
-                branch = "master",
-                commit = "b0b316eb13e79e5ea7e7a56b80117a3526dedeeb",
-                url = "https://gitlab.com/tboox/xmake-repo.git"
-            },
-            version = "v8.92"
-        },
-        ["simpleini v4.25#31fecfc4"] = {
-            branch = "v4.25",
-            repo = {
-                branch = "master",
-                commit = "b0b316eb13e79e5ea7e7a56b80117a3526dedeeb",
-                url = "https://gitlab.com/tboox/xmake-repo.git"
-            },
-            version = "v4.25"
-        },
-        ["simpleini#31fecfc4"] = {
-            repo = {
-                branch = "master",
-                commit = "b0b316eb13e79e5ea7e7a56b80117a3526dedeeb",
-                url = "https://gitlab.com/tboox/xmake-repo.git"
-            },
-            version = "v4.22"
-        },
-        ["skse-menu-framework-api 3.7.0#31fecfc4"] = {
-            repo = {
-                url = "xmake-pkgs"
-            },
-            version = "3.7.0"
-        },
-        ["spdlog v1.16.0#9c36f0a9"] = {
-            branch = "v1.16.0",
-            repo = {
-                branch = "master",
-                commit = "b0b316eb13e79e5ea7e7a56b80117a3526dedeeb",
-                url = "https://gitlab.com/tboox/xmake-repo.git"
-            },
-            version = "v1.16.0"
-        },
-        ["xbyak v7.06#31fecfc4"] = {
-            repo = {
-                branch = "master",
-                commit = "e81b38d77a76847788811a838c0e7fbdb199221d",
-                url = "https://gitlab.com/tboox/xmake-repo.git"
-            },
-            version = "v7.06"
+            version = "2025.03.14"
         }
     }
 }

--- a/xmake.lua
+++ b/xmake.lua
@@ -153,10 +153,11 @@ target("devbench-tests")
 set_kind("binary")
 set_default(false)
 set_languages("c++23")
-add_packages("nlohmann_json")
+add_packages("nlohmann_json", "stb")
 add_includedirs("src")
 add_files("tests/*.cpp")
 add_files("src/ToolRegistry.cpp") -- exercised directly; pure logic, no game deps
+add_files("src/Ssim.cpp") -- exercised directly; pure logic, no game deps
 add_headerfiles("tests/*.h")
 set_pcxxheader("tests/pch.h")
 add_defines("_WINSOCKAPI_")

--- a/xmake.lua
+++ b/xmake.lua
@@ -33,6 +33,11 @@ add_rules("plugin.vsxmake.autoupdate")
 
 -- packages
 add_requires("nlohmann_json")
+-- Decode-only image loading for the `capture` tool's native SSIM comparison (two already-
+-- captured PNGs -> pixel buffers). Same single-header library Open Shaders already vendors
+-- for its own screenshot encode/decode -- no new dependency ecosystem, just the one everyone
+-- adjacent to this already uses.
+add_requires("stb")
 
 -- Local package repo: pins the optional SMF3 client API header (single header, pulled at build
 -- time, runtime GetProcAddress — inert when SMF is not installed). See xmake-pkgs/.
@@ -73,7 +78,7 @@ target_end()
 -- target
 target("devbench")
 add_deps("commonlibsse-ng", "cpp-mcp", "devbench-UI", "devbench-UI-fuck")
-add_packages("nlohmann_json")
+add_packages("nlohmann_json", "stb")
 
 -- DLL output name
 set_basename("devbench")


### PR DESCRIPTION
## Summary

Adds a plugin-agnostic screenshot-checkpoint capability to devbench's record/replay system, for shader-variant visual regression testing. All comparison logic (SSIM/thresholds/goldens) lives entirely outside the plugin — devbench only captures and signals readiness.

- **Registrant ledger** (`HostApi`) + `inspect kind=registrants`: tracks which plugins requested the C-ABI and what they registered, so a capability gate can answer "is a capture provider actually available" without guessing.
- **`capture` tool**: a third `RegisterToolExtension`-based base tool (alongside `menu`/`inspect`). `kind=auto` resolves the sole registered provider, 404s on zero (unless `allowNative:true`), 400s naming multiple — never silently guesses. A small native fallback (`kind=native`, vanilla `MenuControls::QueueScreenshot()` + directory poll with an exclusive-open readiness probe) exists for when no provider is registered; explicitly lower-fidelity and stamped as `degraded` so it's never mistaken for a comparable capture. `inspect kind=screenshots` shares the same directory-scan helper.
- **Recording manifest checkpoints**: `meta.checkpoints`/`meta.capabilities` expand into `capture` steps interleaved into a replay's trajectory at the recorder's own wait-accumulated clock (`atMs`) — a macro over existing scenario primitives, not a new step kind (per `ROADMAP.md`'s "keep scenario thin" guard). A capability gate fails clearly and early (409) if a recording requires a provider that isn't registered. `captureCheckpoints:false` lets the same recording replay as a plain trajectory-only tour instead, skipping checkpoint expansion and the provider gate entirely.
- **Native SSIM comparison** (`src/Ssim.h/.cpp`): a fast, single-checkpoint pass/fail verdict inline in the `capture` response, independent of `tests/http/visual.py` (which stays the batch/corpus-scoring tool for many recordings at once). Unit-tested in the host-independent `devbench-tests` target (16 cases: identical/inverted/partial-difference scoring, region/ROI scoring, golden-file error paths).
- **Python scoring** (`tests/http/visual.py` + tests): SSIM via scikit-image, optional per-checkpoint ROI regions, and an inconclusive-vs-fail distinction (scene mismatch / degraded / native-fallback captures are never reported as false regressions).

Design produced via a supervisor design pass (Opus) → adversarial review (Gemini) → rebuttal/reconciliation cycle; full reasoning in `docs/plans/replay-checkpoint-capture.md`, including findings accepted, findings correctly rejected (with independent verification), and the fixes applied.

The Open Shaders reference capture-provider implementation is tracked separately (not in this PR) — see gbrain `todo-openshaders-devbench-capture-provider`.

## Test plan

- [x] `xmake build devbench` / `devbench-tests` — clean, no warnings; `xmake run devbench-tests` — all 24 cases pass.
- [x] Live SE testing (multiple passes): native-fallback capture, multi-checkpoint replay (Whiterun Dragonsreach and Guardian Stones → Whiterun), golden scoring including a deliberately mismatched golden (confirms the failure path reports correctly, not just the happy path), and the `captureCheckpoints:false` opt-out (confirmed zero captures written, full trajectory still replays).
- [x] Path-traversal rejection verified live: malicious `recording`/`variant`/`checkpointId` values (`../../evil`, `..`, `a/b`) all correctly rejected with `400`, while a legitimate capture immediately after still succeeds.
- [ ] End-to-end with a real capture provider (blocked on the separate Open Shaders implementation) — native fallback is the only path exercised so far.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VG5JVCZu45815sLroKp6F7