### PR TITLE
fix(shutdown): avoid server teardown at exit

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -22,9 +22,10 @@
 
 namespace
 {
-	// Constructed at kDataLoaded with the configured port (null if disabled via config).
-	std::unique_ptr<dvb::Server> g_server;
-	dvb::Config                  g_config;  // captured at kPostLoad; used at kInputLoaded
+	// Process-lifetime: DLL detach runs after Windows terminates the server's workers,
+	// so destroying it there would wait for threads that can no longer finish.
+	dvb::Server* g_server = nullptr;
+	dvb::Config  g_config;  // captured at kPostLoad; used at kInputLoaded
 
 	void InitLogging()
 	{
@@ -84,7 +85,7 @@ namespace
 				// registers its self-test tool) BEFORE Start() so they appear on both
 				// transports from the first request; then attach game-event sources.
 				g_config = cfg;  // kept for kInputLoaded (input sink registers later)
-				g_server = std::make_unique<dvb::Server>("127.0.0.1", cfg.port);
+				g_server = new dvb::Server("127.0.0.1", cfg.port);
 				g_server->Events().SetFrameProvider(&dvb::game::CurrentFrame);
 				dvb::RegisterCoreTools(g_server->Tools(), g_server->Events());
 				dvb::Recording::SetLoadSettleMs(cfg.loadSettleMs);

--- a/tests/http/README.md
+++ b/tests/http/README.md
@@ -30,6 +30,18 @@ $env:DEVBENCH_URL = "http://127.0.0.1:8921"; pytest tests/http -v
 DEVBENCH_URL=http://127.0.0.1:8921 pytest tests/http -v
 ```
 
+### Shutdown
+
+Run the Windows shutdown test separately. It exits Skyrim without saving and
+checks that the process terminates successfully within 30 seconds:
+
+```powershell
+$env:DEVBENCH_URL = "http://127.0.0.1:8920"
+$env:DEVBENCH_TEST_SHUTDOWN = "1"
+pytest tests/http/test_shutdown.py -v
+Remove-Item Env:DEVBENCH_TEST_SHUTDOWN
+```
+
 ## How discovery works
 
 The base URL is resolved in this order (first hit wins):

--- a/tests/http/test_shutdown.py
+++ b/tests/http/test_shutdown.py
@@ -1,0 +1,55 @@
+"""Opt-in Windows shutdown test. Exits the selected Skyrim process without saving."""
+
+from __future__ import annotations
+
+import ctypes
+import os
+from ctypes import wintypes
+
+import pytest
+import requests
+
+
+pytestmark = pytest.mark.skipif(
+    os.name != "nt"
+    or os.environ.get("DEVBENCH_TEST_SHUTDOWN") != "1"
+    or not os.environ.get("DEVBENCH_URL"),
+    reason="requires Windows, DEVBENCH_TEST_SHUTDOWN=1 and an explicit DEVBENCH_URL",
+)
+
+
+def test_qqq_completes_process_exit(client):
+    health = client.ok("inspect", {"kind": "health"})
+    kernel = ctypes.WinDLL("kernel32", use_last_error=True)
+    kernel.OpenProcess.argtypes = [wintypes.DWORD, wintypes.BOOL, wintypes.DWORD]
+    kernel.OpenProcess.restype = wintypes.HANDLE
+    kernel.WaitForSingleObject.argtypes = [wintypes.HANDLE, wintypes.DWORD]
+    kernel.WaitForSingleObject.restype = wintypes.DWORD
+    kernel.GetExitCodeProcess.argtypes = [wintypes.HANDLE, ctypes.POINTER(wintypes.DWORD)]
+    kernel.GetExitCodeProcess.restype = wintypes.BOOL
+    kernel.CloseHandle.argtypes = [wintypes.HANDLE]
+    kernel.CloseHandle.restype = wintypes.BOOL
+
+    handle = kernel.OpenProcess(0x100000 | 0x1000, False, health["pid"])
+    if not handle:
+        raise ctypes.WinError(ctypes.get_last_error())
+    try:
+        assert kernel.WaitForSingleObject(handle, 0) == 258, "game already exited"
+        assert client.ok("inspect", {"kind": "health"})["pid"] == health["pid"]
+        try:
+            client.ok("console", {"command": "qqq"})
+        except requests.ConnectionError:
+            pass  # The process can exit before HTTP sends its response.
+
+        # DLL teardown can hang after the window closes and the exit code is set.
+        # Only a signalled process handle establishes that termination completed.
+        result = kernel.WaitForSingleObject(handle, 30000)
+        if result == 0xFFFFFFFF:
+            raise ctypes.WinError(ctypes.get_last_error())
+        assert result == 0, f"Skyrim PID {health['pid']} did not exit within 30 seconds"
+        exit_code = wintypes.DWORD()
+        if not kernel.GetExitCodeProcess(handle, ctypes.byref(exit_code)):
+            raise ctypes.WinError(ctypes.get_last_error())
+        assert exit_code.value == 0, f"Skyrim exited with code {exit_code.value:#x}"
+    finally:
+        kernel.CloseHandle(handle)

--- a/tests/http/test_shutdown_safety.py
+++ b/tests/http/test_shutdown_safety.py
@@ -1,0 +1,28 @@
+"""Verify that ordinary test runs cannot trigger the opt-in shutdown test."""
+
+from pathlib import Path
+
+import pytest
+
+import test_shutdown
+
+
+pytest_plugins = ["pytester"]
+
+
+@pytest.mark.parametrize("enabled,url", [(None, "http://unused.invalid"), ("1", None)])
+def test_missing_opt_in_skips_before_discovery(pytester, monkeypatch, enabled, url):
+    for name, value in (("DEVBENCH_TEST_SHUTDOWN", enabled), ("DEVBENCH_URL", url)):
+        if value is None:
+            monkeypatch.delenv(name, raising=False)
+        else:
+            monkeypatch.setenv(name, value)
+    pytester.makeconftest('''
+import pytest
+@pytest.fixture
+def client():
+    pytest.fail("client discovery ran before opt-in")
+''')
+    pytester.makepyfile(test_opt_in=Path(test_shutdown.__file__).read_text(encoding="utf-8"))
+    result = pytester.runpytest("-q")
+    result.assert_outcomes(skipped=1)


### PR DESCRIPTION
Skyrim can hang on exit while DevBench destroys its server during DLL teardown. Windows has already terminated the worker threads, but the MCP thread-pool destructor waits for them to finish. The game window closes while the process remains alive, keeping DLLs locked and mod managers waiting.

Give the host server process lifetime, following the existing VR input manager’s pattern. This avoids running threaded cleanup during DLL teardown and lets Windows reclaim the resources when the process exits.

### Testing

- Captured the hung thread in the MCP thread-pool destructor, reached through the global server’s destructor during process detach.
- Added an opt-in HTTP shutdown test that checks the Windows process handle becomes signalled with exit code 0. It fails on the previous DLL and passes with the fix.
- Verified three clean exits on Steam AE 1.7.104 with SKSE 2.3.1, covering the main menu, a loaded save, and a build containing the pending input fixes. MO2 cleanup completed and DLL locks were released.
- All 75 native tests pass. Offline tests verify that the shutdown test skips before server discovery without explicit opt-in and a target URL.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved Windows process shutdown handling to ensure the application can exit cleanly without hanging during worker-thread shutdown.

- **Tests**
  - Added an opt-in Windows integration test verifying graceful process termination and successful exit status.
  - Added coverage confirming shutdown checks are skipped safely when required configuration is unavailable.

- **Documentation**
  - Documented how to run the Windows shutdown test independently, including required environment settings and expected behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->