### PR TITLE
feat(health): add a main-thread stall watchdog

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ shared registry every mod can extend.
 - **Performance / A-B testing.** A recorded play-through replays the **same path and conditions
   every run**, so an A/B shader/feature comparison measures the _change_, not your hands.
   devbench publishes **semantic `EventBus` events** — `record.started`/`record.stopped`,
-  `scene.cellLoaded`, `menu`, `lifecycle` — so a profiler client can align a capture to those
+  `scene.cellLoaded`, `menu`, `lifecycle`, `health.stalled`/`health.resumed` — so a profiler client can align a capture to those
   boundaries; pair it with a Tracy-instrumented build (via the `tracy` MCP) to attribute
   frametime/GPU cost to a specific moment, toggle a feature through its tool, replay the same
   recipe, and diff the numbers.
@@ -129,6 +129,12 @@ Missing → auto-created with defaults. Invalid → defaults (logged). All keys 
   // cleanTransitionCell to force a clean loading screen. Save-loads already tear down.
   "cleanTransition": true,
   "cleanTransitionCell": "QASmoke",
+
+  // If the engine frame counter hasn't advanced for this long (ms), publish a
+  // "health.stalled" EventBus event (and "health.resumed" once it recovers) — catches a
+  // frozen main thread, which a menu/lifecycle event can never report on its own (those are
+  // published BY the main thread). 0 disables the watchdog.
+  "stallWatchdogMs": 5000,
 }
 ```
 
@@ -371,7 +377,7 @@ interface is shared), so **namespace your topics** the way you namespace tool na
 ## Performance data
 
 devbench publishes semantic **`EventBus` events** — `record.started`/`record.stopped`,
-`scene.cellLoaded`, `menu`, and `lifecycle` — so a client can align a capture to those
+`scene.cellLoaded`, `menu`, `lifecycle`, and `health.stalled`/`health.resumed` — so a client can align a capture to those
 boundaries (and the `scenario` tool returns per-step timings synchronously) — but devbench does
 not collect or serve profiling data itself.
 Frametime and GPU metrics are left to dedicated clients: pair devbench with a Tracy-instrumented

--- a/src/Config.cpp
+++ b/src/Config.cpp
@@ -44,6 +44,7 @@ namespace dvb
 				{ "captureScanDirs", a_cfg.captureScanDirs },
 				{ "captureTimeoutMs", a_cfg.captureTimeoutMs },
 				{ "captureSettleMs", a_cfg.captureSettleMs },
+				{ "stallWatchdogMs", a_cfg.stallWatchdogMs },
 			};
 			out << j.dump(2) << '\n';
 		}
@@ -121,6 +122,7 @@ namespace dvb
 			cfg.captureScanDirs = j.value("captureScanDirs", cfg.captureScanDirs);
 			cfg.captureTimeoutMs = j.value("captureTimeoutMs", cfg.captureTimeoutMs);
 			cfg.captureSettleMs = j.value("captureSettleMs", cfg.captureSettleMs);
+			cfg.stallWatchdogMs = j.value("stallWatchdogMs", cfg.stallWatchdogMs);
 
 			// Migrate forward: if the file predates any key (e.g. an install from before
 			// the record hotkeys existed), rewrite it so the new keys appear with their
@@ -131,7 +133,8 @@ namespace dvb
 				"recordHotkeyShift", "replayHotkeyShift", "replayPath", "replayRestoreScene",
 				"recordIntervalMs", "autoRunPath", "autoRunRestoreScene", "loadSettleMs",
 				"couplingAnchorMs", "couplingCellMs", "cleanTransition", "cleanTransitionCell",
-				"captureDir", "captureScanDirs", "captureTimeoutMs", "captureSettleMs"
+				"captureDir", "captureScanDirs", "captureTimeoutMs", "captureSettleMs",
+				"stallWatchdogMs"
 			};
 			const bool complete = std::all_of(std::begin(kKeys), std::end(kKeys),
 				[&](const char* k) { return j.contains(k); });

--- a/src/Config.h
+++ b/src/Config.h
@@ -62,6 +62,12 @@ namespace dvb
 		std::vector<std::string> captureScanDirs = { "", "Screenshots" };
 		int                      captureTimeoutMs = 8000;
 		int                      captureSettleMs = 500;  // default settle before a checkpoint capture
+
+		// Background watchdog: if the engine frame counter hasn't advanced for this long,
+		// publish a "health.stalled" EventBus event (and "health.resumed" once it recovers) —
+		// covers a frozen main thread, which a `menu`/`lifecycle` event never can (those are
+		// published BY the main thread). 0 disables the watchdog.
+		int stallWatchdogMs = 5000;
 	};
 
 	// Load Data/SKSE/Plugins/devbench/config.json. If the file is missing it is

--- a/src/StallWatchdog.cpp
+++ b/src/StallWatchdog.cpp
@@ -1,0 +1,60 @@
+#include "StallWatchdog.h"
+
+#include "EventBus.h"
+#include "GameEvents.h"
+#include "GameState.h"
+#include "Json.h"
+
+#include <chrono>
+#include <thread>
+
+namespace dvb::StallWatchdog
+{
+	namespace
+	{
+		using namespace std::chrono;
+		constexpr int kPollMs = 1000;
+	}
+
+	void Start(EventBus& a_bus, int a_stallMs)
+	{
+		if (a_stallMs <= 0)
+			return;
+		EventBus* bus = &a_bus;
+		std::thread([bus, a_stallMs]() {
+			int  lastFrame = game::CurrentFrame();
+			auto lastAdvance = steady_clock::now();
+			bool stalled = false;
+			for (;;) {
+				std::this_thread::sleep_for(milliseconds(kPollMs));
+				const int frame = game::CurrentFrame();
+				if (frame < 0)
+					continue;  // address library not resolved yet -- nothing to watch
+				const auto now = steady_clock::now();
+				if (frame != lastFrame) {
+					if (stalled) {
+						const long long stalledForMs = duration_cast<milliseconds>(now - lastAdvance).count();
+						bus->Publish("health.resumed", json{ { "frame", frame }, { "stalledForMs", stalledForMs } });
+						stalled = false;
+					}
+					lastFrame = frame;
+					lastAdvance = now;
+					continue;
+				}
+				if (stalled)
+					continue;  // already reported; wait for it to resolve
+				const long long sinceAdvance = duration_cast<milliseconds>(now - lastAdvance).count();
+				if (sinceAdvance < a_stallMs)
+					continue;
+				stalled = true;
+				json j{ { "frame", frame }, { "stalledForMs", sinceAdvance } };
+				// Best-effort context: read from the live tracked set (no main-thread marshal),
+				// so this still reports something even though the stall itself means RE::UI
+				// can't be safely queried right now.
+				if (auto menus = GetOpenMenus(); !menus.empty())
+					j["lastKnownOpenMenus"] = std::move(menus);
+				bus->Publish("health.stalled", j);
+			}
+		}).detach();
+	}
+}

--- a/src/StallWatchdog.cpp
+++ b/src/StallWatchdog.cpp
@@ -5,6 +5,7 @@
 #include "GameState.h"
 #include "Json.h"
 
+#include <algorithm>
 #include <chrono>
 #include <thread>
 
@@ -13,20 +14,23 @@ namespace dvb::StallWatchdog
 	namespace
 	{
 		using namespace std::chrono;
-		constexpr int kPollMs = 1000;
 	}
 
 	void Start(EventBus& a_bus, int a_stallMs)
 	{
 		if (a_stallMs <= 0)
 			return;
+		// A fixed 1s poll can't reliably detect a threshold shorter than that (the stall could
+		// come and go between two samples) — scale the interval down for a low threshold, but
+		// never poll tighter than 100ms or looser than 1s.
+		const int pollMs = std::clamp(a_stallMs / 3, 100, 1000);
 		EventBus* bus = &a_bus;
-		std::thread([bus, a_stallMs]() {
+		std::thread([bus, a_stallMs, pollMs]() {
 			int  lastFrame = game::CurrentFrame();
 			auto lastAdvance = steady_clock::now();
 			bool stalled = false;
 			for (;;) {
-				std::this_thread::sleep_for(milliseconds(kPollMs));
+				std::this_thread::sleep_for(milliseconds(pollMs));
 				const int frame = game::CurrentFrame();
 				if (frame < 0)
 					continue;  // address library not resolved yet -- nothing to watch

--- a/src/StallWatchdog.h
+++ b/src/StallWatchdog.h
@@ -1,0 +1,19 @@
+#pragma once
+
+namespace dvb
+{
+	class EventBus;
+
+	/// Background watchdog for a frozen main thread — the case `menu`/`lifecycle` events can
+	/// never cover, since those are published BY the main thread (nothing publishes if it's
+	/// stalled). Samples the lock-free game frame counter off its own thread; if the frame
+	/// hasn't advanced for `a_stallMs`, publishes "health.stalled" { frame, stalledForMs,
+	/// lastKnownOpenMenus? } once, then "health.resumed" { frame, stalledForMs } once frame
+	/// advances again. `a_stallMs <= 0` disables the watchdog (no-op). Call once, after the
+	/// server's EventBus exists; the thread runs for the plugin's lifetime (detached — devbench
+	/// never unloads mid-process, so there is no shutdown point to join from).
+	namespace StallWatchdog
+	{
+		void Start(EventBus& a_bus, int a_stallMs);
+	}
+}

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -9,6 +9,7 @@
 #include "Recording.h"
 #include "RecordingsMenu.h"
 #include "Server.h"
+#include "StallWatchdog.h"
 #include "Tools.h"
 #include "Version.h"
 
@@ -89,6 +90,7 @@ namespace
 				dvb::HostApi::Init(g_server->Tools(), g_server->Events());
 				g_server->Start();
 				dvb::InstallGameEvents(g_server->Events());
+				dvb::StallWatchdog::Start(g_server->Events(), cfg.stallWatchdogMs);
 				dvb::ConsoleHook::Install(g_server->Events());  // observe console commands as events / for recording
 
 				// Receive cross-plugin interface requests from ANY plugin (nullptr sender),


### PR DESCRIPTION
## Summary
- Add a detached background thread that samples the existing lock-free engine frame counter and publishes `health.stalled` / `health.resumed` over the EventBus (poll + SSE), so a client can be *pushed* a notification instead of polling `/api/health` and eyeballing the frame count.
- `menu`/`lifecycle` events are published *by* the main thread and can never report on a stall of that same thread — this fills that gap using only lock-free reads (`game::CurrentFrame()`) and the already-non-blocking `EventBus::Publish`, so it can't itself get stuck on a frozen main thread.
- New `stallWatchdogMs` config knob (default 5000ms; 0 disables).

## Test plan
- [x] `xmake build devbench` / `devbench-tests` — clean, no warnings.
- [x] `xmake run devbench-tests` — all 24 cases pass.
- [x] Live SE test (lowered `stallWatchdogMs` to 300ms): watchdog correctly fired `health.stalled` → `health.resumed` bracketing the plugin's own real boot/loading-screen sequence (frame 0 → frame 38, ~10s), with no false positives on two subsequent normal `coc` loading-screen transitions.
- [x] Verified in an integration branch merged with `feat/replay-checkpoint-capture` (#66) — both features build and run together with no conflicts; capture/SSIM path still returns correct results on the merged build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VG5JVCZu45815sLroKp6F7

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automatic detection of prolonged engine stalls.
  * Added `health.stalled` notifications with stall duration and available menu context.
  * Added `health.resumed` notifications when normal frame progress returns.
  * Added the `stallWatchdogMs` setting, configurable in milliseconds and disabled with `0`.

* **Documentation**
  * Documented the new health events and watchdog configuration option.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->