### PR TITLE
ci(release): ship devbench-bridge.exe in releases

### DIFF
--- a/.github/workflows/_build.yaml
+++ b/.github/workflows/_build.yaml
@@ -1,6 +1,7 @@
-# Reusable build: compiles devbench.dll with xmake (releasedbg) and uploads the
-# binaries as an artifact. Called by build.yaml (CI) and release.yaml (packaging),
-# so the toolchain is defined in exactly one place.
+# Reusable build: compiles devbench.dll with xmake (releasedbg) and the standalone
+# devbench-bridge.exe (bun compile), uploading each as its own artifact. Called by
+# build.yaml (CI) and release.yaml (packaging), so the toolchain is defined in
+# exactly one place.
 name: "_build"
 
 on:
@@ -18,6 +19,9 @@ on:
       artifact-name:
         description: "Artifact name the binaries were uploaded under."
         value: ${{ inputs.artifact-name }}
+      bridge-artifact-name:
+        description: "Artifact name the bridge exe was uploaded under."
+        value: ${{ inputs.artifact-name }}-bridge
 
 permissions:
   contents: read
@@ -81,4 +85,40 @@ jobs:
         with:
           name: ${{ inputs.artifact-name }}
           path: staging/*
+          if-no-files-found: error
+
+  bridge:
+    name: Build bridge (bun compile)
+    runs-on: windows-2025
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+        with:
+          ref: ${{ inputs.ref }}
+          persist-credentials: false
+
+      # npm ci (not bun install) so the compiled exe bundles the exact dependency
+      # versions pinned in package-lock.json — the same lockfile lint.yaml installs
+      # from for eslint. bun is only the compiler here, not the package manager.
+      - name: Set up Node
+        uses: actions/setup-node@v7
+        with:
+          node-version: 22
+
+      - name: Install bridge dependencies
+        working-directory: bridge
+        run: npm ci
+
+      - name: Set up bun
+        uses: oven-sh/setup-bun@v2
+
+      - name: Compile standalone exe
+        working-directory: bridge
+        run: bun run compile
+
+      - name: Upload bridge binary
+        uses: actions/upload-artifact@v7
+        with:
+          name: ${{ inputs.artifact-name }}-bridge
+          path: bridge/dist/devbench-bridge.exe
           if-no-files-found: error

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -3,8 +3,8 @@
 # picks the next version, bumps `local version` in xmake.lua, commits it back to main
 # (with [skip ci] so it doesn't re-trigger), creates the vX.Y.Z tag, and publishes a
 # GitHub Release whose body is the curated changelog. Downstream jobs then build the
-# plugin, attach the .7z mod archive to that release, and — on the source repo —
-# upload to Nexus with the same changelog.
+# plugin and the bridge exe, attach the .7z mod archive to that release, and — on the
+# source repo — upload to Nexus with the same changelog.
 #
 # Debounce: a leading `debounce` job waits out a short quiet window; each new push cancels the
 # still-sleeping wait and restarts it, so a burst of merges collapses into ONE release instead of
@@ -128,17 +128,25 @@ jobs:
           name: ${{ needs.build.outputs.artifact-name }}
           path: bin
 
+      - name: Download bridge binary
+        uses: actions/download-artifact@v8
+        with:
+          name: ${{ needs.build.outputs.bridge-artifact-name }}
+          path: bin-bridge
+
       - name: Assemble mod archive
         id: pkg
         run: |
           set -euo pipefail
           tag="${{ needs.semantic-release.outputs.new_release_git_tag }}"
           stage="devbench-${tag}"
-          # User archive ships only the plugin; docs/license live in the repo and the
-          # GitHub Release page, and the C-ABI dev API is consumed from source, not from
-          # the Nexus download.
-          mkdir -p "$stage/SKSE/Plugins"
+          # User archive ships the plugin plus the standalone MCP bridge exe (bridge/README.md
+          # promises it's already at this path — nothing to download separately); docs/license
+          # live in the repo and the GitHub Release page, and the C-ABI dev API is consumed
+          # from source, not from the Nexus download.
+          mkdir -p "$stage/SKSE/Plugins/devbench"
           cp bin/devbench.dll bin/devbench.pdb "$stage/SKSE/Plugins/"
+          cp bin-bridge/devbench-bridge.exe "$stage/SKSE/Plugins/devbench/"
           # Bundle the default recordings straight into the recordings dir so a fresh
           # install ships a ready-to-replay benchmark (e.g. Guardian Stones -> Whiterun).
           mkdir -p "$stage/SKSE/Plugins/devbench/recordings"


### PR DESCRIPTION
## Summary
- The release pipeline (`_build.yaml` → `release.yaml`'s `package` job) only ever built and staged `devbench.dll`/`devbench.pdb`. The bridge exe (`bridge/dist/devbench-bridge.exe`, built via `bun build --compile`) was never built in CI or added to the shipped `.7z` archive.
- `bridge/README.md` (added in #76) has claimed since v1.16.0 that "the bridge is already at `Data/SKSE/Plugins/devbench/devbench-bridge.exe` — nothing to download," which has never actually been true.
- Adds a `bridge` job to `_build.yaml` (`npm ci` for pinned deps, `bun run compile` to produce the standalone exe) and a new `bridge-artifact-name` output; `release.yaml`'s `package` job now downloads it and stages it at `SKSE/Plugins/devbench/devbench-bridge.exe` in the archive, matching the README's documented path.
- Also runs on every CI push/PR via `build.yaml`, so a bridge compile break now fails CI instead of silently rotting.

Split from a second, unrelated fix (mirroring runtime state outside a VFS mod manager's virtual Data tree, for MO2 users) — that's now its own PR, #84, since the two are independently revertable and `release.yaml`'s debounce job already collapses same-window merges into one release regardless of PR count.

## Test plan
- [x] `npm ci && bun run compile` verified locally — produces a working `dist/devbench-bridge.exe`; `node --test bridge/test/smoke-client.mjs` passes against it.
- [x] Reused the existing `oven-sh/setup-bun` pattern and `windows-2025` runner already used for the plugin build.
- [ ] Full CI run on this PR (build + release job wiring) — not exercised locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XCkukXEauoDj683tsdcnXx

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Release packages now include a standalone bridge executable alongside the plugin files.
  - Build outputs now provide both the plugin and bridge components, supporting more complete installation and distribution.

- **Improvements**
  - Release archives organize the plugin and bridge executable together for easier deployment.
  - Build and packaging documentation now reflects the complete set of included outputs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->