### PR TITLE
fix(scenario): honor embedded tool errors

### DIFF
--- a/src/ScenarioPolicy.h
+++ b/src/ScenarioPolicy.h
@@ -6,6 +6,8 @@
 
 namespace dvb::ScenarioPolicy
 {
+	inline constexpr int kEmbeddedToolFallbackErrorCode = 422;
+
 	/// Extension tools report domain failures in their JSON payload. A scenario
 	/// must treat those as failed steps even when transport dispatch succeeded.
 	[[nodiscard]] inline bool IsEmbeddedToolFailure(const json& a_value)
@@ -14,7 +16,8 @@ namespace dvb::ScenarioPolicy
 			return false;
 		if (const auto error = a_value.find("error");
 			error != a_value.end() && !error->is_null()) {
-			return !error->is_string() || !error->get_ref<const std::string&>().empty();
+			if (!error->is_string() || !error->get_ref<const std::string&>().empty())
+				return true;
 		}
 		if (const auto ok = a_value.find("ok");
 			ok != a_value.end() && ok->is_boolean()) {
@@ -23,6 +26,7 @@ namespace dvb::ScenarioPolicy
 		return false;
 	}
 
+	/// Return the receipt's code or the scenario fallback failure code.
 	[[nodiscard]] inline json EmbeddedToolErrorCode(const json& a_value)
 	{
 		if (a_value.is_object()) {
@@ -31,14 +35,19 @@ namespace dvb::ScenarioPolicy
 				return *code;
 			}
 		}
-		return 422;
+		return kEmbeddedToolFallbackErrorCode;
 	}
 
+	/// Return the receipt's message or a stable ok:false fallback.
 	[[nodiscard]] inline std::string EmbeddedToolErrorMessage(const json& a_value)
 	{
 		if (a_value.is_object()) {
-			if (const auto error = a_value.find("error"); error != a_value.end()) {
-				return error->is_string() ? error->get<std::string>() : error->dump();
+			if (const auto error = a_value.find("error");
+				error != a_value.end() && !error->is_null()) {
+				if (!error->is_string())
+					return error->dump();
+				if (!error->get_ref<const std::string&>().empty())
+					return error->get<std::string>();
 			}
 		}
 		return "tool returned ok:false";

--- a/src/ScenarioPolicy.h
+++ b/src/ScenarioPolicy.h
@@ -1,0 +1,46 @@
+#pragma once
+
+#include <string>
+
+#include "Json.h"
+
+namespace dvb::ScenarioPolicy
+{
+	/// Extension tools report domain failures in their JSON payload. A scenario
+	/// must treat those as failed steps even when transport dispatch succeeded.
+	[[nodiscard]] inline bool IsEmbeddedToolFailure(const json& a_value)
+	{
+		if (!a_value.is_object())
+			return false;
+		if (const auto error = a_value.find("error");
+			error != a_value.end() && !error->is_null()) {
+			return !error->is_string() || !error->get_ref<const std::string&>().empty();
+		}
+		if (const auto ok = a_value.find("ok");
+			ok != a_value.end() && ok->is_boolean()) {
+			return !ok->get<bool>();
+		}
+		return false;
+	}
+
+	[[nodiscard]] inline json EmbeddedToolErrorCode(const json& a_value)
+	{
+		if (a_value.is_object()) {
+			if (const auto code = a_value.find("errorCode");
+				code != a_value.end() && !code->is_null()) {
+				return *code;
+			}
+		}
+		return 422;
+	}
+
+	[[nodiscard]] inline std::string EmbeddedToolErrorMessage(const json& a_value)
+	{
+		if (a_value.is_object()) {
+			if (const auto error = a_value.find("error"); error != a_value.end()) {
+				return error->is_string() ? error->get<std::string>() : error->dump();
+			}
+		}
+		return "tool returned ok:false";
+	}
+}

--- a/src/Tools.cpp
+++ b/src/Tools.cpp
@@ -10,6 +10,7 @@
 #include "MainThread.h"
 #include "Papyrus.h"
 #include "Recording.h"
+#include "ScenarioPolicy.h"
 #include "Server.h"
 #include "ToolExtensions.h"
 #include "ToolRegistry.h"
@@ -1768,9 +1769,17 @@ namespace dvb
 							ToolContext stepCtx = a_ctx;
 							stepCtx.internal = true;  // scenario-driven — don't log each step (replay logs a summary)
 							const ToolResult tr = a_registry.Invoke(tool, args, stepCtx);
-							r["ok"] = tr.ok;
-							if (tr.ok) {
+							const bool       embeddedFailure =
+								tr.ok && ScenarioPolicy::IsEmbeddedToolFailure(tr.value);
+							r["ok"] = tr.ok && !embeddedFailure;
+							if (tr.ok && !embeddedFailure) {
 								r["result"] = tr.value;
+							} else if (embeddedFailure) {
+								// Keep the complete domain receipt while making fail-fast honor it.
+								r["result"] = tr.value;
+								r["errorCode"] = ScenarioPolicy::EmbeddedToolErrorCode(tr.value);
+								r["error"] = ScenarioPolicy::EmbeddedToolErrorMessage(tr.value);
+								stepFailed = true;
 							} else {
 								r["errorCode"] = tr.errorCode;
 								r["error"] = tr.errorMessage;

--- a/src/Tools.cpp
+++ b/src/Tools.cpp
@@ -1576,6 +1576,7 @@ namespace dvb
 			std::map<uint64_t, State> m_runs;
 		};
 
+		/// Execute a scenario step list and return its complete transcript.
 		json ScenarioHandler(const json& a_args, const ToolContext& a_ctx,
 			const ToolRegistry& a_registry, EventBus& a_events)
 		{

--- a/tests/ScenarioPolicy_test.cpp
+++ b/tests/ScenarioPolicy_test.cpp
@@ -1,0 +1,37 @@
+#include "test_framework.h"
+
+#include "ScenarioPolicy.h"
+
+using dvb::json;
+
+TEST_CASE("scenario rejects embedded extension errors")
+{
+	const json result{
+		{ "error", "qualification_wait requires object parameter 'target'" },
+		{ "errorCode", "invalid_target" },
+	};
+
+	CHECK(dvb::ScenarioPolicy::IsEmbeddedToolFailure(result));
+	CHECK(dvb::ScenarioPolicy::EmbeddedToolErrorCode(result) == "invalid_target");
+	CHECK(dvb::ScenarioPolicy::EmbeddedToolErrorMessage(result) ==
+		  "qualification_wait requires object parameter 'target'");
+}
+
+TEST_CASE("scenario rejects explicit ok false receipts")
+{
+	const json result{ { "ok", false }, { "errors", json::array({ "failed" }) } };
+
+	CHECK(dvb::ScenarioPolicy::IsEmbeddedToolFailure(result));
+	CHECK(dvb::ScenarioPolicy::EmbeddedToolErrorCode(result) == 422);
+}
+
+TEST_CASE("semantic waiter outcomes remain successful tool steps")
+{
+	const json result{
+		{ "satisfied", false },
+		{ "outcome", "timeout" },
+		{ "failureReasons", json::array({ "profile_pending" }) },
+	};
+
+	CHECK(!dvb::ScenarioPolicy::IsEmbeddedToolFailure(result));
+}

--- a/tests/ScenarioPolicy_test.cpp
+++ b/tests/ScenarioPolicy_test.cpp
@@ -25,6 +25,22 @@ TEST_CASE("scenario rejects explicit ok false receipts")
 	CHECK(dvb::ScenarioPolicy::EmbeddedToolErrorCode(result) == 422);
 }
 
+TEST_CASE("scenario evaluates ok false after an empty error")
+{
+	const json result{ { "error", "" }, { "ok", false } };
+
+	CHECK(dvb::ScenarioPolicy::IsEmbeddedToolFailure(result));
+	CHECK(dvb::ScenarioPolicy::EmbeddedToolErrorMessage(result) == "tool returned ok:false");
+}
+
+TEST_CASE("scenario uses the fallback message for a null error")
+{
+	const json result{ { "error", nullptr }, { "ok", false } };
+
+	CHECK(dvb::ScenarioPolicy::IsEmbeddedToolFailure(result));
+	CHECK(dvb::ScenarioPolicy::EmbeddedToolErrorMessage(result) == "tool returned ok:false");
+}
+
 TEST_CASE("semantic waiter outcomes remain successful tool steps")
 {
 	const json result{


### PR DESCRIPTION
## Why

Extension tools can return a successful transport result while reporting a
domain failure in the JSON payload. Scenario execution currently records such
a call as successful, so `failFast` can continue dispatching later steps after
the tool has already reported an error.

## What changed

- Treat a non-empty top-level `error` or explicit `ok: false` receipt as a
  failed scenario step.
- Preserve the complete tool result in the scenario transcript for diagnosis.
- Propagate an embedded `errorCode`, with a safe fallback when none is present.
- Keep semantic waiter outcomes such as `satisfied: false` as successful tool
  dispatches rather than transport or domain failures.
- Add focused host-independent tests for all three classifications.

## Failure behavior

Embedded domain failures now participate in the existing scenario failure and
`failFast` behavior. The original result remains available to callers, so this
does not discard extension-specific diagnostics.

## Validation

- `pre-commit run --files src/ScenarioPolicy.h src/Tools.cpp tests/ScenarioPolicy_test.cpp`
  - Passed all applicable hooks, including `clang-format`.
- `git diff --check upstream/main...HEAD`
  - Passed.
- Fork GitHub Actions run `33313429589`
  - ReleaseDbg build and `devbench-tests` passed with this source change.
- Local `xmake build --yes devbench-tests`
  - Not run because `xmake` is unavailable in the local environment.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Scenario steps now correctly recognize embedded tool and extension failures, even when responses appear technically successful.
  * Failure handling now preserves the complete tool response and reports the relevant error code and message.
  * Empty or missing error messages now receive a standard fallback message.
  * Fail-fast and continue-on-error behavior now reflects embedded domain failures.

* **Tests**
  * Added coverage for extension errors, unsuccessful receipts with missing error details, and successful semantic waiter outcomes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->