### PR TITLE
fix(input): sustain synthetic key holds

### DIFF
--- a/src/KeyboardInput.cpp
+++ b/src/KeyboardInput.cpp
@@ -4,6 +4,7 @@
 #include "GameState.h"
 #include "KeyboardInputState.h"
 #include "MainThread.h"
+#include "MainThreadTask.h"
 #include "ToolRegistry.h"
 #include "VRInput.h"
 #include "VRInputState.h"
@@ -16,6 +17,7 @@
 #include <condition_variable>
 #include <cstring>
 #include <limits>
+#include <memory>
 #include <mutex>
 #include <thread>
 #include <unordered_set>
@@ -47,17 +49,52 @@ namespace dvb
 		struct RepeatingKey
 		{
 			std::uint16_t scancode;
+			std::uint64_t generation;
 			std::int64_t  pressedAtMs;
 			std::int64_t  expiresAtMs;
 		};
 
-		// Only the game thread accesses these. Input requests hold the manager mutex
-		// while waiting on that thread, so the polling hook must not acquire it.
-		std::vector<RepeatingKey> g_repeatingKeys;
-		std::uint64_t             g_repeatCutoff = 0;
+		// Only PollKeyboard accesses the held state and the engine input queue.
+		// SKSE tasks can run after input dispatch and lose events at the queue reset.
+		std::vector<RepeatingKey>                            g_repeatingKeys;
+		std::atomic<std::uint64_t>                           g_repeatCutoff{ 0 };
+		std::mutex                                           g_inputTasksMutex;
+		std::vector<std::shared_ptr<MainThread::QueuedTask>> g_inputTasks;
+
+		json RunAtInputPoll(std::function<json()> a_fn)
+		{
+			const auto deadline = steady_clock::now() + seconds(5);
+			auto       invocation = std::make_shared<MainThread::QueuedTask>(std::move(a_fn), deadline);
+			auto       future = invocation->GetFuture();
+			{
+				std::lock_guard lock(g_inputTasksMutex);
+				g_inputTasks.push_back(invocation);
+			}
+			if (future.wait_until(deadline) == std::future_status::ready)
+				return future.get();
+			const bool abandoned = invocation->Abandon();
+			{
+				std::lock_guard lock(g_inputTasksMutex);
+				std::erase(g_inputTasks, invocation);
+			}
+			if (future.wait_for(milliseconds(0)) == std::future_status::ready)
+				return future.get();
+			throw MainThread::TaskTimeout(!abandoned, abandoned ?
+														  "keyboard input polling did not start within 5000ms. Queued input abandoned" :
+														  "keyboard input polling did not finish within 5000ms. Input already started and may still complete");
+		}
 
 		void PollKeyboard(CONTEXT&)
 		{
+			std::vector<std::shared_ptr<MainThread::QueuedTask>> tasks;
+			{
+				std::lock_guard lock(g_inputTasksMutex);
+				tasks.swap(g_inputTasks);
+			}
+			for (const auto& task : tasks)
+				task->Run();
+			const auto cutoff = g_repeatCutoff.load(std::memory_order_acquire);
+			std::erase_if(g_repeatingKeys, [=](const auto& key) { return key.generation <= cutoff; });
 			if (g_repeatingKeys.empty())
 				return;
 			auto* queue = RE::BSInputEventQueue::GetSingleton();
@@ -434,8 +471,7 @@ namespace dvb
 			void RequestLifecycleRelease() noexcept
 			{
 				const auto cutoff = m_latestGeneration.load(std::memory_order_acquire);
-				g_repeatCutoff = cutoff;
-				g_repeatingKeys.clear();
+				g_repeatCutoff.store(cutoff, std::memory_order_release);
 				if (!cutoff)
 					return;
 				RaiseLifecycleCutoff(cutoff);
@@ -452,8 +488,8 @@ namespace dvb
 			QueueResult QueueButton(const KeyboardLease& a_lease, bool a_down, float a_heldSecs)
 			{
 				try {
-					const json result = MainThread::RunAndWait([=]() -> json {
-						if (a_down && a_lease.generation <= g_repeatCutoff)
+					const json result = RunAtInputPoll([=]() -> json {
+						if (a_down && a_lease.generation <= g_repeatCutoff.load(std::memory_order_acquire))
 							throw ToolError(503, "keyboard press cancelled by game load");
 						auto* queue = RE::BSInputEventQueue::GetSingleton();
 						if (!queue)
@@ -461,7 +497,7 @@ namespace dvb
 						if (queue->buttonEventCount >= RE::BSInputEventQueue::MAX_BUTTON_EVENTS)
 							throw ToolError(503, "Skyrim keyboard input queue is full for this frame — retry after the next frame");
 						if (a_down)
-							g_repeatingKeys.push_back({ a_lease.key.scancode, NowMs(), a_lease.expiresAtMs });
+							g_repeatingKeys.push_back({ a_lease.key.scancode, a_lease.generation, NowMs(), a_lease.expiresAtMs });
 						else
 							std::erase_if(g_repeatingKeys, [&](const auto& key) { return key.scancode == a_lease.key.scancode; });
 						queue->AddButtonEvent(RE::INPUT_DEVICE::kKeyboard, 0, a_lease.key.scancode,

--- a/src/KeyboardInput.cpp
+++ b/src/KeyboardInput.cpp
@@ -14,6 +14,7 @@
 #include <atomic>
 #include <chrono>
 #include <condition_variable>
+#include <cstring>
 #include <limits>
 #include <mutex>
 #include <thread>
@@ -41,6 +42,48 @@ namespace dvb
 		std::int64_t NowMs()
 		{
 			return duration_cast<milliseconds>(steady_clock::now().time_since_epoch()).count();
+		}
+
+		struct RepeatingKey
+		{
+			std::uint16_t scancode;
+			std::int64_t  pressedAtMs;
+			std::int64_t  expiresAtMs;
+		};
+
+		// Only the game thread accesses these. Input requests hold the manager mutex
+		// while waiting on that thread, so the polling hook must not acquire it.
+		std::vector<RepeatingKey> g_repeatingKeys;
+		std::uint64_t             g_repeatCutoff = 0;
+
+		void PollKeyboard(CONTEXT&)
+		{
+			if (g_repeatingKeys.empty())
+				return;
+			auto* queue = RE::BSInputEventQueue::GetSingleton();
+			if (!queue)
+				return;
+			const auto now = NowMs();
+			for (const auto& key : g_repeatingKeys) {
+				if (now >= key.expiresAtMs)
+					continue;
+				if (queue->buttonEventCount >= RE::BSInputEventQueue::MAX_BUTTON_EVENTS)
+					break;
+				// Do not emit a held event in the same poll as the initial down.
+				bool queued = false;
+				for (auto* event = queue->GetQueueHead(); event; event = event->next) {
+					const auto* button = event->AsButtonEvent();
+					if (button && button->device == RE::INPUT_DEVICE::kKeyboard &&
+						button->GetIDCode() == key.scancode) {
+						queued = true;
+						break;
+					}
+				}
+				if (!queued) {
+					const float heldSecs = std::max(0.001F, static_cast<float>(now - key.pressedAtMs) / 1000.0F);
+					queue->AddButtonEvent(RE::INPUT_DEVICE::kKeyboard, 0, key.scancode, 1.0F, heldSecs);
+				}
+			}
 		}
 
 		int BoundedInteger(const json& a_object, const char* a_name, int a_default, int a_min, int a_max)
@@ -205,7 +248,7 @@ namespace dvb
 					}
 					m_latestGeneration.store(acquired.lease.generation, std::memory_order_release);
 					try {
-						queued = QueueButton(a_key, true, 0.0F);
+						queued = QueueButton(acquired.lease, true, 0.0F);
 					} catch (...) {
 						m_leases.RemoveExact(a_key.scancode, acquired.lease.generation);
 						throw;
@@ -233,7 +276,7 @@ namespace dvb
 					throw ToolError(409, std::format("key '{}' is held by owner '{}' (not '{}')", a_key.name, current->owner, a_owner));
 				const float       heldSecs = std::max(0.001F,
 					static_cast<float>(NowMs() - current->pressedAtMs) / 1000.0F);
-				const QueueResult queued = QueueButton(a_key, false, heldSecs);
+				const QueueResult queued = QueueButton(*current, false, heldSecs);
 				m_leases.RemoveExact(a_key.scancode, current->generation);
 				SignalWatchdog();
 				PublishLocked("up", *current, a_reason, queued.pending);
@@ -391,6 +434,8 @@ namespace dvb
 			void RequestLifecycleRelease() noexcept
 			{
 				const auto cutoff = m_latestGeneration.load(std::memory_order_acquire);
+				g_repeatCutoff = cutoff;
+				g_repeatingKeys.clear();
 				if (!cutoff)
 					return;
 				RaiseLifecycleCutoff(cutoff);
@@ -404,25 +449,29 @@ namespace dvb
 					throw ToolError(503, "keyboard input is advertised but not ready — SKSE kInputLoaded has not completed; inspect input capabilities/status and retry");
 			}
 
-			QueueResult QueueButton(const KeyboardKey& a_key, bool a_down, float a_heldSecs)
+			QueueResult QueueButton(const KeyboardLease& a_lease, bool a_down, float a_heldSecs)
 			{
 				try {
 					const json result = MainThread::RunAndWait([=]() -> json {
+						if (a_down && a_lease.generation <= g_repeatCutoff)
+							throw ToolError(503, "keyboard press cancelled by game load");
 						auto* queue = RE::BSInputEventQueue::GetSingleton();
 						if (!queue)
 							throw ToolError(503, "Skyrim BSInputEventQueue unavailable");
 						if (queue->buttonEventCount >= RE::BSInputEventQueue::MAX_BUTTON_EVENTS)
 							throw ToolError(503, "Skyrim keyboard input queue is full for this frame — retry after the next frame");
-						queue->AddButtonEvent(RE::INPUT_DEVICE::kKeyboard, 0, a_key.scancode,
+						if (a_down)
+							g_repeatingKeys.push_back({ a_lease.key.scancode, NowMs(), a_lease.expiresAtMs });
+						else
+							std::erase_if(g_repeatingKeys, [&](const auto& key) { return key.scancode == a_lease.key.scancode; });
+						queue->AddButtonEvent(RE::INPUT_DEVICE::kKeyboard, 0, a_lease.key.scancode,
 							a_down ? 1.0F : 0.0F, a_down ? 0.0F : a_heldSecs);
 						return json{ { "frame", game::CurrentFrame() } };
 					});
 					return { false, result.value("frame", -1) };
-				} catch (const ToolError& e) {
-					// RunAndWait's 504 means the task is already queued and will execute if the main
-					// thread resumes. Treat that as accepted/pending so a down retains its lease and
-					// watchdog, and an up can safely retire it without a retry racing the queued event.
-					if (e.code == 504)
+				} catch (const MainThread::TaskTimeout& e) {
+					// Only a running task can still deliver its event after a timeout.
+					if (e.started)
 						return { true, -1 };
 					throw;
 				}
@@ -578,7 +627,7 @@ namespace dvb
 					return false;
 				const float       heldSecs = std::max(0.001F,
 					static_cast<float>(NowMs() - current->pressedAtMs) / 1000.0F);
-				const QueueResult queued = QueueButton(current->key, false, heldSecs);
+				const QueueResult queued = QueueButton(*current, false, heldSecs);
 				m_leases.RemoveExact(a_scancode, a_generation);
 				PublishLocked("up", *current, a_reason, queued.pending);
 				return true;
@@ -699,6 +748,21 @@ namespace dvb
 
 	void MarkKeyboardInputReady()
 	{
+		if (g_inputReady.load(std::memory_order_relaxed))
+			return;
+		REL::Relocation<std::uintptr_t> poll{ RELOCATION_ID(67315, 68617) };
+		// PollInputDevices begins with two five-byte register saves on SE, AE and VR.
+		// Emit before control mapping and dispatch so every input sink sees the hold.
+		constexpr std::uint8_t prologue[]{ 0x48, 0x89, 0x5C, 0x24, 0x10, 0x48, 0x89, 0x74, 0x24, 0x18 };
+		if (std::memcmp(reinterpret_cast<const void*>(poll.address()), prologue, sizeof(prologue)) != 0) {
+			logs::error("devbench: unexpected input polling prologue (keyboard input unavailable)");
+			return;
+		}
+		g_repeatingKeys.reserve(kMaximumHeldKeys);
+		if (!SKSE::stl::install_context_hook(poll.address(), sizeof(prologue), &PollKeyboard, sizeof(prologue))) {
+			logs::error("devbench: failed to install keyboard input polling hook");
+			return;
+		}
 		g_inputReady.store(true, std::memory_order_relaxed);
 		logs::info("devbench: keyboard input API ready (contract v{}, Skyrim BSInputEventQueue)", kKeyboardContractVersion);
 	}

--- a/src/KeyboardInput.cpp
+++ b/src/KeyboardInput.cpp
@@ -16,10 +16,12 @@
 #include <chrono>
 #include <condition_variable>
 #include <cstring>
+#include <future>
 #include <limits>
 #include <memory>
 #include <mutex>
 #include <thread>
+#include <unordered_map>
 #include <unordered_set>
 
 namespace dvb
@@ -61,7 +63,7 @@ namespace dvb
 		std::mutex                                           g_inputTasksMutex;
 		std::vector<std::shared_ptr<MainThread::QueuedTask>> g_inputTasks;
 
-		json RunAtInputPoll(std::function<json()> a_fn)
+		std::future<json> RunAtInputPoll(std::function<json()> a_fn)
 		{
 			const auto deadline = steady_clock::now() + seconds(5);
 			auto       invocation = std::make_shared<MainThread::QueuedTask>(std::move(a_fn), deadline);
@@ -71,17 +73,17 @@ namespace dvb
 				g_inputTasks.push_back(invocation);
 			}
 			if (future.wait_until(deadline) == std::future_status::ready)
-				return future.get();
+				return future;
 			const bool abandoned = invocation->Abandon();
 			{
 				std::lock_guard lock(g_inputTasksMutex);
 				std::erase(g_inputTasks, invocation);
 			}
 			if (future.wait_for(milliseconds(0)) == std::future_status::ready)
-				return future.get();
-			throw MainThread::TaskTimeout(!abandoned, abandoned ?
-														  "keyboard input polling did not start within 5000ms. Queued input abandoned" :
-														  "keyboard input polling did not finish within 5000ms. Input already started and may still complete");
+				return future;
+			if (abandoned)
+				throw MainThread::TaskTimeout(false, "keyboard input polling did not start within 5000ms. Queued input abandoned");
+			return future;
 		}
 
 		void PollKeyboard(CONTEXT&)
@@ -190,8 +192,15 @@ namespace dvb
 
 		struct QueueResult
 		{
-			bool pending = false;
-			int  frame = -1;
+			bool              pending = false;
+			int               frame = -1;
+			std::future<json> completion;
+		};
+
+		struct PendingRelease
+		{
+			std::future<json> completion;
+			std::string       reason;
 		};
 
 		class KeyboardManager
@@ -273,6 +282,9 @@ namespace dvb
 					std::lock_guard lock(m_mutex);
 					if (m_leases.Size() >= kMaximumHeldKeys && !m_leases.Find(a_key.scancode))
 						throw ToolError(409, std::format("keyboard synthetic hold limit reached ({}) — release a key or call releaseAll", kMaximumHeldKeys));
+					if (const auto current = m_leases.Find(a_key.scancode);
+						current && m_pendingReleases.contains(current->generation))
+						throw ToolError(409, std::format("key '{}' has a pending release — retry after it completes", a_key.name));
 					acquired = m_leases.Acquire(a_key, a_owner, NowMs(), a_maxHoldMs);
 					if (acquired.status == KeyboardAcquireStatus::kConflict)
 						throw ToolError(409, std::format("key '{}' is held by owner '{}'", a_key.name, acquired.lease.owner));
@@ -311,13 +323,8 @@ namespace dvb
 				}
 				if (!a_force && current->owner != a_owner)
 					throw ToolError(409, std::format("key '{}' is held by owner '{}' (not '{}')", a_key.name, current->owner, a_owner));
-				const float       heldSecs = std::max(0.001F,
-					static_cast<float>(NowMs() - current->pressedAtMs) / 1000.0F);
-				const QueueResult queued = QueueButton(*current, false, heldSecs);
-				m_leases.RemoveExact(a_key.scancode, current->generation);
-				SignalWatchdog();
-				PublishLocked("up", *current, a_reason, queued.pending);
-				return EventResult("up", *current, queued.pending, true, queued.frame);
+				const auto queued = ReleaseLocked(*current, a_reason);
+				return EventResult("up", *current, queued.pending, !queued.pending, queued.frame);
 			}
 
 			json Tap(const KeyboardKey& a_key, const std::string& a_owner, int a_durationMs)
@@ -448,10 +455,16 @@ namespace dvb
 				}
 				json released = json::array();
 				json failed = json::array();
+				json pending = json::array();
 				for (const auto& lease : selected) {
 					try {
 						if (ReleaseGenerationWithRetry(lease.key.scancode, lease.generation, a_reason))
 							released.push_back(KeyJson(lease.key));
+						else {
+							std::lock_guard lock(m_mutex);
+							if (m_pendingReleases.contains(lease.generation))
+								pending.push_back(KeyJson(lease.key));
+						}
 					} catch (const std::exception& e) {
 						json item = KeyJson(lease.key);
 						item["error"] = e.what();
@@ -465,6 +478,7 @@ namespace dvb
 					{ "owner", a_all ? "*" : a_owner },
 					{ "released", std::move(released) },
 					{ "failed", std::move(failed) },
+					{ "pending", std::move(pending) },
 				};
 			}
 
@@ -487,30 +501,55 @@ namespace dvb
 
 			QueueResult QueueButton(const KeyboardLease& a_lease, bool a_down, float a_heldSecs)
 			{
-				try {
-					const json result = RunAtInputPoll([=]() -> json {
-						if (a_down && a_lease.generation <= g_repeatCutoff.load(std::memory_order_acquire))
-							throw ToolError(503, "keyboard press cancelled by game load");
-						auto* queue = RE::BSInputEventQueue::GetSingleton();
-						if (!queue)
-							throw ToolError(503, "Skyrim BSInputEventQueue unavailable");
-						if (queue->buttonEventCount >= RE::BSInputEventQueue::MAX_BUTTON_EVENTS)
-							throw ToolError(503, "Skyrim keyboard input queue is full for this frame — retry after the next frame");
-						if (a_down)
-							g_repeatingKeys.push_back({ a_lease.key.scancode, a_lease.generation, NowMs(), a_lease.expiresAtMs });
-						else
-							std::erase_if(g_repeatingKeys, [&](const auto& key) { return key.scancode == a_lease.key.scancode; });
-						queue->AddButtonEvent(RE::INPUT_DEVICE::kKeyboard, 0, a_lease.key.scancode,
-							a_down ? 1.0F : 0.0F, a_down ? 0.0F : a_heldSecs);
-						return json{ { "frame", game::CurrentFrame() } };
-					});
-					return { false, result.value("frame", -1) };
-				} catch (const MainThread::TaskTimeout& e) {
-					// Only a running task can still deliver its event after a timeout.
-					if (e.started)
-						return { true, -1 };
-					throw;
+				auto completion = RunAtInputPoll([=]() -> json {
+					if (a_down && a_lease.generation <= g_repeatCutoff.load(std::memory_order_acquire))
+						throw ToolError(503, "keyboard press cancelled by game load");
+					auto* queue = RE::BSInputEventQueue::GetSingleton();
+					if (!queue)
+						throw ToolError(503, "Skyrim BSInputEventQueue unavailable");
+					if (queue->buttonEventCount >= RE::BSInputEventQueue::MAX_BUTTON_EVENTS)
+						throw ToolError(503, "Skyrim keyboard input queue is full for this frame — retry after the next frame");
+					if (a_down)
+						g_repeatingKeys.push_back({ a_lease.key.scancode, a_lease.generation, NowMs(), a_lease.expiresAtMs });
+					else
+						std::erase_if(g_repeatingKeys, [&](const auto& key) { return key.scancode == a_lease.key.scancode; });
+					queue->AddButtonEvent(RE::INPUT_DEVICE::kKeyboard, 0, a_lease.key.scancode,
+						a_down ? 1.0F : 0.0F, a_down ? 0.0F : a_heldSecs);
+					return json{ { "frame", game::CurrentFrame() } };
+				});
+				if (completion.wait_for(milliseconds(0)) != std::future_status::ready)
+					return { true, -1, std::move(completion) };
+				return { false, completion.get().value("frame", -1), {} };
+			}
+
+			// Called under m_mutex. An empty future marks a failed release awaiting retry.
+			QueueResult ReleaseLocked(const KeyboardLease& a_lease, std::string_view a_reason)
+			{
+				const auto        pending = m_pendingReleases.find(a_lease.generation);
+				const std::string reason = pending != m_pendingReleases.end() ? pending->second.reason : std::string(a_reason);
+				if (pending != m_pendingReleases.end() && pending->second.completion.valid()) {
+					if (pending->second.completion.wait_for(milliseconds(0)) != std::future_status::ready)
+						return { true, -1, {} };
+					auto       completion = std::move(pending->second.completion);
+					const auto result = completion.get();
+					m_leases.RemoveExact(a_lease.key.scancode, a_lease.generation);
+					PublishLocked("up", a_lease, reason, false);
+					m_pendingReleases.erase(pending);
+					return { false, result.value("frame", -1), {} };
 				}
+
+				const float heldSecs = std::max(0.001F,
+					static_cast<float>(NowMs() - a_lease.pressedAtMs) / 1000.0F);
+				auto        queued = QueueButton(a_lease, false, heldSecs);
+				if (queued.pending) {
+					m_pendingReleases.insert_or_assign(a_lease.generation, PendingRelease{ std::move(queued.completion), reason });
+				} else {
+					m_leases.RemoveExact(a_lease.key.scancode, a_lease.generation);
+					m_pendingReleases.erase(a_lease.generation);
+				}
+				SignalWatchdog();
+				PublishLocked("up", a_lease, reason, queued.pending);
+				return queued;
 			}
 
 			json EventResult(std::string_view a_action, const KeyboardLease& a_lease,
@@ -582,12 +621,12 @@ namespace dvb
 						const auto now = NowMs();
 						if (lifecycle) {
 							for (const auto& lease : leases)
-								if (lease.generation <= lifecycleCutoff)
+								if (lease.generation <= lifecycleCutoff || m_pendingReleases.contains(lease.generation))
 									selected.push_back(lease);
 						} else {
 							const auto earliest = std::min_element(leases.begin(), leases.end(),
 								[](const auto& a, const auto& b) { return a.expiresAtMs < b.expiresAtMs; });
-							if (earliest != leases.end() && earliest->expiresAtMs > now) {
+							if (m_pendingReleases.empty() && earliest != leases.end() && earliest->expiresAtMs > now) {
 								const auto revision = m_watchdogRevision.load(std::memory_order_acquire);
 								m_watchdogCv.wait_for(lock, milliseconds(earliest->expiresAtMs - now), [&] {
 									return m_lifecycleCutoff.load(std::memory_order_acquire) != 0 ||
@@ -596,7 +635,7 @@ namespace dvb
 								continue;
 							}
 							for (const auto& lease : leases)
-								if (lease.expiresAtMs <= now)
+								if (lease.expiresAtMs <= now || m_pendingReleases.contains(lease.generation))
 									selected.push_back(lease);
 						}
 					}
@@ -616,10 +655,11 @@ namespace dvb
 								lease.key.name, lease.generation, e.what());
 						}
 					}
-					if (retryPending) {
-						std::unique_lock lock(m_mutex);
+					std::unique_lock lock(m_mutex);
+					if (retryPending)
 						m_watchdogCv.wait_for(lock, kWatchdogRetryDelay);
-					}
+					else if (!m_pendingReleases.empty())
+						m_watchdogCv.wait_for(lock, kReleaseRetryDelay);
 				}
 			}
 
@@ -661,22 +701,18 @@ namespace dvb
 				const auto      current = m_leases.Find(a_scancode);
 				if (!current || current->generation != a_generation)
 					return false;
-				const float       heldSecs = std::max(0.001F,
-					static_cast<float>(NowMs() - current->pressedAtMs) / 1000.0F);
-				const QueueResult queued = QueueButton(*current, false, heldSecs);
-				m_leases.RemoveExact(a_scancode, a_generation);
-				PublishLocked("up", *current, a_reason, queued.pending);
-				return true;
+				return !ReleaseLocked(*current, a_reason).pending;
 			}
 
-			std::mutex                 m_mutex;
-			std::condition_variable    m_watchdogCv;
-			KeyboardLeaseTable         m_leases;
-			EventBus*                  m_events = nullptr;
-			bool                       m_watchdogStarted = false;
-			std::atomic<std::uint64_t> m_latestGeneration{ 0 };
-			std::atomic<std::uint64_t> m_lifecycleCutoff{ 0 };
-			std::atomic<std::uint64_t> m_watchdogRevision{ 0 };
+			std::mutex                                        m_mutex;
+			std::condition_variable                           m_watchdogCv;
+			KeyboardLeaseTable                                m_leases;
+			std::unordered_map<std::uint64_t, PendingRelease> m_pendingReleases;
+			EventBus*                                         m_events = nullptr;
+			bool                                              m_watchdogStarted = false;
+			std::atomic<std::uint64_t>                        m_latestGeneration{ 0 };
+			std::atomic<std::uint64_t>                        m_lifecycleCutoff{ 0 };
+			std::atomic<std::uint64_t>                        m_watchdogRevision{ 0 };
 		};
 
 		json HandleInputImpl(const json& a_args, const ToolContext& a_ctx)
@@ -746,7 +782,9 @@ namespace dvb
 			"no-op. 'tap' emits down, waits durationMs (default 50), then up. 'sequence' executes a "
 			"prevalidated balanced array of tap/down/up/wait events (optional afterMs); it rejects an "
 			"unbalanced hold before injecting anything and releases keys acquired by the sequence on "
-			"failure. 'releaseAll' releases this owner only; all-owner cleanup is internal-only. Every "
+			"failure. 'releaseAll' releases this owner only; all-owner cleanup is internal-only. Pending "
+			"releases retain their leases until completion. 'up' returns pending=true and released=false, "
+			"and 'releaseAll' lists those keys in pending rather than released. Every "
 			"lease watchdog retries a failed automatic release until it succeeds or becomes obsolete. "
 			"owner defaults to the MCP session id or rest:anonymous; automation should "
 			"supply a stable task owner. DevBench also releases owned keys on load/new-game and emits "

--- a/src/MainThread.cpp
+++ b/src/MainThread.cpp
@@ -72,20 +72,20 @@ namespace dvb::MainThread
 			if (future.wait_for(std::chrono::milliseconds(0)) == std::future_status::ready)
 				return future.get();
 			if (!abandoned)
-				throw ToolError(504, std::format("main-thread task did not finish within {}ms; it already started and may still complete", a_timeout.count()));
+				throw TaskTimeout(true, std::format("main-thread task did not finish within {}ms; it already started and may still complete", a_timeout.count()));
 			// The engine's frame counter discriminates the two 504 causes: still
 			// advancing = main thread busy; frozen = hung OR
 			// fully paused (the counter also freezes in pause menus).
 			const int frameNow = game::CurrentFrame();
 			if (frameAtStart < 0 || frameNow < 0)
-				throw ToolError(504, std::format("main-thread task did not start within {}ms; queued task abandoned", a_timeout.count()));
+				throw TaskTimeout(false, std::format("main-thread task did not start within {}ms; queued task abandoned", a_timeout.count()));
 			if (frameNow == frameAtStart)
-				throw ToolError(504, std::format(
-										 "main-thread task did not start within {}ms; queued task abandoned and the game frame counter has not advanced -- main thread hung or the game is fully paused; if no pause menu is open, only a process restart recovers",
-										 a_timeout.count()));
-			throw ToolError(504, std::format(
-									 "main-thread task did not start within {}ms; queued task abandoned ({} frames elapsed -- main thread busy)",
-									 a_timeout.count(), frameNow - frameAtStart));
+				throw TaskTimeout(false, std::format(
+											 "main-thread task did not start within {}ms; queued task abandoned and the game frame counter has not advanced -- main thread hung or the game is fully paused; if no pause menu is open, only a process restart recovers",
+											 a_timeout.count()));
+			throw TaskTimeout(false, std::format(
+										 "main-thread task did not start within {}ms; queued task abandoned ({} frames elapsed -- main thread busy)",
+										 a_timeout.count(), frameNow - frameAtStart));
 		}
 
 		return future.get();  // rethrows the handler's exception on the listener thread

--- a/src/MainThread.h
+++ b/src/MainThread.h
@@ -5,16 +5,24 @@
 #include <functional>
 
 #include "Json.h"
+#include "ToolRegistry.h"
 
 namespace dvb::MainThread
 {
+	struct TaskTimeout : ToolError
+	{
+		bool started;
+		TaskTimeout(bool a_started, const std::string& a_message) :
+			ToolError(504, a_message), started(a_started) {}
+	};
+
 	/// Run `a_fn` on the main game thread (via SKSE's TaskInterface) and block the
 	/// calling (listener) thread until it returns, propagating its JSON result — or
 	/// rethrowing whatever it threw (e.g. a dvb::ToolError) on the caller's thread.
 	///
 	/// This is the value-returning primitive that lets tools read live game/render
 	/// state synchronously (the agentic-renderdoc "Eval returns a value" model)
-	/// rather than fire-and-forget + poll. Throws dvb::ToolError(504) if the task
+	/// rather than fire-and-forget + poll. Throws TaskTimeout (HTTP 504) if the task
 	/// does not finish within `a_timeout` (e.g. the main thread is stalled mid-load).
 	/// Tasks still queued at their deadline are abandoned and will not invoke a_fn.
 	/// Already-running tasks cannot be interrupted and may finish after a timeout.

--- a/tests/http/README.md
+++ b/tests/http/README.md
@@ -30,6 +30,15 @@ $env:DEVBENCH_URL = "http://127.0.0.1:8921"; pytest tests/http -v
 DEVBENCH_URL=http://127.0.0.1:8921 pytest tests/http -v
 ```
 
+## Held-key movement checks
+
+`test_input_holds.py` is opt-in. Set `DEVBENCH_TEST_INPUT=1` and
+`DEVBENCH_URL`, then run `pytest tests/http/test_input_holds.py -v`. Load an
+unpaused development save with the player on foot and clear ground ahead.
+Avoid other input during the test. It moves the player using the configured
+Forward key, checks continued movement, and verifies that release and lease
+expiry stop it. It releases its own keys without saving or reloading.
+
 ## How discovery works
 
 The base URL is resolved in this order (first hit wins):

--- a/tests/http/test_input_holds.py
+++ b/tests/http/test_input_holds.py
@@ -1,0 +1,81 @@
+"""Opt-in held-key movement regression against a running game.
+
+Set DEVBENCH_TEST_INPUT=1 and DEVBENCH_URL. Load an unpaused development save
+with the player on foot and clear ground ahead, without other input. The tests
+move the player forward and release their own keys without saving or reloading.
+"""
+
+from __future__ import annotations
+
+import math
+import os
+import time
+import uuid
+
+import pytest
+
+from conftest import require_enum, require_tool
+
+
+pytestmark = pytest.mark.skipif(
+    os.environ.get("DEVBENCH_TEST_INPUT") != "1" or not os.environ.get("DEVBENCH_URL"),
+    reason="set DEVBENCH_TEST_INPUT=1 and DEVBENCH_URL to the intended test instance",
+)
+
+
+@pytest.mark.parametrize("release", ["up", "expiry"])
+def test_keyboard_hold_moves_until_release(client, tool_schema, release):
+    desc = require_tool(tool_schema, "input")
+    for action in ("status", "down", "up", "releaseAll"):
+        require_enum(desc, "action", action)
+    status = client.ok("input", {"action": "status"})
+    if not status["ready"]:
+        pytest.skip("keyboard input is not ready")
+    if status["held"]:
+        pytest.skip("release existing synthetic input before running movement tests")
+    scene = client.ok("inspect", {"kind": "scene"})
+    if not scene["playerLoaded"]:
+        pytest.skip("load a development save before running movement tests")
+    menus = client.ok("menu", {"action": "list"})
+    if set(menus["openMenus"]) - {"HUD Menu", "Cursor Menu"}:
+        pytest.skip("close menus before running movement tests")
+    key = client.ok("papyrus", {
+        "action": "call", "script": "Input", "function": "GetMappedKey",
+        "args": ["Forward", 0],
+    })["returned"]
+    assert isinstance(key, int) and 0 < key < 256, key
+    pid = client.ok("inspect", {"kind": "health"})["pid"]
+    owner = f"pytest-keyboard-{uuid.uuid4().hex}"
+
+    def send(action, **args):
+        assert client.ok("inspect", {"kind": "health"})["pid"] == pid, "game instance changed"
+        return client.ok("input", {"action": action, "owner": owner, **args})
+
+    def position():
+        current = client.ok("inspect", {"kind": "scene"})
+        assert current["cell"] == scene["cell"], "player left the test cell"
+        return current["position"][:2]
+
+    try:
+        start = position()
+        send("down", key=key, maxHoldMs=10000 if release == "up" else 1000)
+        time.sleep(0.25)
+        first = position()
+        time.sleep(0.25)
+        second = position()
+        assert math.dist(first, second) > 10, (first, second)
+        assert math.dist(start, first) > 10, (start, first)
+        if release == "up":
+            result = send("up", key=key)
+            assert result["released"], result
+        else:
+            time.sleep(0.7)
+        time.sleep(0.25)
+        stopped = position()
+        time.sleep(0.3)
+        after = position()
+        assert math.dist(stopped, after) < 2, (stopped, after)
+        assert not any(item["owner"] == owner for item in client.ok("input", {"action": "status"})["held"])
+    finally:
+        result = send("releaseAll")
+        assert not result["failed"], result

--- a/tests/http/test_input_holds.py
+++ b/tests/http/test_input_holds.py
@@ -23,7 +23,7 @@ pytestmark = pytest.mark.skipif(
 )
 
 
-@pytest.mark.parametrize("release", ["up", "expiry"])
+@pytest.mark.parametrize("release", ["up", "releaseAll", "expiry"])
 def test_keyboard_hold_moves_until_release(client, tool_schema, release):
     desc = require_tool(tool_schema, "input")
     for action in ("status", "down", "up", "releaseAll"):
@@ -58,7 +58,7 @@ def test_keyboard_hold_moves_until_release(client, tool_schema, release):
 
     try:
         start = position()
-        send("down", key=key, maxHoldMs=10000 if release == "up" else 1000)
+        send("down", key=key, maxHoldMs=1000 if release == "expiry" else 10000)
         time.sleep(0.25)
         first = position()
         time.sleep(0.25)
@@ -68,6 +68,11 @@ def test_keyboard_hold_moves_until_release(client, tool_schema, release):
         if release == "up":
             result = send("up", key=key)
             assert result["released"], result
+        elif release == "releaseAll":
+            result = send("releaseAll")
+            assert not result["failed"], result
+            assert not result.get("pending"), result
+            assert any(item["scancode"] == key for item in result["released"]), result
         else:
             time.sleep(0.7)
         time.sleep(0.25)


### PR DESCRIPTION
Holding a synthetic key only moves the player briefly because no held events are sent between the press and release. Releases can also be lost when an SKSE task queues them after input dispatch, leaving an action active even though the request succeeded.

Send presses, held events and releases from `BSInputDeviceManager::PollInputDevices`, before control mapping and dispatch. Stop held events on release, lease expiry or game load. Cancel queued presses across loads and preserve lease cleanup when a request times out.

### Testing

- Native unit tests and HTTP input tests pass. The added movement regressions fail without the held-event fix.
- Verified sustained movement, spell casting stopping on release, lease expiry, and input cleanup across game loads on Steam AE 1.7.104 with SKSE 2.3.1.
- Checked the polling hook location and overwritten instructions for SE 1.5.97, Steam AE 1.6.1170 and 1.7.104, GOG AE 1.6.1179, and VR 1.4.15. Only Steam AE 1.7.104 was tested in-game.

The CommonLib submodule is pinned to the keyboard queue fix from the merged [CommonLibSSE-NG #347](https://github.com/alandtse/CommonLibSSE-NG/pull/347).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved held-key input so movement continues reliably across frames.
  - Ensured held inputs stop correctly after explicit release or lease expiration.
  - Improved handling and reporting of main-thread timeout errors.
  - Improved reporting and retry handling for pending input releases.

- **Documentation**
  - Added guidance for testing held-key movement behavior, including setup requirements and expected results.

- **Tests**
  - Added an opt-in integration test covering held-key movement, release, release-all, and lease expiration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

