### PR TITLE
build(xmake): set /utf-8 on all shipped targets

### DIFF
--- a/xmake.lua
+++ b/xmake.lua
@@ -59,6 +59,9 @@ add_deps("commonlibsse-ng")
 add_packages("skse-menu-framework-api", "nlohmann_json")
 add_defines("_SILENCE_CXX17_CODECVT_HEADER_DEPRECATION_WARNING") -- SMF header uses std::wstring_convert
 add_defines("UNICODE", "_UNICODE", "_WINSOCKAPI_")
+-- MSVC's default execution charset is the system codepage, not UTF-8; without this,
+-- non-ASCII bytes in string literals (e.g. em dashes in UI tooltip text) get mangled.
+add_cxflags("/utf-8", { force = true })
 add_files("src/RecordingsMenu.cpp")
 add_includedirs("src")
 target_end()
@@ -71,6 +74,7 @@ set_warnings("all")
 add_deps("commonlibsse-ng")
 add_packages("fuck-api", "imgui", "simpleini", "nlohmann_json")
 add_defines("UNICODE", "_UNICODE", "_WINSOCKAPI_")
+add_cxflags("/utf-8", { force = true }) -- see devbench-UI's identical flag for why
 add_files("src/RecordingsMenuFuck.cpp")
 add_includedirs("src")
 target_end()
@@ -86,6 +90,10 @@ set_basename("devbench")
 -- ensure winsock2 (pulled in by cpp-mcp/httplib) wins over the legacy winsock
 -- that <Windows.h> would otherwise include via CommonLib.
 add_defines("_WINSOCKAPI_")
+
+-- see devbench-UI's identical flag for why (this target's own sources carry the same
+-- non-ASCII string literals, e.g. Server.cpp's log lines and mcp_bridge_setup's note).
+add_cxflags("/utf-8", { force = true })
 
 -- generate PDB (releasedbg handles /Zi; /DEBUG tells the linker to emit it)
 add_shflags("/DEBUG", { force = true })


### PR DESCRIPTION
## Summary
Found while getting an Ollama code review on #82/#84: `Server.cpp`'s `BridgeDiscoveryInfo()` `note` string embeds em dashes in a plain `char` string literal, and MSVC's default execution charset is the system codepage, not UTF-8 — without `/utf-8`, those bytes can get mangled at compile time. I checked whether that em dash predates either PR (it does — already on `main`), so it's a pre-existing, codebase-wide gap, not something #82/#84 introduced. Split into its own PR per the one-fix-per-PR standard those two were already split under.

`devbench-tests` already carried `/utf-8` — its own comment claimed "matches the main target," which was false: none of `devbench`, `devbench-UI`, or `devbench-UI-fuck` (the three targets that actually ship in the plugin) ever had it, despite `grep -rlP '[^\x00-\x7F]' src/*.cpp` turning up non-ASCII bytes (mostly em dashes) in the majority of source files — including user-visible ImGui tooltip text (`RecordingsMenu.cpp`/`RecordingsMenuFuck.cpp`, e.g. `"No recordings yet — press %s to record."`), not just log lines and the one REST-facing `note` field that prompted this.

Adds `add_cxflags("/utf-8", { force = true })` to all three targets, matching the flag `devbench-tests` already used and fixing the stale comment's premise rather than the comment itself.

## Test plan
- [x] `xmake build devbench` — clean full build (compile + link).
- [x] `xmake build devbench-tests && xmake run devbench-tests` — 55/55 pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XCkukXEauoDj683tsdcnXx