### PR TITLE
feat: support Skyrim AE 1.7.99

### DIFF
--- a/README.md
+++ b/README.md
@@ -348,6 +348,20 @@ needed. Pass a `"description"` in the descriptor; it's shown inline. For menus,
 `registered`; `menu open` on a registered name returns a 400 pointing you at `invoke`. Opening/closing/
 listing engine menus already works generically — only custom interaction/data needs a handler.
 
+**Only extend a base tool whose name already means what you're adding — or a cold agent won't find it.**
+An LLM client triaging a long tool list reads a tool's existing summary as its whole story before
+reading the full schema. A/B-tested with two cold subagents (same task, same target mod, no other
+context): one build exposed a settings-command/query dispatcher as its own top-level tool
+(`yourmod.actions`); the other bolted the identical dispatcher onto `menu` via new `op` values
+(`op:"invokeCommand"`, alongside the existing `open`/`close`/`toggle`). The agent given the separate
+tool found it immediately and used it correctly. The agent given the merged `menu` tool never tried
+it — `menu`'s summary reads "open/close/toggle a window," so the agent judged it irrelevant to a
+settings task and moved on, missing the extra `op` values entirely even though they were fully
+present in the schema — then fell back to hand-deriving raw state to accomplish the task, the exact
+fragile path the dispatcher existed to avoid. `RegisterToolExtension` keeps the top-level list short,
+but that's not free if the extension's job doesn't semantically match the base tool it hides under —
+register a new top-level tool instead when it doesn't.
+
 ### Design your tools the agentic-renderdoc way
 
 devbench follows the **[agentic-renderdoc](https://github.com/EdenLabs/agentic-renderdoc#why-this-design)**

--- a/src/Tools.cpp
+++ b/src/Tools.cpp
@@ -519,7 +519,7 @@ namespace dvb
 						{ "messageBoxOpen", true },
 						{ "bodyText", data->bodyText.c_str() ? std::string(data->bodyText.c_str()) : std::string{} },
 						{ "buttons", std::move(buttons) },
-						{ "cancelIndex", data->cancelOptionIndex },
+						{ "cancelIndex", data->cancelButtonIndex },
 					};
 				});
 			}
@@ -535,7 +535,7 @@ namespace dvb
 						if (!data->bodyText.c_str() || !ContainsCI(data->bodyText.c_str(), matchBody))
 							return json{ { "accepted", false }, { "reason", "body did not match matchBody" } };
 						// Non-cancel button, but never out of range: fall back to 0 on a one-button box.
-						const int pick = (data->cancelOptionIndex == 0 && data->buttonText.size() > 1) ? 1 : 0;
+						const int pick = (data->cancelButtonIndex == 0 && data->buttonText.size() > 1) ? 1 : 0;
 						RE::MessageBoxMenu::SelectOption(pick);
 						return json{ { "accepted", true }, { "index", pick } };
 					});
@@ -1424,7 +1424,7 @@ namespace dvb
 					auto* data = RE::MessageBoxMenu::GetCurrentMessageBoxData();
 					if (!data || !data->bodyText.c_str() || !ContainsCI(data->bodyText.c_str(), a_matchBody))
 						return false;
-					RE::MessageBoxMenu::SelectOption((data->cancelOptionIndex == 0 && data->buttonText.size() > 1) ? 1 : 0);
+					RE::MessageBoxMenu::SelectOption((data->cancelButtonIndex == 0 && data->buttonText.size() > 1) ? 1 : 0);
 					return true;
 				},
 					milliseconds(1000))
@@ -1440,7 +1440,7 @@ namespace dvb
 			try {
 				MainThread::RunAndWait([]() -> json {
 					if (auto* data = RE::MessageBoxMenu::GetCurrentMessageBoxData())
-						RE::MessageBoxMenu::SelectOption(data->cancelOptionIndex);
+						RE::MessageBoxMenu::SelectOption(data->cancelButtonIndex);
 					return true;
 				},
 					milliseconds(1000));


### PR DESCRIPTION
## Summary
- Bumps the `lib/commonlibsse-ng` submodule to CommonLibVR-ng `v6.4.0`, which adds support for AE 1.7.99's new address-library format.
- Renames 4 call sites in `src/Tools.cpp` from `RE::MessageBoxData::cancelOptionIndex` to `cancelButtonIndex` -- unrelated general upstream drift since this repo's old `v4.25.1` pin, surfaced as a compile error by the bump.
- No devbench-side code reads any of the AE-1.7.99-affected fields directly (`SkyrimVM::handlePolicy` and friends), so no other RE-driven changes were needed.

## Test plan
- [x] `xmake` -- clean build
- [x] `xmake run devbench-tests`
- [x] Smoke-tested against a real SE instance (`inspect kind=player` returns real data, clean shutdown, no crash log)

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>

https://claude.ai/code/session_013WqQD3vawqgNMZ4tAR3bSA

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Added guidance for designing extensions that semantically match their base tools.
  - Clarified when unrelated capabilities should be exposed as separate top-level tools.
  - Included findings from an A/B test showing how tool placement can affect discoverability.

- **Bug Fixes**
  - Corrected menu cancellation handling so the appropriate cancel button is recognized across menu and modal interactions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->