### PR TITLE
docs: warn RegisterToolExtension can hide capabilities from agents

### DIFF
--- a/README.md
+++ b/README.md
@@ -348,6 +348,20 @@ needed. Pass a `"description"` in the descriptor; it's shown inline. For menus,
 `registered`; `menu open` on a registered name returns a 400 pointing you at `invoke`. Opening/closing/
 listing engine menus already works generically — only custom interaction/data needs a handler.
 
+**Only extend a base tool whose name already means what you're adding — or a cold agent won't find it.**
+An LLM client triaging a long tool list reads a tool's existing summary as its whole story before
+reading the full schema. A/B-tested with two cold subagents (same task, same target mod, no other
+context): one build exposed a settings-command/query dispatcher as its own top-level tool
+(`yourmod.actions`); the other bolted the identical dispatcher onto `menu` via new `op` values
+(`op:"invokeCommand"`, alongside the existing `open`/`close`/`toggle`). The agent given the separate
+tool found it immediately and used it correctly. The agent given the merged `menu` tool never tried
+it — `menu`'s summary reads "open/close/toggle a window," so the agent judged it irrelevant to a
+settings task and moved on, missing the extra `op` values entirely even though they were fully
+present in the schema — then fell back to hand-deriving raw state to accomplish the task, the exact
+fragile path the dispatcher existed to avoid. `RegisterToolExtension` keeps the top-level list short,
+but that's not free if the extension's job doesn't semantically match the base tool it hides under —
+register a new top-level tool instead when it doesn't.
+
 ### Design your tools the agentic-renderdoc way
 
 devbench follows the **[agentic-renderdoc](https://github.com/EdenLabs/agentic-renderdoc#why-this-design)**


### PR DESCRIPTION
## Summary

An A/B test (two cold LLM subagents, identical task, no shared
context) found that merging a new capability into an existing
`RegisterToolExtension` base tool can make it practically
undiscoverable, even though it's fully present in the JSON schema.

- **Setup:** a consuming mod (Open Shaders) built two variants of a
  new command/query dispatcher: one as its own top-level tool, one
  merged into the existing `menu` tool's extension via new `op`
  values alongside `open`/`close`/`toggle`.
- **Result:** the agent given the separate tool found and used it
  immediately, citing the tool's own description as the reason it
  preferred the dedicated action over hand-deriving state. The
  agent given the merged tool read `menu`'s existing summary ("open/
  close/toggle... headlessly"), judged it irrelevant to a
  settings-mutation task, and moved on -- never reading far enough
  to notice the new `op` values -- then fell back to a fragile
  manual workaround.
- **Root cause:** a client triaging a long tool list treats an
  existing tool's established name/summary as its whole story
  before reading the full schema. `RegisterToolExtension`'s "keep
  the surface small" benefit is real, but only when the extension's
  job semantically matches what the base tool already means.

Adds a short caveat to the "Use devbench from your mod" section,
right after the existing `RegisterToolExtension` usage example,
where a plugin author deciding whether to extend `menu`/`inspect`
vs. register a new top-level tool would actually read it.

## Test plan

- [x] Docs-only change; no build/test impact.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added guidance on when to extend an existing tool versus register a new top-level tool.
  * Clarified the importance of semantic alignment and discoverability when organizing tool functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->