### PR TITLE
fix(bridge): mirror state files outside MO2's VFS

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,7 +157,10 @@ Missing → auto-created with defaults. Invalid → defaults (logged). All keys 
 The port is **deterministic per runtime** — **SE/AE `8920`, VR `8921`** — so a fixed MCP client URL
 never moves; set `port` explicitly to override. If the chosen port is already taken (e.g. a second
 instance of the same runtime), devbench iterates to the next free port (logged) and writes the bound
-port to `Data/SKSE/Plugins/devbench/runtime.json` (`{ "port": N }`) for discovery.
+port to `Data/SKSE/Plugins/devbench/runtime.json` (`{ "port": N }`) for discovery. Under a VFS mod
+manager (MO2, …) that path is virtual and unreachable from outside the manager's own hook, so the
+same file is also mirrored to `%LOCALAPPDATA%\devbench\<se|vr>\runtime.json`, which isn't
+virtualized — devbench-bridge checks both and uses whichever is freshest.
 
 ## Connect an MCP client
 

--- a/bridge/README.md
+++ b/bridge/README.md
@@ -8,7 +8,10 @@ to devbench's own `/mcp` endpoint does not.
 
 It holds no port/cache state of its own — every call reads the live port from that
 install's `Data/SKSE/Plugins/devbench/runtime.json` and proxies straight through, so a
-live call never drifts from whatever devbench build is actually running. `tools/list`
+live call never drifts from whatever devbench build is actually running. Under a VFS mod
+manager (MO2, …) that path is virtual and unreachable from outside the manager's own
+hook, so devbench also mirrors `runtime.json` to `%LOCALAPPDATA%\devbench\<se|vr>\`, which
+isn't virtualized — the bridge checks both and uses whichever is freshest. `tools/list`
 is the one exception: it returns `src/tools-fallback.json` (devbench's real core tool
 set, baked in at build time) when no game is up, since an MCP client typically caches
 `tools/list` for the whole session and can't be relied on to notice a
@@ -28,7 +31,13 @@ the build otherwise
 
 If devbench is installed, the bridge is already at
 `Data/SKSE/Plugins/devbench/devbench-bridge.exe` — nothing to download. Add one entry to
-your MCP client's config (Claude Code's `.mcp.json`, Claude Desktop's config, etc.):
+your MCP client's config (Claude Code's `.mcp.json`, Claude Desktop's config, etc.).
+
+**Under a VFS mod manager (MO2, …)** that path is only reachable by processes the manager
+itself launches — an MCP client spawning the bridge directly (the normal case) can't see
+it. Extract `devbench-bridge.exe` from the release archive to a real, on-disk folder and
+point `command` at that copy instead; `runtime.json`'s VFS-proof mirror (above) means the
+extracted exe still finds the live game either way.
 
 ```json
 {

--- a/bridge/src/runtime.ts
+++ b/bridge/src/runtime.ts
@@ -7,7 +7,7 @@ import { join } from "node:path";
 export interface Target {
   /** Human-readable label for error messages ("SE", "VR", or the --install path). */
   label: string;
-  /** Directory containing runtime.json (…/Data/SKSE/Plugins/devbench). */
+  /** Directory containing runtime.json — the Data-relative path or its %LOCALAPPDATA% mirror. */
   runtimeDir: string;
 }
 
@@ -32,6 +32,13 @@ const DEFAULT_VR_INSTALLS = [
 
 function runtimeDirFor(installPath: string): string {
   return join(installPath, "Data", "SKSE", "Plugins", "devbench");
+}
+
+// Must match Server.cpp's ExternalStateDir() exactly: %LOCALAPPDATA%\devbench\<se|vr>,
+// reachable even under a VFS mod manager (MO2) where Data/SKSE/Plugins/devbench is virtual.
+function localAppDataDevbenchDir(game: "se" | "vr"): string | undefined {
+  const localAppData = process.env.LOCALAPPDATA;
+  return localAppData ? join(localAppData, "devbench", game) : undefined;
 }
 
 // runtime.json survives after the game exits, so picking the first readable
@@ -67,6 +74,8 @@ export function resolveTarget(args: {
     const candidates = (
       args.game === "se" ? DEFAULT_SE_INSTALLS : DEFAULT_VR_INSTALLS
     ).map(runtimeDirFor);
+    const localAppDataDir = localAppDataDevbenchDir(args.game);
+    if (localAppDataDir) candidates.push(localAppDataDir);
     const found = freshestExisting(candidates);
     if (!found) {
       throw new Error(

--- a/src/Server.cpp
+++ b/src/Server.cpp
@@ -56,24 +56,47 @@ namespace
 		return available;
 	}
 
+	// %LOCALAPPDATA% survives a VFS mod manager's Data virtualization (MO2's overwrite folder
+	// swallows writes to Data/SKSE/Plugins/devbench); per-game subfolder since SE and VR run
+	// concurrently on separate ports.
+	std::optional<std::filesystem::path> ExternalStateDir()
+	{
+		wchar_t    buf[MAX_PATH]{};
+		const auto n = ::GetEnvironmentVariableW(L"LOCALAPPDATA", buf, static_cast<DWORD>(std::size(buf)));
+		if (n == 0 || n >= std::size(buf))
+			return std::nullopt;
+		return std::filesystem::path(buf) / "devbench" / (REL::Module::IsVR() ? "vr" : "se");
+	}
+
 	// Publish the actually-bound port so fixed-URL clients can discover a non-default
 	// choice (when auto-iteration moved off the configured port).
 	void WriteRuntimeInfo(int a_port)
 	{
-		std::error_code ec;
+		const std::string payload = "{\"port\":" + std::to_string(a_port) + "}\n";
+		std::error_code   ec;
 		std::filesystem::create_directories("Data/SKSE/Plugins/devbench", ec);
-		std::ofstream f("Data/SKSE/Plugins/devbench/runtime.json", std::ios::trunc);
-		if (f)
-			f << "{\"port\":" << a_port << "}\n";
+		if (std::ofstream f("Data/SKSE/Plugins/devbench/runtime.json", std::ios::trunc); f)
+			f << payload;
+		if (auto dir = ExternalStateDir()) {
+			std::filesystem::create_directories(*dir, ec);
+			if (std::ofstream f(*dir / "runtime.json", std::ios::trunc); f)
+				f << payload;
+		}
 	}
 
 	// Mirror of GET /api/tools's mcp_bridge block onto disk, for a caller who found devbench
 	// via its files rather than a live REST call (e.g. reading the install directory directly).
 	void WriteBridgeInfo()
 	{
-		std::ofstream f("Data/SKSE/Plugins/devbench/mcp-bridge.json", std::ios::trunc);
-		if (f)
-			f << dvb::BridgeDiscoveryInfo().dump(2) << "\n";
+		const std::string payload = dvb::BridgeDiscoveryInfo().dump(2) + "\n";
+		if (std::ofstream f("Data/SKSE/Plugins/devbench/mcp-bridge.json", std::ios::trunc); f)
+			f << payload;
+		if (auto dir = ExternalStateDir()) {
+			std::error_code ec;
+			std::filesystem::create_directories(*dir, ec);
+			if (std::ofstream f(*dir / "mcp-bridge.json", std::ios::trunc); f)
+				f << payload;
+		}
 	}
 }
 
@@ -267,7 +290,7 @@ namespace dvb
 		std::error_code   ec;
 		const std::string exePath = std::filesystem::absolute("Data/SKSE/Plugins/devbench/devbench-bridge.exe", ec).string();
 		const std::string name = "devbench-" + game;
-		return json{
+		json              result{
 			{ "exePath", exePath },
 			{ "args", json::array({ "--game", game }) },
 			{ "mcpJsonSnippet",
@@ -275,7 +298,14 @@ namespace dvb
 			{ "installCommand", std::format("\"{}\" setup --game {}", exePath, game) },
 			{ "note",
 				"Add mcpJsonSnippet to your MCP client's config (e.g. .mcp.json), or run installCommand "
-				"to print the same thing — devbench never edits your client config itself." },
+				"to print the same thing — devbench never edits your client config itself. Under a VFS mod "
+				"manager (MO2, …), exePath is only reachable by processes launched through that manager's "
+				"virtual filesystem -- an MCP client spawning the bridge directly needs a real, on-disk copy "
+				"instead (extract devbench-bridge.exe from the release archive). runtime.json and this file "
+				"are also mirrored to externalStateDir, which isn't virtualized, for exactly that reason." },
 		};
+		if (auto dir = ExternalStateDir())
+			result["externalStateDir"] = dir->string();
+		return result;
 	}
 }


### PR DESCRIPTION
## Summary
Independent of #82 (which just ships `devbench-bridge.exe` in the release archive) — split out per review feedback, since these are two separately-revertable fixes bundled by mistake, not one atomic change. `release.yaml`'s debounce job already collapses same-window merges into a single release, so there's no need to cram unrelated fixes into one PR to get them released together.

Under MO2 (and similar VFS mod managers), `Data/SKSE/Plugins/devbench` is virtual: writes from the game process land in the manager's overwrite folder, invisible to any reader not launched through the same hook — including `devbench-bridge.exe` spawned directly by an MCP client, which was silently falling back to the default port instead of the actually-bound one.

- Mirrors `runtime.json` and `mcp-bridge.json` to `%LOCALAPPDATA%\devbench\<se|vr>\` — app-local machine state, not virtualized, and (unlike `Documents\My Games\...`, SKSE's own log location) not personal user content subject to Controlled Folder Access or cloud sync/backup.
- `devbench-bridge`'s `resolveTarget` now checks both the Data-relative and `%LOCALAPPDATA%` candidates and uses whichever `runtime.json` is freshest.
- `BridgeDiscoveryInfo()` (the `mcp_bridge_setup` tool / `GET /api/tools`'s `mcp_bridge` field) now surfaces `externalStateDir` and a `note` explaining `exePath` is still only VFS-reachable — shipping the exe (#82) doesn't by itself fix a client spawning it directly outside MO2's hook; extracting it to a real folder is still required there.

Reported by an external VR/MO2 tester against 1.16.1/1.17.0. A third issue from the same report — console output capture (`ConsoleLog` hook) returning empty on VR — is unrelated and tracked separately as #83.

## Test plan
- [x] `xmake build devbench` compiles clean (link not re-verified — a live SkyrimVR test instance holds `devbench.pdb` locked; untouched per this repo's multi-instance coordination convention).
- [x] `npm run build && npm run lint` (bridge) clean.
- [ ] Not live-tested under an actual MO2 install.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XCkukXEauoDj683tsdcnXx